### PR TITLE
fix(core): wait for location change on new tab

### DIFF
--- a/client/lib/SetupAwaitedHandler.ts
+++ b/client/lib/SetupAwaitedHandler.ts
@@ -8,7 +8,14 @@ import IAwaitedOptions from '../interfaces/IAwaitedOptions';
 import CoreTab from './CoreTab';
 
 // Sets up AwaitedHandler initializer hooks. See Noderdom/AwaitedDOM
-AwaitedHandler.delegate = exports;
+AwaitedHandler.delegate = {
+  getProperty,
+  setProperty,
+  construct,
+  runMethod,
+  runStatic,
+  loadState,
+};
 
 export async function getProperty<T, TClass>(
   self: AwaitedHandler<TClass>,

--- a/core/index.ts
+++ b/core/index.ts
@@ -22,6 +22,7 @@ import ISessionReplayServer from '@secret-agent/session-state/interfaces/ISessio
 import Queue from '@secret-agent/commons/Queue';
 import Chrome83 from '@secret-agent/emulate-chrome-83';
 import Emulators from '@secret-agent/emulators';
+import IResourceMeta from '@secret-agent/core-interfaces/IResourceMeta';
 import IListenerObject from './interfaces/IListenerObject';
 import UserProfile from './lib/UserProfile';
 import Session from './lib/Session';
@@ -64,7 +65,7 @@ export default class Core implements ICore {
   }
 
   public async goto(url: string) {
-    return this.tab.runCommand<void>('goto', url);
+    return this.tab.runCommand<IResourceMeta>('goto', url);
   }
 
   public async goBack() {
@@ -203,6 +204,7 @@ export default class Core implements ICore {
   public async waitForNewTab(sinceCommandId?: number) {
     const lastCommandId = sinceCommandId ?? this.lastCommandId;
     const tab = await this.tab.runCommand<Tab>('waitForNewTab', lastCommandId);
+    await tab.locationTracker.waitForLocationResourceId();
     return Core.registerSessionTab(this.session, tab);
   }
 

--- a/full-client/test/emulate.test.ts
+++ b/full-client/test/emulate.test.ts
@@ -200,6 +200,7 @@ test('should not leave stack trace markers when calling in page functions', asyn
   });
   const url = `${koaServer.baseUrl}/marker`;
   await browser.goto(url);
+  await browser.waitForAllContentLoaded();
   const core = Core.byTabId[browser.activeTab.tabId];
 
   const pageFunction = await core.getJsValue('errorCheck()');

--- a/mitm/test/http2.test.ts
+++ b/mitm/test/http2.test.ts
@@ -86,7 +86,7 @@ it('should send http1 response headers through proxy', async () => {
     res1.setHeader('x-test', ['1', '2']);
     res1.end('headers done');
   });
-  const session = new RequestSession('h2-to-h2', 'any agent', null);
+  const session = new RequestSession('h1-to-h2-response', 'any agent', null);
   Helpers.needsClosing.push(session);
   const proxyCredentials = session.getProxyCredentials();
 
@@ -131,7 +131,7 @@ test('should support push streams', async () => {
     res1.end('H2 response');
   });
 
-  const session = new RequestSession('h2', 'any agent', null);
+  const session = new RequestSession('push-streams', 'any agent', null);
   Helpers.needsClosing.push(session);
   const proxyCredentials = session.getProxyCredentials();
 

--- a/puppet-chrome/lib/NetworkManager.ts
+++ b/puppet-chrome/lib/NetworkManager.ts
@@ -123,6 +123,7 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
         documentUrl: networkRequest.request.headers.Referer,
         isDocumentNavigation: false,
         frameId: networkRequest.frameId,
+        redirectedFromUrl: null,
       });
     }
   }
@@ -130,6 +131,8 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
   private onNetworkRequestWillBeSent(networkRequest: RequestWillBeSentEvent) {
     const isNavigation =
       networkRequest.requestId === networkRequest.loaderId && networkRequest.type === 'Document';
+
+    const redirectedFromUrl = networkRequest.redirectResponse?.url;
 
     this.emit('resource-will-be-requested', {
       browserRequestId: networkRequest.requestId,
@@ -142,6 +145,7 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
       referer: networkRequest.request.headers.Referer,
       isDocumentNavigation: isNavigation,
       frameId: networkRequest.frameId,
+      redirectedFromUrl,
     });
   }
 

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -96,6 +96,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
         'frame-requested-navigation',
         'websocket-frame',
         'websocket-handshake',
+        'navigation-response',
         'worker',
       ],
       'puppet-chrome',

--- a/puppet/interfaces/IPuppetNetworkEvents.ts
+++ b/puppet/interfaces/IPuppetNetworkEvents.ts
@@ -19,6 +19,7 @@ export interface IPuppetNetworkEvents {
   };
   'resource-will-be-requested': {
     browserRequestId: string;
+    redirectedFromUrl: string;
     resourceType: ResourceType;
     url: string;
     method: string;

--- a/session-state/index.ts
+++ b/session-state/index.ts
@@ -227,9 +227,11 @@ export default class SessionState {
     if (isResponse) {
       log.info('Http.Response', {
         sessionId: this.sessionId,
+        tabId,
         url: request.url,
         method: request.method,
         headers: response.headers,
+        status: response.statusCode,
         wasCached,
         executionMillis,
         bytes: body ? Buffer.byteLength(body) : -1,


### PR DESCRIPTION
This PR changes a few things:
1) Connect redirects to navigations after the initial one (ie, new link, new tab)
2) waitForNewTab waits for an initial resource to be loaded - this is so that location "Change" events will not trigger for the first page loaded in a new tab.