### PR TITLE
fix(puppet): incorrect reuse of executionContextId

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -309,13 +309,13 @@ export function SecretAgentClientGenerator(
     }
   }
 
-  if (initArgs?.handleShutdownSignals) {
+  if (initArgs?.handleShutdownSignals ?? true) {
     ['exit', 'SIGTERM', 'SIGINT', 'SIGQUIT'].forEach(name => {
       process.once(name as Signals, async () => await SecretAgent.shutdown());
     });
   }
 
-  if (initArgs?.captureUncaughtClientErrors) {
+  if (initArgs?.captureUncaughtClientErrors ?? true) {
     process.on('uncaughtException', async (error: Error) => {
       // keep core node behavior intact
       process.stderr.write(`${error.stack}\n`);

--- a/commons/Timer.ts
+++ b/commons/Timer.ts
@@ -39,6 +39,10 @@ export default class Timer {
     return this.elapsedMillis() > this.timeoutMillis;
   }
 
+  public isResolved() {
+    return this.expirePromise.isResolved;
+  }
+
   public elapsedMillis() {
     const time = process.hrtime(this.time);
     return time[0] * 1000 + time[1] / 1000000;

--- a/puppet-chrome/lib/Frame.ts
+++ b/puppet-chrome/lib/Frame.ts
@@ -1,15 +1,15 @@
-import { createPromise, IResolvablePromise } from "@secret-agent/commons/utils";
-import { ILifecycleEvents, IPuppetFrame } from "@secret-agent/puppet/interfaces/IPuppetFrame";
-import { URL } from "url";
-import Protocol from "devtools-protocol";
-import { CanceledPromiseError } from "@secret-agent/commons/interfaces/IPendingWaitEvent";
-import { TypedEventEmitter } from "@secret-agent/commons/eventUtils";
-import { NavigationReason } from "@secret-agent/core-interfaces/INavigation";
-import { IBoundLog } from "@secret-agent/commons/Logger";
-import ProtocolError from "@secret-agent/puppet/lib/ProtocolError";
-import { CDPSession } from "./CDPSession";
-import ConsoleMessage from "./ConsoleMessage";
-import { DEFAULT_PAGE, ISOLATED_WORLD } from "./FramesManager";
+import { createPromise, IResolvablePromise } from '@secret-agent/commons/utils';
+import { ILifecycleEvents, IPuppetFrame } from '@secret-agent/puppet/interfaces/IPuppetFrame';
+import { URL } from 'url';
+import Protocol from 'devtools-protocol';
+import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+import { TypedEventEmitter } from '@secret-agent/commons/eventUtils';
+import { NavigationReason } from '@secret-agent/core-interfaces/INavigation';
+import { IBoundLog } from '@secret-agent/commons/Logger';
+import ProtocolError from '@secret-agent/puppet/lib/ProtocolError';
+import { CDPSession } from './CDPSession';
+import ConsoleMessage from './ConsoleMessage';
+import { DEFAULT_PAGE, ISOLATED_WORLD } from './FramesManager';
 import PageFrame = Protocol.Page.Frame;
 
 export default class Frame extends TypedEventEmitter<IFrameEvents> implements IPuppetFrame {
@@ -248,6 +248,16 @@ export default class Frame extends TypedEventEmitter<IFrameEvents> implements IP
       this.defaultContextIds.has(executionContextId) ||
       this.isolatedContextIds.has(executionContextId)
     );
+  }
+
+  public removeContextId(executionContextId: number) {
+    this.defaultContextIds.delete(executionContextId);
+    this.isolatedContextIds.delete(executionContextId);
+  }
+
+  public clearContextIds() {
+    this.defaultContextIds.clear();
+    this.isolatedContextIds.clear();
   }
 
   public addContextId(executionContextId: number, isDefault: boolean) {

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -150,11 +150,17 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameEvents>
   private async onExecutionContextDestroyed(event: ExecutionContextDestroyedEvent) {
     await this.isReady;
     this.activeContexts.delete(event.executionContextId);
+    for (const frame of this.framesById.values()) {
+      frame.removeContextId(event.executionContextId);
+    }
   }
 
   private async onExecutionContextsCleared() {
     await this.isReady;
     this.activeContexts.clear();
+    for (const frame of this.framesById.values()) {
+      frame.clearContextIds();
+    }
   }
 
   private async onExecutionContextCreated(event: ExecutionContextCreatedEvent) {


### PR DESCRIPTION
This PR fixes some bugs found while running Double Agent tests.
1) Default handling shutdown in Secret Agent if settings are provided but no handleShutdownSignals/captureUncaughtClientErrors option
2) Shutdown waitForElement handlers when SecretAgent is interrupted (was waiting full 30 seconds on kill).
3) If a tab keeps the same frameid but navigates to new urls, contextIds are occasionally reused. This was causing an incorrect contextId to be used for "evaluate" commands.