### PR TITLE
fix(replay): fix realtime not loading correctly

### DIFF
--- a/replay-app/backend/api/index.ts
+++ b/replay-app/backend/api/index.ts
@@ -48,7 +48,9 @@ export default class ReplayApi extends EventEmitter {
 
       if (path === '/session') {
         const data = await streamToJson<ISaSession>(stream);
-        return this.onSession(data);
+        this.onSession(data);
+        this.isReady.resolve();
+        return;
       }
 
       await this.isReady.promise;
@@ -120,7 +122,6 @@ export default class ReplayApi extends EventEmitter {
       dataLocation: data.dataLocation,
     });
     this.state.loadSession(this.saSession);
-    this.isReady.resolve();
   }
 
   public static quit() {

--- a/replay-app/frontend/package.json
+++ b/replay-app/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "vue-cli-service build",
+    "build:dev": "vue-cli-service build --mode=development",
     "clean": "vue-cli-service clean",
     "start": "vue-cli-service serve",
     "dev": "vue-cli-service serve --mode=development"

--- a/session-state/api/SessionLoader.ts
+++ b/session-state/api/SessionLoader.ts
@@ -8,10 +8,10 @@ import SessionState from '../index';
 
 export default class SessionLoader extends EventEmitter {
   public static eventStreams = [
+    'dom-changes',
     'mouse-events',
     'scroll-events',
     'focus-events',
-    'dom-changes',
     'frames',
     'commands',
     'script-state',
@@ -118,9 +118,6 @@ export default class SessionLoader extends EventEmitter {
       lastState.unresponsiveSeconds !== scriptState.unresponsiveSeconds
     ) {
       this.emit('script-state', scriptState);
-      if (scriptState.closeTime) {
-        setImmediate(() => this.emit('close'));
-      }
     }
   }
 }


### PR DESCRIPTION
This solution is a very temporary way to solve resources not loading up during a realtime replay session. We need a more permanent solution to know when resources are available. I haven't yet been able to figure out what's actually failing to load.