### PR TITLE
fix(mitm): don’t send duplicated headers to h2

### DIFF
--- a/full-client/test/emulate.test.ts
+++ b/full-client/test/emulate.test.ts
@@ -182,7 +182,7 @@ test('should not leave stack trace markers when calling in page functions', asyn
   const browser = await SecretAgent.createBrowser();
   koaServer.get('/marker', ctx => {
     ctx.body = `
-<body></body>
+<body>
 <script type="text/javascript">
   function errorCheck() {
     const err = new Error('This is from inside');
@@ -195,6 +195,7 @@ test('should not leave stack trace markers when calling in page functions', asyn
     };
   })(document.querySelectorAll);
 </script>
+</body>
     `;
   });
   const url = `${koaServer.baseUrl}/marker`;

--- a/mitm/handlers/CacheHandler.ts
+++ b/mitm/handlers/CacheHandler.ts
@@ -24,7 +24,8 @@ export default class CacheHandler {
       const cache = this.responseCache?.get(ctx.url.href);
 
       if (cache?.etag) {
-        ctx.requestHeaders['If-None-Match'] = cache.etag;
+        const key = this.ctx.isServerHttp2 ? 'if-none-match' : 'If-None-Match';
+        ctx.requestHeaders[key] = cache.etag;
         this.didProposeCachedResource = true;
       }
     }

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -146,7 +146,7 @@ export default class HeadersHandler {
       }
       if (singleValueHttp2Headers.has(lowerKey)) {
         const value = ctx.requestHeaders[key];
-        if (Array.isArray(value) && value.length) ctx.requestHeaders[key] = value[0];
+        if (Array.isArray(value) && value.length) ctx.requestHeaders[lowerKey] = value[0];
       }
     }
   }

--- a/mitm/handlers/HttpRequestHandler.ts
+++ b/mitm/handlers/HttpRequestHandler.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import Log from '@secret-agent/commons/Logger';
 import * as http2 from 'http2';
-import { ClientHttp2Stream } from 'http2';
+import { ClientHttp2Stream, Http2ServerResponse } from 'http2';
 import IMitmRequestContext from '../interfaces/IMitmRequestContext';
 import HeadersHandler from './HeadersHandler';
 import CookieHandler from './CookieHandler';
@@ -144,7 +144,7 @@ export default class HttpRequestHandler extends BaseHttpHandler {
 
     for await (const chunk of serverToProxyResponse) {
       const data = context.cacheHandler.onResponseData(chunk as Buffer);
-      if (data) {
+      if (data && !(proxyToClientResponse as Http2ServerResponse).stream?.destroyed) {
         proxyToClientResponse.write(data, error => {
           if (error) this.onError('ServerToProxy.WriteResponseError', error);
         });

--- a/mitm/test/basic.test.ts
+++ b/mitm/test/basic.test.ts
@@ -1,16 +1,16 @@
-import http from "http";
-import { Helpers } from "@secret-agent/testing";
-import HttpProxyAgent from "http-proxy-agent";
-import { AddressInfo } from "net";
-import WebSocket from "ws";
-import Url from "url";
-import { createPromise } from "@secret-agent/commons/utils";
-import HttpRequestHandler from "../handlers/HttpRequestHandler";
-import RequestSession from "../handlers/RequestSession";
-import MitmServer from "../lib/MitmProxy";
-import HeadersHandler from "../handlers/HeadersHandler";
-import HttpUpgradeHandler from "../handlers/HttpUpgradeHandler";
-import { parseRawHeaders } from "../lib/Utils";
+import http from 'http';
+import { Helpers } from '@secret-agent/testing';
+import HttpProxyAgent from 'http-proxy-agent';
+import { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import Url from 'url';
+import { createPromise } from '@secret-agent/commons/utils';
+import HttpRequestHandler from '../handlers/HttpRequestHandler';
+import RequestSession from '../handlers/RequestSession';
+import MitmServer from '../lib/MitmProxy';
+import HeadersHandler from '../handlers/HeadersHandler';
+import HttpUpgradeHandler from '../handlers/HttpUpgradeHandler';
+import { parseRawHeaders } from '../lib/Utils';
 
 const mocks = {
   httpRequestHandler: {
@@ -35,6 +35,8 @@ beforeEach(() => {
 afterAll(Helpers.afterAll);
 afterEach(Helpers.afterEach);
 
+let sessionCounter = 1;
+
 describe('basic MitM tests', () => {
   it('should send request through proxy', async () => {
     const httpServer = await Helpers.runHttpServer();
@@ -42,7 +44,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -69,7 +71,7 @@ describe('basic MitM tests', () => {
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
 
-    let rawHeaders: string[];
+    let rawHeaders: string[] = null;
     const res = await Helpers.httpRequest(
       httpServer.url,
       'GET',
@@ -97,7 +99,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -123,7 +125,11 @@ describe('basic MitM tests', () => {
       socket.end();
     });
 
-    const session = new RequestSession('1', 'any agent', Promise.resolve(upstreamProxyHost));
+    const session = new RequestSession(
+      `${(sessionCounter += 1)}`,
+      'any agent',
+      Promise.resolve(upstreamProxyHost),
+    );
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -156,7 +162,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -185,7 +191,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('2', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -204,7 +210,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('3', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -278,7 +284,7 @@ describe('basic MitM tests', () => {
     const serverMessages = [];
     const serverMessagePromise = createPromise();
     const wsServer = new WebSocket.Server({ noServer: true });
-    const session = new RequestSession('4', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     httpServer.server.on('upgrade', (request, socket, head) => {
       // ensure header is stripped
@@ -337,11 +343,11 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
     session.delegate.modifyHeadersBeforeSend = jest.fn();
     session.registerResource({
       tabId: '1',
-      browserRequestId: '1',
+      browserRequestId: '25.123',
       url: `${httpServer.url}page1`,
       method: 'GET',
       resourceType: 'Document',


### PR DESCRIPTION
Also catch h2 push streams closing/errors

This PR catches some bugs we had in http2 handling. Most notably, a closed push stream could kill the process