### PR TITLE
fix(core): dont close client on promise rejections

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -76,7 +76,7 @@ export function SecretAgentClientGenerator(
     process.on('unhandledRejection', async (error: Error) => {
       // keep core node behavior intact
       process.stderr.write(`${error.stack}\n`);
-      await SecretAgent.shutdown(error);
+      await SecretAgent.recordUnhandledError(error);
     });
   }
 

--- a/client/lib/CoreClient.ts
+++ b/client/lib/CoreClient.ts
@@ -42,11 +42,11 @@ export default class CoreClient {
     return coreTabs;
   }
 
-  public async shutdown(error?: Error): Promise<void> {
+  public async shutdown(fatalError?: Error): Promise<void> {
     const tabIds = Object.keys(this.tabsById);
     this.commandQueue.clearPending();
-    if (tabIds.length || error) {
-      await this.commandQueue.run('disconnect', tabIds, error);
+    if (tabIds.length || fatalError) {
+      await this.commandQueue.run('disconnect', tabIds, fatalError);
     }
     for (const tabId of tabIds) {
       delete this.tabsById[tabId];

--- a/session-state/test/api.test.ts
+++ b/session-state/test/api.test.ts
@@ -99,7 +99,7 @@ describe('basic Replay API tests', () => {
     expect(paintEvents[0]).toHaveLength(1);
     expect(paintEvents[1]).toHaveLength(13);
 
-    await Core.shutdown(null, true);
+    await Core.shutdown(true);
     api.destroy();
   }, 20e3);
 });

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -328,7 +328,7 @@ export async function afterEach() {
 
 export async function afterAll() {
   await closeAll(true);
-  await Core.shutdown(null, true);
+  await Core.shutdown(true);
 }
 
 async function closeAll(isFinal = false) {


### PR DESCRIPTION
Don't shutdown client when there's an unhandled promise rejection, but still log them.