### PR TITLE
Deployment fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+
+### Bug Fixes
+
+* lerna packages ([92798e8](https://github.com/ulixee/secret-agent/commit/92798e8c9a017754ec86edf3dfe09de90828cb00))
+* packaging issues with mitm and replay ([520a912](https://github.com/ulixee/secret-agent/commit/520a912d50b935270b75f2d6ef1faf5fed796e85))
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/client
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/client

--- a/client/package.json
+++ b/client/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@secret-agent/client",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "The client interface for SecretAgent",
   "dependencies": {
     "@secret-agent/commons": "^1.0.0-alpha.5",
     "@secret-agent/core-interfaces": "^1.0.0-alpha.5",
-    "@secret-agent/replay": "^1.0.0-alpha.5",
+    "@secret-agent/replay": "^1.0.0-alpha.6",
     "awaited-dom": "^1.1.3",
     "uuid": "^8.1.0"
   },

--- a/core-server/CHANGELOG.md
+++ b/core-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/core-server
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/core-server

--- a/core-server/package.json
+++ b/core-server/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@secret-agent/core-server",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Server framework for running SecretAgent remotely",
   "dependencies": {
     "@secret-agent/commons": "^1.0.0-alpha.5",
-    "@secret-agent/core": "^1.0.0-alpha.5"
+    "@secret-agent/core": "^1.0.0-alpha.6"
   },
   "devDependencies": {
-    "@secret-agent/remote-client": "^1.0.0-alpha.5",
+    "@secret-agent/remote-client": "^1.0.0-alpha.6",
     "@secret-agent/remote-interfaces": "^1.0.0-alpha.5",
     "@secret-agent/testing": "^1.0.0-alpha.5",
     "@types/node": "^12.7.11",

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/core
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/core

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secret-agent/core",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "The core browser API used to run SecretAgent",
   "dependencies": {
     "@secret-agent/commons": "^1.0.0-alpha.5",
@@ -8,8 +8,8 @@
     "@secret-agent/emulators": "^1.0.0-alpha.5",
     "@secret-agent/humanoids": "^1.0.0-alpha.5",
     "@secret-agent/injected-scripts": "^1.0.0-alpha.5",
-    "@secret-agent/mitm": "^1.0.0-alpha.5",
-    "@secret-agent/session-state": "^1.0.0-alpha.5",
+    "@secret-agent/mitm": "^1.0.0-alpha.6",
+    "@secret-agent/session-state": "^1.0.0-alpha.6",
     "awaited-dom": "^1.1.3",
     "moment": "^2.24.0",
     "puppeteer": "~2.1.1",

--- a/full-client/CHANGELOG.md
+++ b/full-client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/full-client
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/full-client

--- a/full-client/package.json
+++ b/full-client/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@secret-agent/full-client",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "The Web Browser Built for Scraping",
   "dependencies": {
-    "@secret-agent/client": "^1.0.0-alpha.5",
-    "@secret-agent/core": "^1.0.0-alpha.5",
+    "@secret-agent/client": "^1.0.0-alpha.6",
+    "@secret-agent/core": "^1.0.0-alpha.6",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,27 @@
 {
   "version": "1.0.0-alpha.5",
   "npmClient": "yarn",
+  "packages": [
+    "client",
+    "core",
+    "core-interfaces",
+    "emulators",
+    "emulator-plugins/*",
+    "full-client",
+    "humanoids",
+    "humanoid-plugins/*",
+    "injected-scripts",
+    "mitm",
+    "core-server",
+    "remote-client",
+    "remote-interfaces",
+    "replay",
+    "replay-app",
+    "replay-api",
+    "session-state",
+    "testing",
+    "commons",
+    "website"
+  ],
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "npmClient": "yarn",
   "packages": [
     "client",

--- a/mitm/CHANGELOG.md
+++ b/mitm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/mitm
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/mitm

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secret-agent/mitm",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Man-in-the-middle proxy to fix chrome request/response",
   "main": "index.js",
   "scripts": {

--- a/package.build.json
+++ b/package.build.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start:website": "yarn workspace @secret-agent/website start",
-    "test": "NODE_ENV=test CACHE_DIR=.cache-test jest --runInBand --no-cache",
+    "test": "SA_SHOW_REPLAY=false NODE_ENV=test CACHE_DIR=.cache-test jest --runInBand --no-cache",
     "postinstall": "yarn workspace @secret-agent/mitm postinstall && yarn workspace @secret-agent/emulators postinstall"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The Web Browser Built for Scraping",
   "scripts": {
     "start:website": "yarn workspace @secret-agent/website start",
-    "bump-version": "lerna version prerelease --no-git-tag-version",
+    "bump-version": "lerna version prerelease --no-push --conventional-commits",
     "build": "yarn tsc && yarn workspace @secret-agent/replay-app build && cd build && yarn",
     "build:copy": "copyfiles 'testing/html/**' 'yarn.lock' 'mitm/socket/**' 'mitm/socket/.checksum' 'mitm/test/certs/**' build && cp package.build.json build/package.json",
     "build:dist": "rm -rf build-dist && tsc -b tsconfig.dist.json && copyfiles 'mitm/socket/*' 'mitm/socket/.checksum' -e 'mitm/socket/connect' '**/.gitignore' '**/.npmignore' build-dist && node dist-prepare.js && cp package.dist.json build-dist/package.json",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@secret-agent/monorepo",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.6",
   "private": true,
   "description": "The Web Browser Built for Scraping",
   "scripts": {
     "start:website": "yarn workspace @secret-agent/website start",
-    "bump-version": "lerna version patch --no-git-tag-version",
+    "bump-version": "lerna version prerelease --no-git-tag-version",
     "build": "yarn tsc && yarn workspace @secret-agent/replay-app build && cd build && yarn",
     "build:copy": "copyfiles 'testing/html/**' 'yarn.lock' 'mitm/socket/**' 'mitm/socket/.checksum' 'mitm/test/certs/**' build && cp package.build.json build/package.json",
-    "build:dist": "rm -rf build-dist && tsc -b tsconfig.dist.json && copyfiles 'mitm/socket/*' -e 'mitm/socket/connect' '**/.gitignore' '**/.npmignore' build-dist && node dist-prepare.js && cp package.dist.json build-dist/package.json",
+    "build:dist": "rm -rf build-dist && tsc -b tsconfig.dist.json && copyfiles 'mitm/socket/*' 'mitm/socket/.checksum' -e 'mitm/socket/connect' '**/.gitignore' '**/.npmignore' build-dist && node dist-prepare.js && cp package.dist.json build-dist/package.json",
     "build:docker": "yarn build:dist && docker build -t secret-agent .",
     "tsc": "tsc -b tsconfig.json && yarn build:copy",
     "tsc-modules": "ln -sf node_modules build/node_modules",
     "watch": "tsc -b -w tsconfig.json",
     "watch:dist": "tsc -b -w tsconfig.dist.json",
     "clean": "tsc -b --clean  tsconfig.json && yarn workspace @secret-agent/replay-app clean",
-    "test": "yarn tsc && cd build && yarn test"
+    "test": "yarn tsc && cd build && SA_SHOW_REPLAY=false yarn test"
   },
   "repository": "git@github.com:ulixee/secret-agent.git",
   "author": "Data Liberation Foundation",

--- a/remote-client/CHANGELOG.md
+++ b/remote-client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/remote-client
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/remote-client

--- a/remote-client/package.json
+++ b/remote-client/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@secret-agent/remote-client",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "SecretAgent client that runs remotely",
   "dependencies": {
-    "@secret-agent/client": "^1.0.0-alpha.5",
+    "@secret-agent/client": "^1.0.0-alpha.6",
     "@secret-agent/commons": "^1.0.0-alpha.5"
   },
   "devDependencies": {

--- a/replay-api/CHANGELOG.md
+++ b/replay-api/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/replay-api
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 

--- a/replay-api/package.json
+++ b/replay-api/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@secret-agent/replay-api",
   "description": "The backend API for Replay",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "dependencies": {
     "@secret-agent/commons": "^1.0.0-alpha.5",
     "@secret-agent/core-interfaces": "^1.0.0-alpha.5",
     "@secret-agent/injected-scripts": "^1.0.0-alpha.5",
-    "@secret-agent/session-state": "^1.0.0-alpha.5",
+    "@secret-agent/session-state": "^1.0.0-alpha.6",
     "command-line-args": "^5.1.1",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@secret-agent/core": "^1.0.0-alpha.5",
+    "@secret-agent/core": "^1.0.0-alpha.6",
     "@secret-agent/testing": "^1.0.0-alpha.5"
   }
 }

--- a/replay-app/CHANGELOG.md
+++ b/replay-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/replay-app
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 

--- a/replay-app/package.json
+++ b/replay-app/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": "git@github.com:ulixee/secret-agent.git",
   "description": "A browser for visually replaying your scraper scripts",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "main": "./index.js",
   "build": {
     "appId": "dev.secretagent.replay",

--- a/replay/CHANGELOG.md
+++ b/replay/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+
+### Bug Fixes
+
+* packaging issues with mitm and replay ([520a912](https://github.com/ulixee/secret-agent/commit/520a912d50b935270b75f2d6ef1faf5fed796e85))
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 **Note:** Version bump only for package @secret-agent/replay

--- a/replay/index.ts
+++ b/replay/index.ts
@@ -1,29 +1,34 @@
 import ChildProcess from 'child_process';
 import { getBinaryPath, isBinaryInstalled } from './Utils';
+import Log from '@secret-agent/commons/Logger';
+
+const { log } = Log(module);
 
 const apiPath = require.resolve('@secret-agent/replay-api/start');
 
-const showLogs = !!process.env.SA_REPLAY_DEBUG;
-
-export default function replay(args: IReplayLaunchArgs) {
-  const { sessionsDataLocation, sessionName, id } = args;
-  const argArray = [
-    require.resolve('@secret-agent/replay-app'),
-    sessionsDataLocation,
-    sessionName,
-    id,
-    apiPath,
-  ];
-
-  let executable = 'node $(yarn bin electron)';
-  let needsShell = true;
+export default function replay(launchArgs: IReplayLaunchArgs) {
+  const { sessionsDataLocation, sessionName, id } = launchArgs;
+  const spawnArgs = ['', sessionsDataLocation, sessionName, id, apiPath];
 
   if (isBinaryInstalled()) {
-    needsShell = false;
-    executable = getBinaryPath();
+    return spawn(getBinaryPath(), spawnArgs);
   }
 
-  ChildProcess.spawn(executable, argArray, {
+  try {
+    // see if we can launch from monorepo
+    spawnArgs[0] = require.resolve('@secret-agent/replay-app');
+
+    spawn('node $(yarn bin electron)', spawnArgs, true);
+  } catch (err) {
+    log.info('Replay app not found');
+    return;
+  }
+}
+
+function spawn(appPath: string, args: string[], needsShell: boolean = false) {
+  const showLogs = !!process.env.SA_REPLAY_DEBUG;
+
+  ChildProcess.spawn(appPath, args, {
     detached: true,
     stdio: showLogs ? 'inherit' : 'ignore',
     shell: needsShell,

--- a/replay/package.json
+++ b/replay/package.json
@@ -5,6 +5,7 @@
   "description": "A browser for visually replaying your scraper scripts",
   "dependencies": {
     "@secret-agent/replay-api": "^1.0.0-alpha.5",
+    "@secret-agent/commons": "^1.0.0-alpha.5",
     "axios": "^0.19.2",
     "progress": "^2.0.3",
     "tar-fs": "^2.1.0"

--- a/replay/package.json
+++ b/replay/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@secret-agent/replay",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "repository": "git@github.com:ulixee/secret-agent.git",
   "description": "A browser for visually replaying your scraper scripts",
   "dependencies": {
-    "@secret-agent/replay-api": "^1.0.0-alpha.5",
     "@secret-agent/commons": "^1.0.0-alpha.5",
+    "@secret-agent/replay-api": "^1.0.0-alpha.6",
     "axios": "^0.19.2",
     "progress": "^2.0.3",
     "tar-fs": "^2.1.0"
   },
   "devDependencies": {
-    "@secret-agent/replay-app": "^1.0.0-alpha.5"
+    "@secret-agent/replay-app": "^1.0.0-alpha.6"
   }
 }

--- a/session-state/CHANGELOG.md
+++ b/session-state/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.6](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2020-07-22)
+
+**Note:** Version bump only for package @secret-agent/session-state
+
+
+
+
+
 # [1.0.0-alpha.5](https://github.com/ulixee/secret-agent/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2020-07-21)
 
 

--- a/session-state/package.json
+++ b/session-state/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@secret-agent/session-state",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Library to capture and store Secret Agent sessions",
   "main": "index.js",
   "dependencies": {
     "@secret-agent/commons": "^1.0.0-alpha.5",
     "@secret-agent/injected-scripts": "^1.0.0-alpha.5",
-    "@secret-agent/mitm": "^1.0.0-alpha.5",
+    "@secret-agent/mitm": "^1.0.0-alpha.6",
     "better-sqlite3": "^7.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We were missing the checksum for mitm and replay-app was being referenced in the published replay, which obviously does not exist in npm.