### PR TITLE
Http2 Bug Fixes; Don't shutdown on UnhandledRejection

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -50,6 +50,10 @@ export function SecretAgentClientGenerator(
       await coreClient.start(options as IConfigureOptions);
     }
 
+    public static async recordUnhandledError(error: Error) {
+      await coreClient.logUnhandledError(error);
+    }
+
     public static async shutdown(error?: Error) {
       await coreClient.shutdown(error);
     }

--- a/client/lib/CoreClient.ts
+++ b/client/lib/CoreClient.ts
@@ -44,12 +44,17 @@ export default class CoreClient {
 
   public async shutdown(error?: Error): Promise<void> {
     const tabIds = Object.keys(this.tabsById);
+    this.commandQueue.clearPending();
     if (tabIds.length || error) {
       await this.commandQueue.run('disconnect', tabIds, error);
     }
     for (const tabId of tabIds) {
       delete this.tabsById[tabId];
     }
+  }
+
+  public async logUnhandledError(error: Error): Promise<void> {
+    await this.commandQueue.run('logUnhandledError', error);
   }
 
   public async start(options?: IConfigureOptions): Promise<void> {

--- a/client/lib/CoreCommandQueue.ts
+++ b/client/lib/CoreCommandQueue.ts
@@ -37,6 +37,10 @@ export default class CoreCommandQueue {
     return promise;
   }
 
+  public clearPending() {
+    this.items.length = 0;
+  }
+
   // PRIVATE
 
   private async processQueue() {

--- a/core/index.ts
+++ b/core/index.ts
@@ -291,9 +291,8 @@ export default class Core implements ICore {
   }
 
   public static async disconnect(tabIds?: string[], clientError?: Error) {
+    if (clientError) this.logUnhandledError(clientError);
     return this.startQueue.run(async () => {
-      if (clientError) log.error('UnhandledClientError', { clientError, sessionId: null });
-
       const promises: Promise<void>[] = [];
       for (const key of tabIds ?? Object.keys(Core.byTabId)) {
         const core = Core.byTabId[key];
@@ -309,6 +308,10 @@ export default class Core implements ICore {
         this.checkForAutoShutdown();
       }
     });
+  }
+
+  public static logUnhandledError(clientError: Error) {
+    log.error('UnhandledError', { clientError, sessionId: null });
   }
 
   public static async shutdown(fatalError?: Error, force = false) {

--- a/full-client/index.ts
+++ b/full-client/index.ts
@@ -5,7 +5,6 @@ import ISessionMeta from '@secret-agent/core-interfaces/ISessionMeta';
 
 process.title = 'SecretAgent';
 
-// tslint:disable:variable-name
 const { SecretAgent, coreClient } = SecretAgentClientGenerator();
 
 // OUTGOING ////////////////////////////////////////////////////////////////////

--- a/mitm/handlers/BaseHttpHandler.ts
+++ b/mitm/handlers/BaseHttpHandler.ts
@@ -57,8 +57,6 @@ export default abstract class BaseHttpHandler {
 
       context.cacheHandler.onRequest();
 
-      await HeadersHandler.modifyHeaders(context);
-
       // do one more check on the session before doing a connect
       if (session.isClosing) return;
 

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -122,24 +122,23 @@ export default class HeadersHandler {
   public static prepareRequestHeadersForHttp2(ctx: IMitmRequestContext) {
     const url = ctx.url;
 
-    const newHeaders = {} as IResourceHeaders;
-    if (!ctx.requestHeaders[':path']) {
-      newHeaders[':authority'] =
-        ctx.requestLowerHeaders.host ?? ctx.requestLowerHeaders[':authority'];
-      newHeaders[':path'] = url.pathname + url.search;
-      newHeaders[':method'] = ctx.method;
-      newHeaders[':scheme'] = 'https';
-    }
+    if (!ctx.requestHeaders[':path']) ctx.requestHeaders[':path'] = url.pathname + url.search;
+    if (!ctx.requestHeaders[':authority'])
+      ctx.requestHeaders[':authority'] = ctx.requestLowerHeaders.host;
+    if (!ctx.requestHeaders[':scheme']) ctx.requestHeaders[':scheme'] = 'https';
+    if (!ctx.requestHeaders[':method']) ctx.requestHeaders[':method'] = ctx.method;
 
+    this.stripHttp1HeadersForHttp2(ctx);
+  }
+
+  public static stripHttp1HeadersForHttp2(ctx: IMitmRequestContext) {
     // TODO: should be part of an emulator for h2 headers
     for (const key of Object.keys(ctx.requestHeaders)) {
       const lowerKey = key.toLowerCase();
       if (stripHttp1HeadersForH2.includes(lowerKey)) {
-        continue;
+        delete ctx.requestHeaders[key];
       }
-      newHeaders[lowerKey] = ctx.requestHeaders[key];
     }
-    ctx.requestHeaders = newHeaders;
   }
 
   private static cleanRequestHeaders(ctx: IMitmRequestContext) {

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -90,12 +90,12 @@ export default class HeadersHandler {
         if (canonizedKey[0] === ':') delete ctx.responseHeaders[key];
       }
 
-      if (!nodeCommon._checkInvalidHeaderChar(value)) {
-        if (Array.isArray(value)) {
-          headers[canonizedKey] = [...value];
-        } else {
-          headers[canonizedKey] = value;
-        }
+      if (nodeCommon._checkInvalidHeaderChar(value)) continue;
+
+      if (Array.isArray(value)) {
+        headers[canonizedKey] = [...value];
+      } else {
+        headers[canonizedKey] = value;
       }
     }
 

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -121,12 +121,13 @@ export default class HeadersHandler {
 
   public static prepareRequestHeadersForHttp2(ctx: IMitmRequestContext) {
     const url = ctx.url;
-
-    if (!ctx.requestHeaders[':path']) ctx.requestHeaders[':path'] = url.pathname + url.search;
-    if (!ctx.requestHeaders[':authority'])
-      ctx.requestHeaders[':authority'] = ctx.requestLowerHeaders.host;
-    if (!ctx.requestHeaders[':scheme']) ctx.requestHeaders[':scheme'] = 'https';
-    if (!ctx.requestHeaders[':method']) ctx.requestHeaders[':method'] = ctx.method;
+    if (ctx.isServerHttp2 && ctx.isClientHttp2 === false) {
+      if (!ctx.requestHeaders[':path']) ctx.requestHeaders[':path'] = url.pathname + url.search;
+      if (!ctx.requestHeaders[':authority'])
+        ctx.requestHeaders[':authority'] = ctx.requestLowerHeaders.host;
+      if (!ctx.requestHeaders[':scheme']) ctx.requestHeaders[':scheme'] = 'https';
+      if (!ctx.requestHeaders[':method']) ctx.requestHeaders[':method'] = ctx.method;
+    }
 
     this.stripHttp1HeadersForHttp2(ctx);
   }

--- a/mitm/lib/MitmRequestAgent.ts
+++ b/mitm/lib/MitmRequestAgent.ts
@@ -49,7 +49,9 @@ export default class MitmRequestAgent {
       mitmSocket = await this.waitForFreeSocket(ctx.url.origin);
     }
     MitmRequestContext.assignMitmSocket(ctx, mitmSocket);
+    await HeadersHandler.modifyHeaders(ctx);
 
+    requestSettings.headers = ctx.requestHeaders;
     requestSettings.createConnection = () => mitmSocket.socket;
     requestSettings.agent = null;
 

--- a/mitm/lib/Utils.ts
+++ b/mitm/lib/Utils.ts
@@ -9,8 +9,9 @@ export function parseRawHeaders(rawHeaders: string[]): IResourceHeaders {
     if (headers[key] || key.toLowerCase() === 'set-cookie') {
       if (Array.isArray(headers[key])) {
         headers[key].push(value);
+      } else if (headers[key]) {
+        headers[key] = [headers[key], value];
       } else {
-        if (headers[key]) headers[key] = [headers[key]];
         headers[key] = [value];
       }
     } else {

--- a/mitm/test/basic.test.ts
+++ b/mitm/test/basic.test.ts
@@ -1,15 +1,15 @@
-import http, { IncomingHttpHeaders } from 'http';
-import { Helpers } from '@secret-agent/testing';
-import HttpProxyAgent from 'http-proxy-agent';
-import { AddressInfo } from 'net';
-import WebSocket from 'ws';
-import Url from 'url';
-import { createPromise } from '@secret-agent/commons/utils';
-import HttpRequestHandler from '../handlers/HttpRequestHandler';
-import RequestSession from '../handlers/RequestSession';
-import MitmServer from '../lib/MitmProxy';
-import HeadersHandler from '../handlers/HeadersHandler';
-import HttpUpgradeHandler from '../handlers/HttpUpgradeHandler';
+import http from "http";
+import { Helpers } from "@secret-agent/testing";
+import HttpProxyAgent from "http-proxy-agent";
+import { AddressInfo } from "net";
+import WebSocket from "ws";
+import Url from "url";
+import { createPromise } from "@secret-agent/commons/utils";
+import HttpRequestHandler from "../handlers/HttpRequestHandler";
+import RequestSession from "../handlers/RequestSession";
+import MitmServer from "../lib/MitmProxy";
+import HeadersHandler from "../handlers/HeadersHandler";
+import HttpUpgradeHandler from "../handlers/HttpUpgradeHandler";
 import { parseRawHeaders } from "../lib/Utils";
 
 const mocks = {

--- a/mitm/test/http2.test.ts
+++ b/mitm/test/http2.test.ts
@@ -2,11 +2,14 @@ import { Helpers } from '@secret-agent/testing';
 import * as http2 from 'http2';
 import { URL } from 'url';
 import MitmSocket from '@secret-agent/mitm-socket';
+import IResourceHeaders from '@secret-agent/core-interfaces/IResourceHeaders';
 import MitmServer from '../lib/MitmProxy';
 import RequestSession from '../handlers/RequestSession';
 import HttpRequestHandler from '../handlers/HttpRequestHandler';
 import HeadersHandler from '../handlers/HeadersHandler';
 import MitmRequestContext from '../lib/MitmRequestContext';
+import { parseRawHeaders } from '../lib/Utils';
+import { h2 } from '../../replay-app/frontend/src/mixins';
 
 const mocks = {
   httpRequestHandler: {
@@ -79,6 +82,33 @@ test('should be able to handle an http2->http2 request', async () => {
   expect(call[0].clientToProxyRequest).toBeInstanceOf(http2.Http2ServerRequest);
 });
 
+it('should send http1 response headers through proxy', async () => {
+  const server = await Helpers.runHttp2Server((req, res1) => {
+    res1.setHeader('x-test', ['1', '2']);
+    res1.end('headers done');
+  });
+  const session = new RequestSession('h2-to-h2', 'any agent', null);
+  Helpers.needsClosing.push(session);
+  const proxyCredentials = session.getProxyCredentials();
+
+  const client = await createH2Connection(session.sessionId, server.baseUrl, proxyCredentials);
+
+  const h2stream = client.request({
+    ':path': '/',
+  });
+  const h2Headers = new Promise<string[]>(resolve => {
+    h2stream.on('response', (headers, flags, rawHeaders) => {
+      resolve(rawHeaders);
+    });
+  });
+  const buffer = await Helpers.readableToBuffer(h2stream);
+  expect(buffer.toString()).toBe('headers done');
+
+  expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(1);
+  const headers = parseRawHeaders(await h2Headers);
+  expect(headers['x-test']).toHaveLength(2);
+});
+
 test('should support push streams', async () => {
   const server = await Helpers.runHttp2Server((req, res1) => {
     res1.createPushResponse(
@@ -92,8 +122,10 @@ test('should support push streams', async () => {
     res1.createPushResponse(
       {
         ':path': '/push2',
+        'send-1': ['a', 'b'],
       },
       (err, pushRes) => {
+        pushRes.setHeader('x-push-test', ['1', '2', '3']);
         pushRes.end('Push2');
       },
     );
@@ -105,15 +137,23 @@ test('should support push streams', async () => {
   const proxyCredentials = session.getProxyCredentials();
 
   const client = await createH2Connection(session.sessionId, server.baseUrl, proxyCredentials);
-  const pushes: string[] = [];
-  client.on('stream', (stream, headers1) => {
-    pushes.push(headers1[':path']);
+  const pushRequestHeaders: {
+    [path: string]: { requestHeaders: IResourceHeaders; responseHeaders?: IResourceHeaders };
+  } = {};
+  client.on('stream', (stream, headers1, flags, rawHeaders) => {
+    const path = headers1[':path'];
+    pushRequestHeaders[path] = { requestHeaders: parseRawHeaders(rawHeaders) };
+    stream.on('push', (responseHeaders, responseFalgs, rawResponseHeaders) => {
+      pushRequestHeaders[path].responseHeaders = parseRawHeaders(rawResponseHeaders);
+    });
   });
   const h2stream = client.request({ ':path': '/' });
   const buffer = await Helpers.readableToBuffer(h2stream);
   expect(buffer.toString()).toBe('H2 response');
-  expect(pushes.includes('/push1')).toBeTruthy();
-  expect(pushes.includes('/push2')).toBeTruthy();
+  expect(pushRequestHeaders['/push1']).toBeTruthy();
+  expect(pushRequestHeaders['/push2']).toBeTruthy();
+  expect(pushRequestHeaders['/push2'].responseHeaders['x-push-test']).toStrictEqual(['1', '2', '3']);
+  expect(pushRequestHeaders['/push2'].requestHeaders['send-1']).toStrictEqual(['a', 'b']);
 });
 
 test('should handle h2 client going to h1 request', async () => {

--- a/mitm/test/http2.test.ts
+++ b/mitm/test/http2.test.ts
@@ -1,15 +1,14 @@
-import { Helpers } from '@secret-agent/testing';
-import * as http2 from 'http2';
-import { URL } from 'url';
-import MitmSocket from '@secret-agent/mitm-socket';
-import IResourceHeaders from '@secret-agent/core-interfaces/IResourceHeaders';
-import MitmServer from '../lib/MitmProxy';
-import RequestSession from '../handlers/RequestSession';
-import HttpRequestHandler from '../handlers/HttpRequestHandler';
-import HeadersHandler from '../handlers/HeadersHandler';
-import MitmRequestContext from '../lib/MitmRequestContext';
-import { parseRawHeaders } from '../lib/Utils';
-import { h2 } from '../../replay-app/frontend/src/mixins';
+import { Helpers } from "@secret-agent/testing";
+import * as http2 from "http2";
+import { URL } from "url";
+import MitmSocket from "@secret-agent/mitm-socket";
+import IResourceHeaders from "@secret-agent/core-interfaces/IResourceHeaders";
+import MitmServer from "../lib/MitmProxy";
+import RequestSession from "../handlers/RequestSession";
+import HttpRequestHandler from "../handlers/HttpRequestHandler";
+import HeadersHandler from "../handlers/HeadersHandler";
+import MitmRequestContext from "../lib/MitmRequestContext";
+import { parseRawHeaders } from "../lib/Utils";
 
 const mocks = {
   httpRequestHandler: {

--- a/puppet-chrome/lib/CDPSession.ts
+++ b/puppet-chrome/lib/CDPSession.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// eslint-disable-next-line max-classes-per-file
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import { Protocol } from 'devtools-protocol';
 import { EventEmitter } from 'events';

--- a/puppet-chrome/lib/CDPSession.ts
+++ b/puppet-chrome/lib/CDPSession.ts
@@ -126,6 +126,8 @@ interface CDPSessionOnMessageObject {
   result?: any;
 }
 
+class ProtocolError extends Error {}
+
 export function createProtocolError(
   error: Error,
   method: string,
@@ -133,7 +135,9 @@ export function createProtocolError(
 ): Error {
   let message = `Protocol error (${method}): ${object.error.message}`;
   if ('data' in object.error) message += ` ${object.error.data}`;
-  return rewriteError(error, message);
+  const protocolError = new ProtocolError(message);
+  protocolError.stack = error.stack;
+  return protocolError;
 }
 
 export function rewriteError(error: Error, message: string): Error {

--- a/puppet/lib/PipeTransport.ts
+++ b/puppet/lib/PipeTransport.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as EventUtils from '@secret-agent/commons/eventUtils';
-import { debug } from '@secret-agent/commons/Debug';
-import IConnectionTransport from '../interfaces/IConnectionTransport';
+import * as EventUtils from "@secret-agent/commons/eventUtils";
+import { debug } from "@secret-agent/commons/Debug";
+import IConnectionTransport from "../interfaces/IConnectionTransport";
 
-const debugError = debug('puppet:error');
+const debugError = debug('puppet:transport:error');
+const debugInfo = debug('puppet:transport');
 
 export class PipeTransport implements IConnectionTransport {
   pipeWrite: NodeJS.WritableStream;
@@ -33,6 +34,7 @@ export class PipeTransport implements IConnectionTransport {
     this.eventListeners = [
       EventUtils.addEventListener(pipeRead, 'data', buffer => this._dispatch(buffer)),
       EventUtils.addEventListener(pipeRead, 'close', () => {
+        debugInfo('PipeTransport closed');
         if (this.onclose) this.onclose.call(null);
       }),
       EventUtils.addEventListener(pipeRead, 'error', debugError),

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -19,12 +19,11 @@ import { StdioOptions } from "child_process";
 import { debug } from "@secret-agent/commons/Debug";
 import { Readable, Writable } from "stream";
 import * as readline from "readline";
+import Path from 'path';
 import { PipeTransport } from "./PipeTransport";
 import ILaunchedProcess from "../interfaces/ILaunchedProcess";
 
 const debugLauncher = debug('puppet:launcher');
-const errorDebug = debug('puppet:browser:error');
-const outDebug = debug('puppet:browser:out');
 
 export default function launchProcess(
   executablePath: string,
@@ -53,6 +52,9 @@ export default function launchProcess(
     throw new Error('Failed to launch');
   }
 
+  const exe = executablePath.split(Path.sep).pop().toLowerCase();
+  const errorDebug = debug(`${exe}:stderr`);
+  const outDebug = debug(`${exe}:stdout`);
   if (pipeIo) {
     const stdout = readline.createInterface({ input: launchedProcess.stdout });
     stdout.on('line', (data: string) => {

--- a/puppet/test/Worker.test.ts
+++ b/puppet/test/Worker.test.ts
@@ -52,6 +52,8 @@ describe.each([
     const worker = page.workers[0];
     expect(worker.url).toContain('worker.js');
 
+    await new Promise(setImmediate);
+
     expect(await worker.evaluate(`self.workerFunction()`)).toBe('worker function result');
 
     await page.goto(server.emptyPage);

--- a/replay-app/backend/models/Window.ts
+++ b/replay-app/backend/models/Window.ts
@@ -33,7 +33,7 @@ export default class Window {
 
   private readonly navHistory: { location?: IWindowLocation; replayMeta?: IReplayMeta }[] = [];
 
-  private navCursor: number;
+  private navCursor = -1;
 
   private _fullscreen = false;
   private isReady: Promise<void>;
@@ -218,6 +218,7 @@ export default class Window {
     if (historyIdx !== undefined) {
       this.navCursor = historyIdx;
     } else {
+      this.navHistory.length = this.navCursor+1;
       this.navCursor = this.navHistory.length;
       this.navHistory.push(history);
     }

--- a/replay-app/frontend/src/pages/command-overlay/index.vue
+++ b/replay-app/frontend/src/pages/command-overlay/index.vue
@@ -49,15 +49,16 @@ export default class CommandOverlay extends Vue {
 .CommandOverlay {
   @include overlayStyle();
   min-height: 80px;
-  padding: 1px;
+  box-sizing: border-box;
+  padding: 10px 25px 10px 15px;
+  overflow: hidden;
   .title {
-    margin: 20px;
+    margin-top: 5px;
     box-sizing: content-box;
-    wrap-word: break-word;
+    word-break: break-word;
     text-align: center;
   }
   .resultBox {
-    margin: 20px;
     font-size: 0.9em;
     .label {
       color: #3c3c3c;
@@ -65,6 +66,7 @@ export default class CommandOverlay extends Vue {
       margin-right: 5px;
     }
     .value {
+      word-break: break-word;
       &.error {
         font-style: italic;
         color: #717171;

--- a/replay-app/frontend/src/pages/header/index.vue
+++ b/replay-app/frontend/src/pages/header/index.vue
@@ -36,7 +36,7 @@
     button(v-if="saSession.tabs.length > 1" @click="showTabs" ref="tabRef")
       .text {{activeTabIdx + 1}}/{{saSession.tabs.length}}
     .address-bar
-      Icon(:src="ICON_LOCK" :size=16 iconStyle="transform: 'scale(-1,1)'")
+      Icon(:src="ICON_LOCK" :size=16 iconStyle="transform: 'scale(-1,1)'" disabled="true")
       .text {{currentUrl}}
 
 </template>
@@ -379,7 +379,8 @@ export default class HeaderPage extends Vue {
       }
       .Icon {
         margin-top: 1px;
-        width: 30px;
+        width: 16px;
+        height: 13px;
       }
     }
   }

--- a/replay-app/injected-scripts/domReplayer.ts
+++ b/replay-app/injected-scripts/domReplayer.ts
@@ -31,10 +31,12 @@ window.replayEvents = async function replayEvents(
     !!scrollEvent,
   );
   if (changeEvents) applyDomChanges(changeEvents);
-  document.body.appendChild(replayNode);
   if (resultNodeIds !== undefined) highlightNodes(resultNodeIds);
   if (mouseEvent) updateMouse(mouseEvent);
   if (scrollEvent) updateScroll(scrollEvent);
+  if (mouseEvent || scrollEvent || resultNodeIds) {
+    document.body.appendChild(replayNode);
+  }
 };
 
 function cancelEvent(e: Event) {
@@ -383,7 +385,7 @@ function highlightNodes(nodeIds: number[]) {
 
       if (bounds.y > maxHighlightTop) maxHighlightTop = bounds.y;
       if (bounds.y + bounds.height < minHighlightTop) minHighlightTop = bounds.y + bounds.height;
-      document.body.appendChild(hoverNode);
+      replayShadow.appendChild(hoverNode);
     }
 
     checkOverflows();

--- a/session-state/api/index.ts
+++ b/session-state/api/index.ts
@@ -119,7 +119,13 @@ function http2PushJson(res: http2.Http2ServerResponse, event: string, data: any)
   });
 
   res.createPushResponse({ ':path': `/${event}` }, (err, pushResponse) => {
-    if (err) throw err;
+    if (err) {
+      log.warn(`Error sending ${event} to Replay`, {
+        err,
+        sessionId: this.sessionId,
+      });
+      return;
+    }
     pushResponse.stream.respond({ ':status': 200 });
     pushResponse.stream.end(json);
   });
@@ -141,7 +147,14 @@ function http2PushResources(res: http2.Http2ServerResponse, resources: any[]) {
         ...headers,
       },
       (err, pushResponse) => {
-        if (err) throw err;
+        if (err) {
+          log.warn(`Error sending resource to Replay`, {
+            err,
+            url: resource.url,
+            sessionId: this.sessionId,
+          });
+          return;
+        }
         pushResponse.stream.respond({ ':status': 200 });
         if (resource.type === 'Document') {
           // body won't be rendered from resource, so just send back empty


### PR DESCRIPTION
This PR fixes a few bugs:

Core/Client:
- Don't disconnect and shutdown on "unhandledPromiseRejection" since this doesn't exit the process
- Cancel pending CommandQueue items when we disconnect

Mitm:
- Http2 push headers were improperly handling request/response headers
- Properly handle "lists" of headers (ie, more than 1 entry)
- Don't manipulate http2 headers to look like http1 headers - we didn't have the http2 server flag set in time for this call

Replay:
- Hide replay elements using a shadow dom
- Reset navigation when going back and then selecting a new "replay" to view.