### PR TITLE
fix(replay): autostart playback, include redirects

### DIFF
--- a/commons/utils.ts
+++ b/commons/utils.ts
@@ -47,7 +47,7 @@ export function createPromise<T = any>(
       clearTimeout(response.timeout);
       reject(err);
     };
-    if (timeoutMillis !== undefined) {
+    if (timeoutMillis !== undefined && timeoutMillis !== null) {
       response.timeout = setTimeout(() => response.reject(error), timeoutMillis).unref();
     }
   });

--- a/emulator-plugins/shared/injected-scripts/navigator.js
+++ b/emulator-plugins/shared/injected-scripts/navigator.js
@@ -55,7 +55,8 @@ if (args.ensureOneVideoDevice) {
 
 proxyFunction(Permissions.prototype, 'query', (func, thisArg, ...parameters) => {
   if (parameters && parameters.length && parameters[0].name === 'notifications') {
-    const result = { state: Notification.permission };
+    const state = Notification.permission === 'default' ? 'prompt' : Notification.permission;
+    const result = { state };
     Object.setPrototypeOf(result, PermissionStatus.prototype);
     return Promise.resolve(result);
   }

--- a/emulator-plugins/shared/injected-scripts/utils.js
+++ b/emulator-plugins/shared/injected-scripts/utils.js
@@ -167,6 +167,8 @@ function buildDescriptor(entry) {
 }
 
 function cleanErrorStack(error) {
+  if (!error.stack) return error;
+
   const stack = error.stack.split(/\r?\n/);
   const newStack = [];
   for (let i = 0; i < stack.length; i += 1) {

--- a/full-client/test/emulate.test.ts
+++ b/full-client/test/emulate.test.ts
@@ -90,20 +90,25 @@ test('should pass FpScanner', async () => {
   expect(data).toBeTruthy();
 });
 
-test('permissions API', async () => {
+test('should not be denied for notifications, but prompt for permissions', async () => {
   const browser = await SecretAgent.createBrowser();
   await browser.goto(`${koaServer.baseUrl}`);
   const core = Core.byTabId[browser.activeTab.tabId];
   // @ts-ignore
   const page = core.tab.puppetPage;
-  const isHeadless = await page.evaluate(`(async () => {
+  const permissions = await page.evaluate<any>(`(async () => {
     const permissionStatus = await navigator.permissions.query({
       name: 'notifications',
     });
   
-    return Notification.permission === 'denied' && permissionStatus.state === 'prompt';
+    return {
+      notificationValue: Notification.permission,
+      permissionState: permissionStatus.state
+    }
   })();`);
-  expect(isHeadless).toBe(false);
+
+  expect(permissions.notificationValue).toBe('default');
+  expect(permissions.permissionState).toBe('prompt');
 });
 
 test('should not leave markers on permissions.query.toString ', async () => {

--- a/puppet-chrome/lib/Frame.ts
+++ b/puppet-chrome/lib/Frame.ts
@@ -276,7 +276,8 @@ export default class Frame extends TypedEventEmitter<IFrameEvents> implements IP
   private async waitForDefaultContext() {
     if (this.getActiveContextId(false)) return;
 
-    return this.waitOn('default-context-created').catch(err => {
+    // don't time out this event, we'll just wait for the page to shut down
+    return this.waitOn('default-context-created', null, null).catch(err => {
       if (err instanceof CanceledPromiseError) return;
       throw err;
     });

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -89,8 +89,9 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameEvents>
     await this.cdpSession.send('Runtime.addBinding', {
       name,
     });
-    return eventUtils.addEventListener(this.cdpSession, 'Runtime.bindingCalled', event => {
+    return eventUtils.addEventListener(this.cdpSession, 'Runtime.bindingCalled', async event => {
       if (event.name === name) {
+        await this.isReady;
         const frameId = this.getFrameIdForExecutionContext(event.executionContextId);
         onCallback(event.payload, frameId);
       }

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -281,7 +281,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     });
   }
 
-  private async onRuntimeConsole(event: ConsoleAPICalledEvent) {
+  private onRuntimeConsole(event: ConsoleAPICalledEvent) {
     const message = ConsoleMessage.create(this.cdpSession, event);
     const frameId = this.framesManager.getFrameIdForExecutionContext(event.executionContextId);
 

--- a/replay-app/backend/Application.ts
+++ b/replay-app/backend/Application.ts
@@ -88,7 +88,8 @@ export default class Application {
       }
     }
 
-    await this.loadSessionReplay(replayMeta, true);
+    const window = await this.loadSessionReplay(replayMeta, true);
+    window.replayOnFocus();
   }
 
   private createWindowIfNeeded() {
@@ -114,18 +115,23 @@ export default class Application {
       scriptEntrypoint: replayApi.saSession.scriptEntrypoint,
     });
 
+    let existingWindow = Window.current;
     if (findOpenReplayScriptWindow) {
-      const match = Window.list.find(
-        x => x.replayApi?.saSession?.scriptEntrypoint === replay.scriptEntrypoint,
+      existingWindow = Window.list.find(
+        x => x.replayApi?.saSession?.scriptEntrypoint === replayApi.saSession.scriptEntrypoint,
       );
-      if (match) return match.openReplayApi(replayApi);
     }
 
-    if (Window.noneOpen()) {
+    if (!existingWindow && Window.current?.isReplayActive === false) {
+      existingWindow = Window.current;
+    }
+
+    if (!existingWindow) {
       return Window.create({ replayApi });
     }
 
-    await Window.current.openReplayApi(replayApi);
+    await existingWindow.openReplayApi(replayApi);
+    return existingWindow;
   }
 
   private bindEventHandlers() {

--- a/replay-app/backend/api/ReplayResources.ts
+++ b/replay-app/backend/api/ReplayResources.ts
@@ -1,6 +1,6 @@
-import * as zlib from "zlib";
-import { PassThrough } from "stream";
-import getResolvable from "~shared/utils/promise";
+import * as zlib from 'zlib';
+import { PassThrough } from 'stream';
+import getResolvable from '~shared/utils/promise';
 
 export default class ReplayResources {
   private resources: {
@@ -37,13 +37,18 @@ export default class ReplayResources {
     });
   }
 
-  public async get(url: string) {
+  public async get(urlStr: string) {
+    const url = urlStr.split('#').shift();
     this.initResource(url);
     const resource = await this.resources[url].promise;
-    const headers = {
+    const headers: any = {
       'Cache-Control': 'public, max-age=500',
       'Content-Type': resource.headers.get('content-type'),
     };
+
+    if (resource.headers.get('location')) {
+      headers.Location = resource.headers.get('location');
+    }
 
     let readable = new PassThrough();
     if (resource.type === 'Document') {

--- a/replay-app/backend/models/ReplayView.ts
+++ b/replay-app/backend/models/ReplayView.ts
@@ -53,7 +53,7 @@ export default class ReplayView extends ViewBackend {
 
     this.tabState = id ? this.replayApi.getTab(id) : this.replayApi.getStartTab;
     this.tabState.on('tick:changes', this.checkResponsive);
-    this.playbarView.load(this.tabState);
+    await this.playbarView.load(this.tabState);
 
     console.log('Loaded tab state', this.tabState.startOrigin);
     this.window.setActiveTabId(this.tabState.tabId);

--- a/replay-app/backend/models/Window.ts
+++ b/replay-app/backend/models/Window.ts
@@ -1,16 +1,16 @@
-import { app, BrowserWindow } from "electron";
-import { resolve } from "path";
-import Application from "../Application";
-import ReplayApi from "~backend/api";
-import storage from "../storage";
-import AppView from "./AppView";
-import ReplayView from "./ReplayView";
-import IWindowLocation, { InternalLocations } from "~shared/interfaces/IWindowLocation";
-import ViewBackend from "~backend/models/ViewBackend";
-import { TOOLBAR_HEIGHT } from "~shared/constants/design";
-import IReplayMeta from "~shared/interfaces/IReplayMeta";
-import generateContextMenu from "~backend/menus/generateContextMenu";
-import { ISessionTab } from "~shared/interfaces/ISaSession";
+import { app, BrowserWindow } from 'electron';
+import { resolve } from 'path';
+import Application from '../Application';
+import ReplayApi from '~backend/api';
+import storage from '../storage';
+import AppView from './AppView';
+import ReplayView from './ReplayView';
+import IWindowLocation, { InternalLocations } from '~shared/interfaces/IWindowLocation';
+import ViewBackend from '~backend/models/ViewBackend';
+import { TOOLBAR_HEIGHT } from '~shared/constants/design';
+import IReplayMeta from '~shared/interfaces/IReplayMeta';
+import generateContextMenu from '~backend/menus/generateContextMenu';
+import { ISessionTab } from '~shared/interfaces/ISaSession';
 
 export default class Window {
   public static list: Window[] = [];
@@ -150,6 +150,10 @@ export default class Window {
     await this.replayView.loadTab(id);
   }
 
+  public replayOnFocus() {
+    this.replayView.start();
+  }
+
   public async fixBounds() {
     const { width, height } = this.browserWindow.getContentBounds();
     const toolbarContentHeight = await this.getHeaderHeight();
@@ -184,9 +188,7 @@ export default class Window {
       `);
 
     if (replayApi) {
-      await this.openReplayApi(replayApi);
-      this.replayView.start();
-      return;
+      return this.openReplayApi(replayApi);
     }
     return this.openAppLocation(location ?? InternalLocations.Dashboard);
   }
@@ -336,6 +338,7 @@ export default class Window {
   ) {
     const window = new Window(initialLocation);
     this.list.push(window);
+    return window;
   }
 
   public static noneOpen() {

--- a/replay-app/frontend/src/pages/header/index.vue
+++ b/replay-app/frontend/src/pages/header/index.vue
@@ -373,9 +373,13 @@ export default class HeaderPage extends Vue {
         padding-left: 5px;
         font-weight: lighter;
         color: #676767;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
       .Icon {
         margin-top: 1px;
+        width: 30px;
       }
     }
   }

--- a/session-state/api/SessionLoader.ts
+++ b/session-state/api/SessionLoader.ts
@@ -147,6 +147,7 @@ const resourceWhitelist: ResourceType[] = [
   'Media',
   'Font',
   'Stylesheet',
+  'Other',
   'Document',
 ];
 


### PR DESCRIPTION
This PR fixes a few issues with replay and some flaky puppet tests:
Replay: 
1 - auto-playing when it's launched.
2 - loading redirected resources
3 - loading svgs that are classified as "Other" resourceType in Chrome
4- upload dom changes if >1 second goes by so we don't have to wait for another command/close to see changes

Random Puppet failures:
- null error stack blowing up some pages
- Permissions overrides are sometimes wrong