### PR TITLE
feat(client): xpath support, array index access

### DIFF
--- a/client/lib/AwaitedEventTarget.ts
+++ b/client/lib/AwaitedEventTarget.ts
@@ -1,6 +1,6 @@
-import StateMachine from "awaited-dom/base/StateMachine";
-import AwaitedPath from "awaited-dom/base/AwaitedPath";
-import CoreTab from "./CoreTab";
+import StateMachine from 'awaited-dom/base/StateMachine';
+import AwaitedPath from 'awaited-dom/base/AwaitedPath';
+import CoreTab from './CoreTab';
 
 interface IAwaitedEventTargetState {
   awaitedPath?: AwaitedPath;
@@ -15,7 +15,7 @@ export default class AwaitedEventTarget<T, IState extends IAwaitedEventTargetSta
     listenerFn: (this: this, event: T[K]) => any,
     options?,
   ): Promise<void> {
-    const { awaitedPath, coreTab } = getState<this, IState>(this);
+    const { awaitedPath, coreTab } = getState(this) as IState;
     const jsPath = awaitedPath ? awaitedPath.toJSON() : null;
     return coreTab.addEventListener(jsPath, eventType as string, listenerFn, options);
   }
@@ -24,7 +24,7 @@ export default class AwaitedEventTarget<T, IState extends IAwaitedEventTargetSta
     eventType: K,
     listenerFn: (this: this, event: T[K]) => any,
   ): Promise<void> {
-    const { awaitedPath, coreTab } = getState<this, IState>(this);
+    const { awaitedPath, coreTab } = getState(this) as IState;
     const jsPath = awaitedPath ? awaitedPath.toJSON() : null;
     return coreTab.removeEventListener(jsPath, eventType as string, listenerFn);
   }

--- a/client/lib/Browser.ts
+++ b/client/lib/Browser.ts
@@ -116,7 +116,7 @@ export default class Browser extends AwaitedEventTarget<IEventType, IState> impl
   // METHODS
 
   public async close(): Promise<void> {
-    const { isClosing, activeTab } = getState<Browser, IState>(this);
+    const { isClosing, activeTab } = getState(this);
     if (isClosing) return;
     setState(this, { isClosing: true });
     const coreTab = getCoreTab(activeTab);
@@ -234,7 +234,7 @@ export async function createBrowser(
 }
 
 async function getSessionTabs(browser: Browser) {
-  const { coreClient, tabs } = getState<Browser, IState>(browser);
+  const { coreClient, tabs } = getState(browser);
   const coreTabs = await coreClient.getTabsForSession(browser.sessionId);
   for (const coreTab of coreTabs) {
     const hasTab = tabs.some(x => x.tabId === coreTab.tabId);

--- a/client/lib/Interactor.ts
+++ b/client/lib/Interactor.ts
@@ -65,7 +65,7 @@ function convertToCoreMousePosition(mousePosition: IMousePosition): ICoreMousePo
   if (Array.isArray(mousePosition)) {
     return mousePosition;
   }
-  const { awaitedPath } = getState<ISuperElement, { awaitedPath: AwaitedPath }>(mousePosition);
+  const { awaitedPath } = getState(mousePosition);
   if (!awaitedPath) throw new Error(`Element not found -> ${mousePosition}`);
   return awaitedPath.toJSON();
 }
@@ -195,13 +195,13 @@ function convertInteractionToInteractionGroup(interaction: IInteraction): IInter
 
       case Command.waitForNode: {
         const command = CoreCommand.waitForNode;
-        const { awaitedPath } = getState<ISuperElement, { awaitedPath: AwaitedPath }>(value);
+        const { awaitedPath } = getState(value);
         const jsPath = awaitedPath.toJSON();
         return iGroup.push({ command, delayNode: jsPath });
       }
       case Command.waitForElementVisible: {
         const command = CoreCommand.waitForElementVisible;
-        const { awaitedPath } = getState<ISuperNode, { awaitedPath: AwaitedPath }>(value);
+        const { awaitedPath } = getState(value);
         const jsPath = awaitedPath.toJSON();
         return iGroup.push({ command, delayElement: jsPath });
       }

--- a/client/lib/Request.ts
+++ b/client/lib/Request.ts
@@ -2,10 +2,12 @@ import FetchRequest from 'awaited-dom/impl/official-klasses/Request';
 import AwaitedPath from 'awaited-dom/base/AwaitedPath';
 import StateMachine from 'awaited-dom/base/StateMachine';
 import { IRequestInfo, IRequestInit } from 'awaited-dom/base/interfaces/official';
+import IAttachedState from "awaited-dom/base/IAttachedState";
 import CoreTab from './CoreTab';
 
 interface IState {
   awaitedPath: AwaitedPath;
+  attachedState: IAttachedState;
   remoteInitializerPromise: Promise<void>;
   coreTab: CoreTab;
 }

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "@secret-agent/core": "1.0.0-alpha.15",
     "@secret-agent/core-interfaces": "1.0.0-alpha.14",
     "@secret-agent/replay": "1.0.0-alpha.14",
-    "awaited-dom": "^1.1.3",
+    "awaited-dom": "^1.1.5",
     "uuid": "^8.1.0"
   },
   "devDependencies": {

--- a/core-interfaces/AwaitedDom.ts
+++ b/core-interfaces/AwaitedDom.ts
@@ -1,0 +1,5 @@
+import XPathResult from 'awaited-dom/impl/official-klasses/XPathResult';
+import Node from 'awaited-dom/impl/official-klasses/Node';
+
+// export these 2 so you can access the static readonly properties (e.g., XPathResult.ANY_RESULT)
+export { XPathResult, Node };

--- a/core-interfaces/package.json
+++ b/core-interfaces/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0-alpha.14",
   "description": "Core interfaces used by SecretAgent",
   "dependencies": {
-    "@secret-agent/commons": "1.0.0-alpha.14"
+    "@secret-agent/commons": "1.0.0-alpha.14",
+    "awaited-dom": "^1.1.5"
   },
   "devDependencies": {
     "@secret-agent/injected-scripts": "1.0.0-alpha.14",
     "@types/node": "^12.7.11",
-    "awaited-dom": "^1.1.3",
     "devtools-protocol": "^0.0.799653"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -12,7 +12,7 @@
     "@secret-agent/mitm": "1.0.0-alpha.15",
     "@secret-agent/puppet": "1.0.0-alpha.15",
     "@secret-agent/session-state": "1.0.0-alpha.15",
-    "awaited-dom": "^1.1.3",
+    "awaited-dom": "^1.1.5",
     "moment": "^2.24.0",
     "typeson": "^5.18.2",
     "typeson-registry": "^1.0.0-alpha.38",

--- a/full-client/package.json
+++ b/full-client/package.json
@@ -15,6 +15,7 @@
     "@secret-agent/testing": "1.0.0-alpha.15",
     "@types/node": "^12.7.11",
     "fpcollect": "^1.0.4",
+    "awaited-dom": "^1.1.5",
     "fpscanner": "^0.1.5",
     "ws": "^7.3.1"
   }

--- a/full-client/test/emulate.test.ts
+++ b/full-client/test/emulate.test.ts
@@ -182,7 +182,7 @@ test('should not leave stack trace markers when calling in page functions', asyn
   const browser = await SecretAgent.createBrowser();
   koaServer.get('/marker', ctx => {
     ctx.body = `
-<body></body>
+<body>
 <script type="text/javascript">
   function errorCheck() {
     const err = new Error('This is from inside');
@@ -195,6 +195,7 @@ test('should not leave stack trace markers when calling in page functions', asyn
     };
   })(document.querySelectorAll);
 </script>
+</body>
     `;
   });
   const url = `${koaServer.baseUrl}/marker`;

--- a/injected-scripts/scripts/jsPath.ts
+++ b/injected-scripts/scripts/jsPath.ts
@@ -263,7 +263,15 @@ class ObjectAtPath {
       this.lookupStep = step;
       if (Array.isArray(step)) {
         const [methodName, ...args] = step;
-        currentObject = runMethod(currentObject, methodName, this.lookupStepIndex, args);
+        // extract node ids as args
+        const finalArgs = args.map(x => {
+          if (typeof x !== 'string') return x;
+          if (!x.startsWith('$$jsPath=')) return x;
+          const innerPath = JSON.parse(x.split('$$jsPath=').pop());
+          const sub = new ObjectAtPath(innerPath).lookup();
+          return sub.objectAtPath;
+        });
+        currentObject = runMethod(currentObject, methodName, this.lookupStepIndex, finalArgs);
       } else if (typeof step === 'number') {
         currentObject = NodeTracker.getNodeWithId(step);
       } else if (typeof step === 'string') {

--- a/mitm/test/basic.test.ts
+++ b/mitm/test/basic.test.ts
@@ -1,16 +1,16 @@
-import http from "http";
-import { Helpers } from "@secret-agent/testing";
-import HttpProxyAgent from "http-proxy-agent";
-import { AddressInfo } from "net";
-import WebSocket from "ws";
-import Url from "url";
-import { createPromise } from "@secret-agent/commons/utils";
-import HttpRequestHandler from "../handlers/HttpRequestHandler";
-import RequestSession from "../handlers/RequestSession";
-import MitmServer from "../lib/MitmProxy";
-import HeadersHandler from "../handlers/HeadersHandler";
-import HttpUpgradeHandler from "../handlers/HttpUpgradeHandler";
-import { parseRawHeaders } from "../lib/Utils";
+import http from 'http';
+import { Helpers } from '@secret-agent/testing';
+import HttpProxyAgent from 'http-proxy-agent';
+import { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import Url from 'url';
+import { createPromise } from '@secret-agent/commons/utils';
+import HttpRequestHandler from '../handlers/HttpRequestHandler';
+import RequestSession from '../handlers/RequestSession';
+import MitmServer from '../lib/MitmProxy';
+import HeadersHandler from '../handlers/HeadersHandler';
+import HttpUpgradeHandler from '../handlers/HttpUpgradeHandler';
+import { parseRawHeaders } from '../lib/Utils';
 
 const mocks = {
   httpRequestHandler: {
@@ -35,6 +35,8 @@ beforeEach(() => {
 afterAll(Helpers.afterAll);
 afterEach(Helpers.afterEach);
 
+let sessionCounter = 1;
+
 describe('basic MitM tests', () => {
   it('should send request through proxy', async () => {
     const httpServer = await Helpers.runHttpServer();
@@ -42,7 +44,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -69,7 +71,7 @@ describe('basic MitM tests', () => {
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
 
-    let rawHeaders: string[];
+    let rawHeaders: string[] = null;
     const res = await Helpers.httpRequest(
       httpServer.url,
       'GET',
@@ -97,7 +99,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -123,7 +125,11 @@ describe('basic MitM tests', () => {
       socket.end();
     });
 
-    const session = new RequestSession('1', 'any agent', Promise.resolve(upstreamProxyHost));
+    const session = new RequestSession(
+      `${(sessionCounter += 1)}`,
+      'any agent',
+      Promise.resolve(upstreamProxyHost),
+    );
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -156,7 +162,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(0);
@@ -185,7 +191,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('2', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -204,7 +210,7 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('3', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     const proxyCredentials = session.getProxyCredentials();
 
@@ -278,7 +284,7 @@ describe('basic MitM tests', () => {
     const serverMessages = [];
     const serverMessagePromise = createPromise();
     const wsServer = new WebSocket.Server({ noServer: true });
-    const session = new RequestSession('4', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
 
     httpServer.server.on('upgrade', (request, socket, head) => {
       // ensure header is stripped
@@ -337,11 +343,11 @@ describe('basic MitM tests', () => {
     Helpers.needsClosing.push(mitmServer);
     const proxyHost = `http://localhost:${mitmServer.port}`;
 
-    const session = new RequestSession('1', 'any agent', null);
+    const session = new RequestSession(`${(sessionCounter += 1)}`, 'any agent', null);
     session.delegate.modifyHeadersBeforeSend = jest.fn();
     session.registerResource({
       tabId: '1',
-      browserRequestId: '1',
+      browserRequestId: '25.123',
       url: `${httpServer.url}page1`,
       method: 'GET',
       resourceType: 'Document',

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@gridsome/vue-remark": "^0.2.1",
     "@types/json2md": "^1.5.0",
     "@types/lodash.kebabcase": "^4.1.6",
-    "awaited-dom": "^1.1.4",
+    "awaited-dom": "^1.1.5",
     "decamelize": "^4.0.0",
     "docsearch.js": "^2.6.3",
     "gridsome": "^0.7.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4348,10 +4348,10 @@ autoprefixer@^9.4.7, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awaited-dom@^1.1.3, awaited-dom@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.1.4.tgz#66308273189607b1e7d736a12ca1630a93a821d4"
-  integrity sha512-wFNmqUVPK2cgHWDE7kfpbf0umPZYf3xAOW5sRq2fbB9KKNumGzTJChF0ZxNbFWy9hHM9E2bfMF3mzOUKwfCM+Q==
+awaited-dom@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.1.5.tgz#5327084da916cec2923c6af9e6fbce2fd446bde6"
+  integrity sha512-Car6uqMQIZ/31k+gB9ilJkW37gEbquzbWhTGto2zIgZjhDCtvd0KV0UG5GBnBA2qWoV/0IkY0Ct4+pbN1U5pXQ==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
Add support for awaited dom features:
- Convert AwaitedHandler to use delegate pattern
- Xpath support (we now loop through all parameters for methods and convert to awaitedPath as necessary)
- JsPath - re-inflate paths in parameters
- Export Node and XPathResult from core-interfaces so you can access the static properties (eg, XPathResult.ANY_TYPE)
- Support for more restrictive type checking on StateMachine