### PR TITLE
Dns over Tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ emulators/data/DOM-*.json
 .gh
 **/dist
 /.eslintcache
+/.network.db

--- a/commons/SqliteTable.ts
+++ b/commons/SqliteTable.ts
@@ -3,7 +3,7 @@ import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
 type SqliteTypes = 'INTEGER' | 'TEXT' | 'BLOB';
 type IRecord = (string | number | Buffer)[];
 
-export default abstract class BaseTable<T> {
+export default abstract class SqliteTable<T> {
   protected readonly insertStatement: Statement;
   protected defaultSortOrder?: string;
   protected insertCallbackFn?: (records: T[]) => void;

--- a/commons/interfaces/IHttpRequestModifierDelegate.ts
+++ b/commons/interfaces/IHttpRequestModifierDelegate.ts
@@ -1,9 +1,11 @@
 import ResourceType from '@secret-agent/core-interfaces/ResourceType';
 import IResourceHeaders from '@secret-agent/core-interfaces/IResourceHeaders';
+import { ConnectionOptions } from "tls";
 import OriginType from './OriginType';
 import IHttpResourceLoadDetails from './IHttpResourceLoadDetails';
 
 export default interface IHttpRequestModifierDelegate {
+  dnsOverTlsConnectOptions?: ConnectionOptions;
   modifyHeadersBeforeSend?: (request: IResourceToModify) => { [key: string]: string };
 
   maxConnectionsPerOrigin?: number;

--- a/commons/package.json
+++ b/commons/package.json
@@ -4,5 +4,7 @@
   "description": "Common utilities for Secret Agent",
   "main": "index.js",
   "dependencies": {
-    "@secret-agent/core-interfaces": "1.0.0-alpha.16"  }
+    "@secret-agent/core-interfaces": "1.0.0-alpha.16",
+    "better-sqlite3": "^7.1.1"
+  }
 }

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -81,9 +81,8 @@ export default class Session {
       this.id,
       this.emulator.userAgent.raw,
       this.proxy.isReady(),
+      this.emulator.delegate,
     );
-
-    this.mitmRequestSession.delegate = this.emulator.delegate;
   }
 
   public getBrowserEmulation() {

--- a/emulator-plugins/emulate-chrome-80/index.ts
+++ b/emulator-plugins/emulate-chrome-80/index.ts
@@ -14,6 +14,7 @@ import {
 import { randomBytes } from 'crypto';
 import { pickRandom } from '@secret-agent/emulators/lib/Utils';
 import IUserAgent from '@secret-agent/emulators/interfaces/IUserAgent';
+import { ConnectionOptions } from 'tls';
 import navigator from './navigator.json';
 import chrome from './chrome.json';
 import codecs from './codecs.json';
@@ -30,6 +31,11 @@ export default class Chrome80 extends EmulatorPlugin {
   public static emulatorId = pkg.name;
   public static statcounterBrowser = 'Chrome 80.0';
   public static engine = pkg.engine;
+  public static dnsOverTlsConnectOptions = <ConnectionOptions>{
+    host: '1.1.1.1',
+    servername: 'cloudflare-dns.com',
+  };
+
   protected static agents = UserAgents.getList(
     {
       deviceCategory: 'desktop',
@@ -70,6 +76,7 @@ export default class Chrome80 extends EmulatorPlugin {
       modifyHeadersBeforeSend: modifyHeaders.bind(this, this.userAgent, headerProfiles),
       tlsProfileId: 'Chrome80',
       tcpVars: tcpVars(this.userAgent.os),
+      dnsOverTlsConnectOptions: Chrome80.dnsOverTlsConnectOptions,
     };
   }
 

--- a/emulator-plugins/emulate-chrome-83/index.ts
+++ b/emulator-plugins/emulate-chrome-83/index.ts
@@ -14,6 +14,7 @@ import {
 import { randomBytes } from 'crypto';
 import { pickRandom } from '@secret-agent/emulators/lib/Utils';
 import IUserAgent from '@secret-agent/emulators/interfaces/IUserAgent';
+import { ConnectionOptions } from 'tls';
 import defaultAgents from './user-agents.json';
 import navigator from './navigator.json';
 import chrome from './chrome.json';
@@ -30,6 +31,10 @@ export default class Chrome83 extends EmulatorPlugin {
   public static emulatorId = pkg.name;
   public static statcounterBrowser = 'Chrome 83.0';
   public static engine = pkg.engine;
+  public static dnsOverTlsConnectOptions = <ConnectionOptions>{
+    host: '1.1.1.1',
+    servername: 'cloudflare-dns.com',
+  };
 
   protected static agents = UserAgents.getList(
     {
@@ -68,6 +73,7 @@ export default class Chrome83 extends EmulatorPlugin {
       modifyHeadersBeforeSend: modifyHeaders.bind(this, this.userAgent, headerProfiles),
       tlsProfileId: 'Chrome83',
       tcpVars: tcpVars(this.userAgent.os),
+      dnsOverTlsConnectOptions: Chrome83.dnsOverTlsConnectOptions,
     };
   }
 

--- a/mitm-socket/index.ts
+++ b/mitm-socket/index.ts
@@ -91,9 +91,6 @@ export default class MitmSocket {
     await this.cleanSocketPathIfNeeded();
     const child = spawn(libPath, [this.socketPath, JSON.stringify(this.connectOpts)], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        GODEBUG: 'netdns=cgo',
-      },
     });
     this.child = child;
     child.stdout.setEncoding('utf8');
@@ -135,7 +132,7 @@ export default class MitmSocket {
   }
 
   private closeChild() {
-    if (this.child.killed) return;
+    if (!this.child || this.child.killed) return;
     try {
       // fix for node 13 throwing errors on closed sockets
       this.child.stdin.on('error', () => {

--- a/mitm/lib/Dns.ts
+++ b/mitm/lib/Dns.ts
@@ -1,0 +1,113 @@
+import { createPromise, IResolvablePromise } from '@secret-agent/commons/utils';
+import Log from '@secret-agent/commons/Logger';
+import { ConnectionOptions } from 'tls';
+import moment from 'moment';
+import net from 'net';
+import DnsOverTlsSocket from './DnsOverTlsSocket';
+import RequestSession from '../handlers/RequestSession';
+
+const { log } = Log(module);
+
+export class Dns {
+  public socket: DnsOverTlsSocket;
+  public dnsEntries = new Map<string, IResolvablePromise<IDnsEntry>>();
+  private readonly dnsServer: ConnectionOptions;
+
+  constructor(readonly requestSession?: RequestSession) {
+    this.dnsServer = requestSession?.delegate?.dnsOverTlsConnectOptions;
+  }
+
+  public async lookupIp(host: string, retries = 3) {
+    if (!this.dnsServer || host === 'localhost' || net.isIP(host)) return host;
+
+    try {
+      // get cached (or in process resolver)
+      const cachedRecord = await this.getNextCachedARecord(host);
+      if (cachedRecord) return cachedRecord.ip;
+    } catch (error) {
+      if (retries === 0) throw error;
+      // if the cache lookup failed, likely because another lookup failed... try again
+      return this.lookupIp(host, retries - 1);
+    }
+
+    // if not found in cache, perform dns lookup
+    try {
+      const dnsEntry = await this.lookupDnsEntry(host);
+      return this.nextIp(dnsEntry);
+    } catch (error) {
+      log.error('DnsLookup.Error', {
+        sessionId: this.requestSession.sessionId,
+        error,
+      });
+      // fallback to host
+      return host;
+    }
+  }
+
+  public close() {
+    this.socket?.close();
+  }
+
+  private async lookupDnsEntry(host: string) {
+    const existing = this.dnsEntries.get(host);
+    if (existing && !existing.isResolved) return existing.promise;
+
+    try {
+      const dnsEntry = createPromise<IDnsEntry>();
+      this.dnsEntries.set(host, dnsEntry);
+
+      if (!this.socket?.isActive) {
+        this.socket = new DnsOverTlsSocket(
+          this.dnsServer,
+          this.requestSession,
+          () => (this.socket = null),
+        );
+      }
+
+      const response = await this.socket.lookupARecords(host);
+
+      const entry = <IDnsEntry>{
+        aRecords: response.answers
+          .filter(x => x.type === 'A') // gives non-query records sometimes
+          .map(x => ({
+            ip: x.data,
+            expiry: moment()
+              .add(x.ttl, 'seconds')
+              .toDate(),
+          })),
+      };
+      dnsEntry.resolve(entry);
+      return entry;
+    } catch (error) {
+      this.dnsEntries.get(host)?.reject(error);
+      this.dnsEntries.delete(host);
+      throw error;
+    }
+  }
+
+  private nextIp(dnsEntry: IDnsEntry) {
+    // implement rotating
+    for (let i = 0; i < dnsEntry.aRecords.length; i += 1) {
+      const record = dnsEntry.aRecords[i];
+      if (record.expiry > new Date()) {
+        // move record to back
+        dnsEntry.aRecords.splice(i, 1);
+        dnsEntry.aRecords.push(record);
+        return record;
+      }
+    }
+    return null;
+  }
+
+  private async getNextCachedARecord(name: string) {
+    const cached = await this.dnsEntries.get(name)?.promise;
+    if (cached?.aRecords?.length) {
+      return this.nextIp(cached);
+    }
+    return null;
+  }
+}
+
+interface IDnsEntry {
+  aRecords: { ip: string; expiry: Date }[];
+}

--- a/mitm/lib/DnsOverTlsSocket.ts
+++ b/mitm/lib/DnsOverTlsSocket.ts
@@ -1,0 +1,161 @@
+import { randomBytes } from 'crypto';
+import * as dnsPacket from 'dns-packet';
+import { ConnectionOptions } from 'tls';
+import { createPromise, IResolvablePromise } from '@secret-agent/commons/utils';
+import MitmSocket from '@secret-agent/mitm-socket/index';
+import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+import RequestSession from '../handlers/RequestSession';
+
+export default class DnsOverTlsSocket {
+  public get host() {
+    return this.dnsServer.host;
+  }
+
+  public get isActive() {
+    return this.mitmSocket.isReusable() && !this.isClosing;
+  }
+
+  private dnsServer: ConnectionOptions;
+  private readonly mitmSocket: MitmSocket;
+  private readonly isConnected: Promise<void>;
+
+  private pending = new Map<number, IResolvablePromise<IDnsResponse>>();
+
+  private currentMessage: Buffer = null;
+  private packetLength = 0;
+  private isClosing = false;
+
+  private readonly onClose?: () => void;
+
+  private requestSession: RequestSession;
+
+  constructor(dnsServer: ConnectionOptions, requestSession?: RequestSession, onClose?: () => void) {
+    this.requestSession = requestSession;
+    this.mitmSocket = new MitmSocket(requestSession?.sessionId, {
+      host: dnsServer.host,
+      port: String(dnsServer.port ?? 853),
+      isSsl: true,
+      servername: dnsServer.servername,
+      rejectUnauthorized: false,
+      clientHelloId: requestSession?.delegate?.tlsProfileId,
+      keepAlive: true,
+    });
+    this.dnsServer = dnsServer;
+    this.onClose = onClose;
+    this.isConnected = this.connect();
+  }
+
+  public async lookupARecords(host: string): Promise<IDnsResponse> {
+    const resolvable = createPromise<IDnsResponse>();
+    await this.isConnected;
+    const id = this.query({
+      name: host,
+      class: 'IN',
+      type: 'A',
+    });
+    this.pending.set(id, resolvable);
+    return resolvable.promise;
+  }
+
+  public close() {
+    if (this.isClosing) return;
+    this.isClosing = true;
+    this.mitmSocket.close();
+    if (this.onClose) this.onClose();
+  }
+
+  protected async connect() {
+    const proxyUrl = await this.requestSession?.getUpstreamProxyUrl();
+    if (proxyUrl) this.mitmSocket.setProxy(proxyUrl);
+
+    await this.mitmSocket.connect();
+
+    this.mitmSocket.socket.on('data', this.onData.bind(this));
+    this.mitmSocket.on('close', () => {
+      this.isClosing = true;
+      if (this.onClose) this.onClose();
+    });
+  }
+
+  private disconnect() {
+    for (const [, entry] of this.pending) {
+      entry.reject(new CanceledPromiseError('Disconnecting Dns Socket'));
+    }
+    this.close();
+  }
+
+  private query(...questions: IQuestion[]) {
+    const id = randomBytes(2).readUInt16BE(0);
+    const dnsQuery = dnsPacket.streamEncode({
+      flags: dnsPacket.RECURSION_DESIRED,
+      id,
+      questions,
+      type: 'query',
+    });
+    this.mitmSocket.socket.write(dnsQuery);
+    return id;
+  }
+
+  private onData(data: Buffer) {
+    if (this.currentMessage === null) {
+      this.currentMessage = Buffer.from(data);
+    } else {
+      this.currentMessage = Buffer.concat([this.currentMessage, data]);
+    }
+
+    if (this.currentMessage.byteLength >= 2 && !this.packetLength) {
+      // https://tools.ietf.org/html/rfc7858#section-3.3
+      // https://tools.ietf.org/html/rfc1035#section-4.2.2
+      // The message is prefixed with a two byte length field which gives the
+      // message length, excluding the two byte length field.
+      this.packetLength = this.currentMessage.readUInt16BE(0);
+      if (this.packetLength < 12) {
+        return this.disconnect();
+      }
+    }
+
+    // append prefixed byte length
+    if (this.currentMessage.byteLength === this.packetLength + 2) {
+      const decoded = dnsPacket.streamDecode(this.currentMessage) as IDnsResponse;
+      this.pending.get(decoded.id)?.resolve(decoded);
+      this.pending.delete(decoded.id);
+      this.currentMessage = null;
+      this.packetLength = 0;
+    }
+  }
+}
+
+interface IQuestion {
+  name: string;
+  type: string;
+  class: string;
+}
+
+interface IAnswer {
+  name: string;
+  type: string;
+  class: string;
+  ttl: number;
+  flush: boolean;
+  data: string;
+}
+
+interface IDnsResponse {
+  id: number;
+  type: string;
+  flags: number;
+  flag_qr: boolean;
+  opcode: string;
+  flag_aa: boolean;
+  flag_tc: boolean;
+  flag_rd: boolean;
+  flag_ra: boolean;
+  flag_z: boolean;
+  flag_ad: boolean;
+  flag_cd: boolean;
+  rcode: string;
+  questions: IQuestion[];
+  answers: IAnswer[];
+  authorities: string[];
+  additionals: string[];
+}

--- a/mitm/lib/MitmRequestAgent.ts
+++ b/mitm/lib/MitmRequestAgent.ts
@@ -108,8 +108,9 @@ export default class MitmRequestAgent {
     const isKeepAlive = ((options.headers.connection ??
       options.headers.Connection) as string)?.match(/keep-alive/i);
 
+    const ipIfNeeded = await session.lookupDns(options.host);
     const mitmSocket = new MitmSocket(session.sessionId, {
-      host: options.host,
+      host: ipIfNeeded,
       port: String(options.port),
       isSsl,
       servername: options.servername || options.host,

--- a/mitm/lib/NetworkDb.ts
+++ b/mitm/lib/NetworkDb.ts
@@ -1,0 +1,52 @@
+import Database, { Database as SqliteDatabase, Transaction } from 'better-sqlite3';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
+import Log from '@secret-agent/commons/Logger';
+import CertificatesTable from '../models/CommandsTable';
+import PkiTable from '../models/PkiTable';
+
+const { log } = Log(module);
+
+export default class NetworkDb {
+  public readonly certificates: CertificatesTable;
+  public readonly pki: PkiTable;
+  private db: SqliteDatabase;
+  private readonly batchInsert: Transaction;
+  private readonly saveInterval: NodeJS.Timeout;
+  private readonly tables: SqliteTable<any>[] = [];
+
+  constructor(baseDir: string) {
+    this.db = new Database(`${baseDir}/.network.db`);
+    this.certificates = new CertificatesTable(this.db);
+    this.pki = new PkiTable(this.db);
+    this.saveInterval = setInterval(this.flush.bind(this), 5e3).unref();
+
+    this.tables = [this.certificates, this.pki];
+
+    this.batchInsert = this.db.transaction(() => {
+      for (const table of this.tables) {
+        try {
+          table.flush();
+        } catch (error) {
+          log.error('NetworkDb.flushError', {
+            sessionId: null,
+            error,
+            table: table.tableName,
+          });
+        }
+      }
+    });
+  }
+
+  public close() {
+    if (this.db) {
+      clearInterval(this.saveInterval);
+      this.flush();
+      this.db.close();
+    }
+    this.db = null;
+  }
+
+  public flush() {
+    this.batchInsert.immediate();
+  }
+}

--- a/mitm/models/CommandsTable.ts
+++ b/mitm/models/CommandsTable.ts
@@ -1,0 +1,40 @@
+import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
+
+export default class CertificatesTable extends SqliteTable<ICertificateRecord> {
+  private readonly getQuery: Statement;
+  constructor(readonly db: SqliteDatabase) {
+    super(
+      db,
+      'Certificates',
+      [
+        ['host', 'TEXT', 'NOT NULL PRIMARY KEY'],
+        ['pem', 'TEXT'],
+        ['beginDate', 'TEXT'],
+        ['expireDate', 'TEXT'],
+      ],
+      true,
+    );
+    this.getQuery = db.prepare(`select * from ${this.tableName} where host = ? limit 1`);
+  }
+
+  public insert(record: ICertificateRecord) {
+    const { host, pem, beginDate, expireDate } = record;
+    this.queuePendingInsert([host, pem, beginDate.toISOString(), expireDate.toISOString()]);
+  }
+
+  public get(host: string) {
+    const record = this.getQuery.get(host) as ICertificateRecord;
+    if (!record) return record;
+    record.beginDate = new Date(record.beginDate);
+    record.expireDate = new Date(record.expireDate);
+    return record;
+  }
+}
+
+export interface ICertificateRecord {
+  host: string;
+  pem: string;
+  beginDate: Date;
+  expireDate: Date;
+}

--- a/mitm/models/PkiTable.ts
+++ b/mitm/models/PkiTable.ts
@@ -1,0 +1,48 @@
+import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
+
+export default class PkiTable extends SqliteTable<IPkiRecord> {
+  private readonly getQuery: Statement;
+  constructor(readonly db: SqliteDatabase) {
+    super(
+      db,
+      'Pki',
+      [
+        ['host', 'TEXT', 'NOT NULL PRIMARY KEY'],
+        ['privateKey', 'TEXT'],
+        ['publicKey', 'TEXT'],
+        ['beginDate', 'TEXT'],
+        ['expireDate', 'TEXT'],
+      ],
+      true,
+    );
+    this.getQuery = db.prepare(`select * from ${this.tableName} where host = ? limit 1`);
+  }
+
+  public insert(record: IPkiRecord) {
+    const { host, privateKey, publicKey, beginDate, expireDate } = record;
+    this.queuePendingInsert([
+      host,
+      privateKey,
+      publicKey,
+      beginDate.toISOString(),
+      expireDate.toISOString(),
+    ]);
+  }
+
+  public get(host: string) {
+    const record = this.getQuery.get(host) as IPkiRecord;
+    if (!record) return record;
+    record.beginDate = new Date(record.beginDate);
+    record.expireDate = new Date(record.expireDate);
+    return record;
+  }
+}
+
+export interface IPkiRecord {
+  host: string;
+  privateKey: string;
+  publicKey: string;
+  beginDate: Date;
+  expireDate: Date;
+}

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -8,6 +8,7 @@
     "@secret-agent/core-interfaces": "1.0.0-alpha.16",
     "@secret-agent/mitm-socket": "1.0.0-alpha.19",
     "devtools-protocol": "^0.0.799653",
+    "better-sqlite3": "^7.1.1",
     "node-forge": "^0.10.0"
   },
   "devDependencies": {

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -9,6 +9,8 @@
     "@secret-agent/mitm-socket": "1.0.0-alpha.19",
     "devtools-protocol": "^0.0.799653",
     "better-sqlite3": "^7.1.1",
+    "dns-packet": "^5.2.1",
+    "moment": "^2.24.1",
     "node-forge": "^0.10.0"
   },
   "devDependencies": {

--- a/mitm/test/CertificateAuthority.test.ts
+++ b/mitm/test/CertificateAuthority.test.ts
@@ -1,6 +1,5 @@
-import Fs from 'fs';
-import { Helpers } from '@secret-agent/testing';
-import MitmProxy from '../lib/MitmProxy';
+import { Helpers } from "@secret-agent/testing";
+import MitmProxy from "../lib/MitmProxy";
 
 afterAll(Helpers.afterAll);
 
@@ -10,6 +9,6 @@ test('should generate a root CA file', async () => {
 
   await proxy.listen();
   // @ts-ignore
-  expect(Fs.existsSync(`${proxy.sslCaDir}/certs/ca.pem`)).toBeTruthy();
+  expect(proxy.ca.certificate).toBeTruthy();
   await proxy.close();
 });

--- a/mitm/test/basic.test.ts
+++ b/mitm/test/basic.test.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import http, { IncomingHttpHeaders } from 'http';
 import { Helpers } from '@secret-agent/testing';
 import HttpProxyAgent from 'http-proxy-agent';
 import { AddressInfo } from 'net';
@@ -54,7 +54,7 @@ describe('basic MitM tests', () => {
     await mitmServer.close();
   });
 
-  it('should send http1 response headers through proxy', async () => {
+  it('should return http1 response headers through proxy', async () => {
     const httpServer = await Helpers.runHttpServer({
       addToResponse(response) {
         response.setHeader('x-test', ['1', '2']);
@@ -136,8 +136,10 @@ describe('basic MitM tests', () => {
   });
 
   it('should support http calls through the mitm', async () => {
+    let headers: IncomingHttpHeaders;
     const server = http
       .createServer((req, res) => {
+        headers = req.headers;
         return res.end('Ok');
       })
       .listen(0)
@@ -164,6 +166,7 @@ describe('basic MitM tests', () => {
       proxyCredentials,
     );
     expect(res).toBe('Ok');
+    expect(headers['proxy-authorization']).not.toBeTruthy();
 
     expect(mocks.httpRequestHandler.onRequest).toBeCalledTimes(1);
   });

--- a/mitm/test/dns.test.ts
+++ b/mitm/test/dns.test.ts
@@ -1,0 +1,82 @@
+import IHttpRequestModifierDelegate from "@secret-agent/commons/interfaces/IHttpRequestModifierDelegate";
+import DnsOverTlsSocket from "../lib/DnsOverTlsSocket";
+import { Dns } from "../lib/Dns";
+import RequestSession from "../handlers/RequestSession";
+
+const CloudFlare = {
+  host: '1.1.1.1',
+  servername: 'cloudflare-dns.com',
+};
+
+const Google = {
+  host: '8.8.8.8',
+  servername: 'dns.google',
+};
+
+const Quad9 = {
+  host: '9.9.9.9',
+  servername: 'dns.quad9.net',
+};
+
+let dns: Dns;
+beforeAll(() => {
+  dns = new Dns({
+    delegate: {
+      tlsProfileId: 'Chrome83',
+      dnsOverTlsConnectOptions: Quad9,
+    } as IHttpRequestModifierDelegate,
+    getUpstreamProxyUrl: () => null,
+  } as RequestSession);
+});
+
+afterAll(() => {
+  dns.close();
+});
+
+describe('DnsOverTlsSocket', () => {
+  let cloudflareDnsSocket: DnsOverTlsSocket;
+  beforeAll(() => {
+    cloudflareDnsSocket = new DnsOverTlsSocket(CloudFlare);
+  });
+  afterAll(() => {
+    cloudflareDnsSocket.close();
+  });
+
+  test('should be able to lookup dns records', async () => {
+    const response = await cloudflareDnsSocket.lookupARecords('dataliberationfoundation.org');
+    expect(response.answers).toHaveLength(1);
+  });
+
+  test('should be able to reuse the socket', async () => {
+    const response = await cloudflareDnsSocket.lookupARecords('ulixee.org');
+    expect(response.answers).toHaveLength(2);
+  });
+
+  test('should be able to lookup with google', async () => {
+    let socket: DnsOverTlsSocket;
+    try {
+      socket = new DnsOverTlsSocket(Google);
+      const response = await socket.lookupARecords('ulixee.org');
+      expect(response.answers).toHaveLength(2);
+    } finally {
+      socket.close();
+    }
+  });
+});
+
+test('should cache and round robin results', async () => {
+  const domain = 'stateofscraping.org';
+  const spy = jest.spyOn<any, any>(dns, 'lookupDnsEntry');
+  const ip = await dns.lookupIp(domain);
+  expect(ip).toBeTruthy();
+  expect(dns.dnsEntries.get(domain).isResolved).toBeTruthy();
+
+  const cached = await dns.dnsEntries.get(domain).promise;
+  expect(cached.aRecords).toHaveLength(2);
+
+  const ip2 = await dns.lookupIp(domain);
+  expect(ip2).toBeTruthy();
+  // should round robin
+  expect(ip).not.toBe(ip2);
+  expect(spy).toHaveBeenCalledTimes(1);
+});

--- a/puppet/lib/ProtocolError.ts
+++ b/puppet/lib/ProtocolError.ts
@@ -1,7 +1,7 @@
 export default class ProtocolError extends Error {
-  private remoteError: { message: string; data: any };
-  private method: string;
-  constructor(stack: string, method: string, remoteError: { message: string; data: any }) {
+  public remoteError: { message: string; data: any; code?: number };
+  public method: string;
+  constructor(stack: string, method: string, remoteError: { message: string; data: any; code?: number }) {
     let message = `${method}: ${remoteError.message}`;
     if ('data' in remoteError) {
       if (typeof remoteError.data === 'string') {

--- a/session-state/lib/SessionDb.ts
+++ b/session-state/lib/SessionDb.ts
@@ -1,6 +1,7 @@
 import Database, { Database as SqliteDatabase, Transaction } from 'better-sqlite3';
 import * as Path from 'path';
 import Log from '@secret-agent/commons/Logger';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 import ResourcesTable from '../models/ResourcesTable';
 import DomChangesTable from '../models/DomChangesTable';
 import CommandsTable from '../models/CommandsTable';
@@ -8,7 +9,6 @@ import WebsocketMessagesTable from '../models/WebsocketMessagesTable';
 import FrameNavigationsTable from '../models/FrameNavigationsTable';
 import FramesTable from '../models/FramesTable';
 import PageLogsTable from '../models/PageLogsTable';
-import BaseTable from './BaseTable';
 import SessionTable from '../models/SessionTable';
 import MouseEventsTable from '../models/MouseEventsTable';
 import FocusEventsTable from '../models/FocusEventsTable';
@@ -48,7 +48,7 @@ export default class SessionDb {
   private readonly saveInterval: NodeJS.Timeout;
 
   private db: SqliteDatabase;
-  private readonly tables: BaseTable<any>[] = [];
+  private readonly tables: SqliteTable<any>[] = [];
 
   constructor(baseDir: string, id: string, dbOptions: IDbOptions = {}) {
     const { readonly = false, fileMustExist = false } = dbOptions;

--- a/session-state/models/CommandsTable.ts
+++ b/session-state/models/CommandsTable.ts
@@ -1,8 +1,8 @@
 import ICommandMeta from '@secret-agent/core-interfaces/ICommandMeta';
 import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class CommandsTable extends BaseTable<ICommandMeta> {
+export default class CommandsTable extends SqliteTable<ICommandMeta> {
   private readonly getQuery: Statement;
   constructor(readonly db: SqliteDatabase) {
     super(

--- a/session-state/models/DevtoolsMessagesTable.ts
+++ b/session-state/models/DevtoolsMessagesTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import type { IPuppetContextEvents } from '@secret-agent/puppet/interfaces/IPuppetContext';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class DevtoolsMessagesTable extends BaseTable<IDevtoolsMessageRecord> {
+export default class DevtoolsMessagesTable extends SqliteTable<IDevtoolsMessageRecord> {
   private fetchRequestIdToNetworkId = new Map<string, string>();
   private sentMessageIds: {
     id: number;

--- a/session-state/models/DomChangesTable.ts
+++ b/session-state/models/DomChangesTable.ts
@@ -1,8 +1,8 @@
 import { IDomChangeEvent } from '@secret-agent/injected-scripts/interfaces/IDomChangeEvent';
 import { Database as SqliteDatabase } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class DomChangesTable extends BaseTable<IDomChangeRecord> {
+export default class DomChangesTable extends SqliteTable<IDomChangeRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'DomChanges', [
       ['commandId', 'INTEGER'],

--- a/session-state/models/FocusEventsTable.ts
+++ b/session-state/models/FocusEventsTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import { IFocusEvent } from '@secret-agent/injected-scripts/interfaces/IFocusEvent';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class FocusEventsTable extends BaseTable<IFocusRecord> {
+export default class FocusEventsTable extends SqliteTable<IFocusRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'FocusEvents', [
       ['tabId', 'TEXT'],

--- a/session-state/models/FrameNavigationsTable.ts
+++ b/session-state/models/FrameNavigationsTable.ts
@@ -1,9 +1,9 @@
 import { LocationStatus } from '@secret-agent/core-interfaces/Location';
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import INavigation from '@secret-agent/core-interfaces/INavigation';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class FrameNavigationsTable extends BaseTable<IFrameNavigationRecord> {
+export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationRecord> {
   private idCounter = 0;
 
   constructor(readonly db: SqliteDatabase) {

--- a/session-state/models/FramesTable.ts
+++ b/session-state/models/FramesTable.ts
@@ -1,7 +1,7 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class FramesTable extends BaseTable<IFrameRecord> {
+export default class FramesTable extends SqliteTable<IFrameRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'Frames', [
       ['id', 'TEXT', 'NOT NULL PRIMARY KEY'],

--- a/session-state/models/MouseEventsTable.ts
+++ b/session-state/models/MouseEventsTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import { IMouseEvent } from '@secret-agent/injected-scripts/interfaces/IMouseEvent';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class MouseEventsTable extends BaseTable<IMouseEventRecord> {
+export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'MouseEvents', [
       ['tabId', 'TEXT'],

--- a/session-state/models/PageLogsTable.ts
+++ b/session-state/models/PageLogsTable.ts
@@ -1,7 +1,7 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class PageLogsTable extends BaseTable<IPageLogRecord> {
+export default class PageLogsTable extends SqliteTable<IPageLogRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'PageLogs', [
       ['tabId', 'TEXT'],

--- a/session-state/models/ResourcesTable.ts
+++ b/session-state/models/ResourcesTable.ts
@@ -3,9 +3,9 @@ import IResourceMeta from '@secret-agent/core-interfaces/IResourceMeta';
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import ResourceType from '@secret-agent/core-interfaces/ResourceType';
 import IResourceHeaders from '@secret-agent/core-interfaces/IResourceHeaders';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class ResourcesTable extends BaseTable<IResourcesRecord> {
+export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(
       db,

--- a/session-state/models/ScrollEventsTable.ts
+++ b/session-state/models/ScrollEventsTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import { IScrollEvent } from '@secret-agent/injected-scripts/interfaces/IScrollEvent';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class ScrollEventsTable extends BaseTable<IScrollRecord> {
+export default class ScrollEventsTable extends SqliteTable<IScrollRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'ScrollEvents', [
       ['tabId', 'TEXT'],

--- a/session-state/models/SessionLogsTable.ts
+++ b/session-state/models/SessionLogsTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import { ILogEntry } from '@secret-agent/commons/Logger';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class SessionLogsTable extends BaseTable<ISessionLogRecord> {
+export default class SessionLogsTable extends SqliteTable<ISessionLogRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'SessionLogs', [
       ['id', 'INTEGER'],

--- a/session-state/models/SessionTable.ts
+++ b/session-state/models/SessionTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import IViewport from '@secret-agent/core-interfaces/IViewport';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class SessionTable extends BaseTable<ISessionRecord> {
+export default class SessionTable extends SqliteTable<ISessionRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(
       db,

--- a/session-state/models/SessionsTable.ts
+++ b/session-state/models/SessionsTable.ts
@@ -1,7 +1,7 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class SessionsTable extends BaseTable<ISessionRecord> {
+export default class SessionsTable extends SqliteTable<ISessionRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'Sessions', [
       ['id', 'TEXT'],

--- a/session-state/models/TabsTable.ts
+++ b/session-state/models/TabsTable.ts
@@ -1,7 +1,7 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class TabsTable extends BaseTable<ITabsRecord> {
+export default class TabsTable extends SqliteTable<ITabsRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'Tabs', [
       ['tabId', 'TEXT'],

--- a/session-state/models/WebsocketMessagesTable.ts
+++ b/session-state/models/WebsocketMessagesTable.ts
@@ -1,8 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import IWebsocketResourceMessage from '@secret-agent/core/interfaces/IWebsocketResourceMessage';
-import BaseTable from '../lib/BaseTable';
+import SqliteTable from '@secret-agent/commons/SqliteTable';
 
-export default class WebsocketMessagesTable extends BaseTable<IWebsocketMessageRecord> {
+export default class WebsocketMessagesTable extends SqliteTable<IWebsocketMessageRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'WebsocketMessages', [
       ['id', 'INTEGER', 'NOT NULL PRIMARY KEY'],

--- a/session-state/package.json
+++ b/session-state/package.json
@@ -9,7 +9,7 @@
     "@secret-agent/core-interfaces": "1.0.0-alpha.16",
     "@secret-agent/injected-scripts": "1.0.0-alpha.16",
     "@secret-agent/mitm": "1.0.0-alpha.19",
-    "better-sqlite3": "^7.1.0",
+    "better-sqlite3": "^7.1.1",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,10 +4555,10 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-better-sqlite3@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.0.tgz#4894d0fa4002bd7859a0a539577f14f24b245f6a"
-  integrity sha512-FV/snQ8F/kyqhdxsevzbojVtMowDWOfe1A5N3lYu1KJwoho2t7JgITmdlSc7DkOh3Zq65I+ZyeNWXQrkLEDFTg==
+better-sqlite3@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.1.tgz#107457a8b770cfb16be646e347c17b42bc204dd3"
+  integrity sha512-AkvGGyhAVZhRBOul2WT+5CB2EuveM3ZkebEKe1wxMqDZUy1XB/1RBgM66t0ybHC4DIni8+pr7NaLqEX87NUTwg==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^5.3.3"
@@ -6963,6 +6963,13 @@ dns-packet@^1.3.1:
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
+
+dns-packet@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.2.1.tgz#26cec0be92252a1b97ed106482921192a7e08f72"
+  integrity sha512-JHj2yJeKOqlxzeuYpN1d56GfhzivAxavNwHj9co3qptECel27B1rLY5PifJAvubsInX5pGLDjAHuCfCUc2Zv/w==
+  dependencies:
+    ip "^1.1.5"
 
 dns-txt@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
The major browsers have switched to Dns over Tls if your dns provider supports it. Dns on a computer comes from:
1) Computer
2) Router
3) ISP

Some domains are using the ad networks as redirects before going to the final domain destinations. Since routers like Eero/piHoles/zscaler/etc are blocking ad networks by default, this means SecretAgent is behaving differently than browsers.

Dns Over Tls providers are configurable at an emulator level. Currently, there's no DNS caching that occurs between different sessions. This is technically going to separate each "session" more, so it looks like it comes from it's own set of dns entries. However, it comes with a performance penalty per domain. We're reusing the underlying tls connection, so it appears to be minimal under small volumes (60 bytes and < ~1ms per domain).


This PR also switches Certificate generation to store in a database instead of files. I thought I was going to be caching IPs across sessions, so was preparing for that.. I didn't end up doing so though.