### PR TITLE
feat(human-emulators): ghost emulator

### DIFF
--- a/core-interfaces/IHumanEmulator.ts
+++ b/core-interfaces/IHumanEmulator.ts
@@ -1,8 +1,12 @@
 import { IInteractionGroups, IInteractionStep } from './IInteractions';
+import IInteractionsHelper from './IInteractionsHelper';
+import IPoint from './IPoint';
 
 export default interface IHumanEmulator {
   playInteractions(
     interactions: IInteractionGroups,
     run: (interaction: IInteractionStep) => Promise<void>,
+    helper?: IInteractionsHelper,
   );
+  getStartingMousePoint?(helper?: IInteractionsHelper): Promise<IPoint>;
 }

--- a/core-interfaces/IInteractions.ts
+++ b/core-interfaces/IInteractions.ts
@@ -13,6 +13,7 @@ export interface IInteractionStep {
   mouseButton?: IMouseButton;
   keyboardCommands?: IKeyboardCommand[];
   keyboardDelayBetween?: number;
+  keyboardKeyupDelay?: number;
   delayNode?: IJsPath;
   delayElement?: IJsPath;
   delayMillis?: number;

--- a/core-interfaces/IInteractionsHelper.ts
+++ b/core-interfaces/IInteractionsHelper.ts
@@ -1,0 +1,11 @@
+import { IMousePosition } from './IInteractions';
+import IRect from './IRect';
+import IPoint from './IPoint';
+import IViewport from './IViewport';
+
+export default interface IInteractionsHelper {
+  lookupBoundingRect(mousePosition: IMousePosition): Promise<IRect & { elementTag?: string }>;
+  mousePosition: IPoint;
+  scrollOffset: Promise<IPoint>;
+  viewport: IViewport;
+}

--- a/core-interfaces/IPoint.ts
+++ b/core-interfaces/IPoint.ts
@@ -1,0 +1,4 @@
+export default interface IPoint {
+  x: number;
+  y: number;
+}

--- a/core-interfaces/IRect.ts
+++ b/core-interfaces/IRect.ts
@@ -1,0 +1,6 @@
+export default interface IRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/core-interfaces/IWindowOffset.ts
+++ b/core-interfaces/IWindowOffset.ts
@@ -1,0 +1,6 @@
+export default interface IWindowOffset {
+  innerWidth: number;
+  innerHeight: number;
+  pageXOffset: number;
+  pageYOffset: number;
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -319,6 +319,7 @@ export default class Core implements ICore {
       const promises: Promise<void>[] = [];
       for (const key of tabIds ?? Object.keys(Core.byTabId)) {
         const core = Core.byTabId[key];
+        if (!core) continue;
         delete Core.byTabId[key];
         promises.push(core.close());
       }

--- a/core/lib/DomEnv.ts
+++ b/core/lib/DomEnv.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
-import Log  from '@secret-agent/commons/Logger';
+import Log from '@secret-agent/commons/Logger';
 import Typeson from 'typeson';
 import TypesonRegistry from 'typeson-registry/dist/presets/builtin';
 import IElementRect from '@secret-agent/injected-scripts/interfaces/IElementRect';
@@ -10,6 +10,7 @@ import IAttachedState from '@secret-agent/injected-scripts/interfaces/IAttachedS
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import injectedSourceUrl from '@secret-agent/core-interfaces/injectedSourceUrl';
 import { IBoundLog } from '@secret-agent/core-interfaces/ILog';
+import IWindowOffset from '@secret-agent/core-interfaces/IWindowOffset';
 import DomEnvError from './DomEnvError';
 import { Serializable } from '../interfaces/ISerializable';
 
@@ -146,12 +147,7 @@ export default class DomEnv {
   }
 
   public getWindowOffset() {
-    return this.runIsolatedFn<{
-      innerWidth: number;
-      innerHeight: number;
-      pageXOffset: number;
-      pageYOffset: number;
-    }>('window.SecretAgent.JsPath.getWindowOffset');
+    return this.runIsolatedFn<IWindowOffset>('window.SecretAgent.JsPath.getWindowOffset');
   }
 
   public locationHref() {

--- a/core/lib/HumanEmulators.ts
+++ b/core/lib/HumanEmulators.ts
@@ -1,6 +1,6 @@
 import { pickRandom } from '@secret-agent/commons/utils';
 import IHumanEmulatorClass from '@secret-agent/core-interfaces/IHumanEmulatorClass';
-import HumanEmulatorBasic from '@secret-agent/emulate-humans-basic';
+import HumanEmulatorGhost from '@secret-agent/emulate-humans-ghost';
 
 export default class HumanEmulators {
   private static readonly emulatorsById: { [id: string]: IHumanEmulatorClass } = {};
@@ -35,4 +35,4 @@ export default class HumanEmulators {
   }
 }
 
-HumanEmulators.load(HumanEmulatorBasic);
+HumanEmulators.load(HumanEmulatorGhost);

--- a/core/lib/Interactor.ts
+++ b/core/lib/Interactor.ts
@@ -1,16 +1,20 @@
 import {
   IInteractionGroup,
   IInteractionGroups,
-  IKeyboardDown,
-  IKeyboardString,
-  IKeyboardUp,
-  IKeyPress,
   IMousePosition,
+  IMousePositionXY,
   InteractionCommand,
 } from '@secret-agent/core-interfaces/IInteractions';
 import { assert } from '@secret-agent/commons/utils';
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
-import { getKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
+import {
+  getKeyboardKey,
+  IKeyboardKey,
+  KeyboardKeys,
+} from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
+import IInteractionsHelper from '@secret-agent/core-interfaces/IInteractionsHelper';
+import IRect from '@secret-agent/core-interfaces/IRect';
+import IWindowOffset from '@secret-agent/core-interfaces/IWindowOffset';
 import Tab from './Tab';
 
 const commandsNeedingScroll = [
@@ -19,7 +23,24 @@ const commandsNeedingScroll = [
   InteractionCommand.move,
 ];
 
-export default class Interactor {
+export default class Interactor implements IInteractionsHelper {
+  public get mousePosition() {
+    return { ...this.mouse.position };
+  }
+
+  public get scrollOffset() {
+    return this.tab.domEnv.getWindowOffset().then(offset => {
+      return {
+        x: offset.pageXOffset,
+        y: offset.pageYOffset,
+      };
+    });
+  }
+
+  public get viewport() {
+    return this.tab.session.viewport;
+  }
+
   private readonly tab: Tab;
 
   private get mouse() {
@@ -30,116 +51,181 @@ export default class Interactor {
     return this.tab.puppetPage.keyboard;
   }
 
+  private get humanEmulator() {
+    return this.tab.session.humanEmulator;
+  }
+
   constructor(tab: Tab) {
     this.tab = tab;
+  }
+
+  public async initialize() {
+    if (this.humanEmulator.getStartingMousePoint) {
+      this.mouse.position = await this.humanEmulator.getStartingMousePoint(this);
+    }
   }
 
   public async play(interactions: IInteractionGroups) {
     const finalInteractions = Interactor.injectScrollToPositions(interactions);
 
-    const humanEmulator = this.tab.session.humanEmulator;
+    const humanEmulator = this.humanEmulator;
 
-    await humanEmulator.playInteractions(finalInteractions, async interaction => {
-      switch (interaction.command) {
-        case InteractionCommand.move: {
-          const { x, y } = await this.getPositionXY(interaction.mousePosition);
-          await this.mouse.move(x, y);
-          break;
-        }
-        case InteractionCommand.scroll: {
-          const windowBounds = await this.tab.domEnv.getWindowOffset();
-          const { x, y } = await this.getPositionXY(interaction.mousePosition);
-
-          const isYInViewPort = y >= 0 && y < windowBounds.innerHeight;
-          const isXInViewPort = x >= 0 && x < windowBounds.innerWidth;
-          if (!isYInViewPort || !isXInViewPort) {
-            const deltaY = isYInViewPort ? 0 : y - windowBounds.innerHeight;
-            const deltaX = isXInViewPort ? 0 : x - windowBounds.innerWidth;
-            await this.mouse.wheel({ deltaY, deltaX });
-            // need to check for offset since wheel event doesn't wait for scroll
-            await this.tab.domEnv.waitForScrollOffset(
-              deltaX + windowBounds.pageXOffset,
-              deltaY + windowBounds.pageYOffset,
-            );
+    await humanEmulator.playInteractions(
+      finalInteractions,
+      async interaction => {
+        switch (interaction.command) {
+          case InteractionCommand.move: {
+            const { x, y } = await this.getPositionXY(interaction.mousePosition);
+            await this.mouse.move(x, y);
+            break;
           }
-          break;
-        }
+          case InteractionCommand.scroll: {
+            const windowBounds = await this.tab.domEnv.getWindowOffset();
+            const scroll = await this.getScrollOffset(interaction.mousePosition, windowBounds);
 
-        case InteractionCommand.click: {
-          const button = interaction.mouseButton || 'left';
-          const { x, y, simulateOptionClick } = await this.getPositionXY(interaction.mousePosition);
-          if (simulateOptionClick) {
-            await this.tab.domEnv.simulateOptionClick(interaction.mousePosition as IJsPath);
-          } else {
-            await this.mouse.click(x, y, { button });
-          }
-          break;
-        }
-        case InteractionCommand.clickUp: {
-          const button = interaction.mouseButton || 'left';
-          await this.mouse.up({ button });
-          break;
-        }
-        case InteractionCommand.clickDown: {
-          const button = interaction.mouseButton || 'left';
-          await this.mouse.down({ button });
-          break;
-        }
-
-        case InteractionCommand.doubleclick: {
-          const button = interaction.mouseButton || 'left';
-          const { x, y } = await this.getPositionXY(interaction.mousePosition);
-          await this.mouse.click(x, y, { button, clickCount: 2 });
-          break;
-        }
-
-        case InteractionCommand.type: {
-          for (const keyboardCommand of interaction.keyboardCommands) {
-            if ('keyCode' in keyboardCommand) {
-              const key = getKeyboardKey((keyboardCommand as IKeyPress).keyCode);
-              await this.keyboard.press(key);
-            } else if ((keyboardCommand as IKeyboardString).string) {
-              const delay = interaction.keyboardDelayBetween || 0;
-              await this.keyboard.type((keyboardCommand as IKeyboardString).string, { delay });
-            } else if ('up' in keyboardCommand) {
-              const key = getKeyboardKey((keyboardCommand as IKeyboardUp).up);
-              await this.keyboard.up(key);
-            } else if ('down' in keyboardCommand) {
-              const key = getKeyboardKey((keyboardCommand as IKeyboardDown).down);
-              await this.keyboard.down(key);
+            if (scroll) {
+              const { deltaY, deltaX } = scroll;
+              await this.mouse.wheel(scroll);
+              // need to check for offset since wheel event doesn't wait for scroll
+              await this.tab.domEnv.waitForScrollOffset(
+                Math.max(0, deltaX + windowBounds.pageXOffset),
+                Math.max(0, deltaY + windowBounds.pageYOffset),
+              );
             }
+            break;
           }
-          break;
-        }
 
-        case InteractionCommand.waitForNode: {
-          await this.tab.waitForNode(interaction.delayNode);
-          break;
+          case InteractionCommand.click:
+          case InteractionCommand.doubleclick: {
+            const button = interaction.mouseButton || 'left';
+            const { x, y, simulateOptionClick } = await this.getPositionXY(
+              interaction.mousePosition,
+            );
+
+            if (simulateOptionClick) {
+              await this.tab.domEnv.simulateOptionClick(interaction.mousePosition as IJsPath);
+            } else {
+              const clickCount = interaction.command === InteractionCommand.doubleclick ? 2 : 1;
+              await this.mouse.click(x, y, { button, clickCount, delay: interaction.delayMillis });
+            }
+            break;
+          }
+          case InteractionCommand.clickUp: {
+            const button = interaction.mouseButton || 'left';
+            await this.mouse.up({ button });
+            break;
+          }
+          case InteractionCommand.clickDown: {
+            const button = interaction.mouseButton || 'left';
+            await this.mouse.down({ button });
+            break;
+          }
+
+          case InteractionCommand.type: {
+            let counter = 0;
+            for (const keyboardCommand of interaction.keyboardCommands) {
+              const delay = interaction.keyboardDelayBetween;
+              const keyupDelay = interaction.keyboardKeyupDelay;
+              if (counter > 0 && delay) {
+                await new Promise(resolve => setTimeout(resolve, delay));
+              }
+
+              if ('keyCode' in keyboardCommand) {
+                const key = getKeyboardKey(keyboardCommand.keyCode);
+                await this.keyboard.press(key, keyupDelay);
+              } else if ('up' in keyboardCommand) {
+                const key = getKeyboardKey(keyboardCommand.up);
+                await this.keyboard.up(key);
+              } else if ('down' in keyboardCommand) {
+                const key = getKeyboardKey(keyboardCommand.down);
+                await this.keyboard.down(key);
+              } else if ('string' in keyboardCommand) {
+                const text = keyboardCommand.string;
+                for (const char of text) {
+                  if (char in KeyboardKeys) {
+                    await this.keyboard.press(char as IKeyboardKey, keyupDelay);
+                  } else {
+                    await this.keyboard.sendCharacter(char);
+                  }
+                  if (delay) await new Promise(resolve => setTimeout(resolve, delay));
+                }
+              }
+              counter += 1;
+            }
+            break;
+          }
+
+          case InteractionCommand.waitForNode: {
+            await this.tab.waitForNode(interaction.delayNode);
+            break;
+          }
+          case InteractionCommand.waitForElementVisible: {
+            await this.tab.waitForElement(interaction.delayElement, { waitForVisible: true });
+            break;
+          }
+          case InteractionCommand.waitForMillis: {
+            await new Promise(resolve => setTimeout(resolve, interaction.delayMillis));
+            break;
+          }
         }
-        case InteractionCommand.waitForElementVisible: {
-          await this.tab.waitForElement(interaction.delayElement, { waitForVisible: true });
-          break;
-        }
-        case InteractionCommand.waitForMillis: {
-          await new Promise(resolve => setTimeout(resolve, interaction.delayMillis));
-          break;
-        }
-      }
-    });
+      },
+      this,
+    );
   }
 
-  private async getPositionXY(value: IMousePosition) {
-    // ToDo: we need to pass in randomized factor from HumanEmulator so point can change.
-    assert(value, 'value should not be null');
-    if (isMousePositionCoordinate(value)) {
-      return { x: value[0] as number, y: value[1] as number };
+  public async lookupBoundingRect(
+    mousePosition: IMousePosition,
+  ): Promise<IRect & { elementTag?: string }> {
+    if (isMousePositionCoordinate(mousePosition)) {
+      return { x: mousePosition[0] as number, y: mousePosition[1] as number, width: 1, height: 1 };
     }
-    const rect = await this.tab.domEnv.getJsPathClientRect(value as IJsPath);
+    const rect = await this.tab.domEnv.getJsPathClientRect(mousePosition as IJsPath);
+
+    return {
+      x: rect.left,
+      y: rect.top,
+      height: rect.height,
+      width: rect.width,
+      elementTag: rect.tag,
+    };
+  }
+
+  private async getScrollOffset(targetPosition: IMousePosition, windowBounds: IWindowOffset) {
+    assert(targetPosition, 'targetPosition should not be null');
+
+    if (isMousePositionCoordinate(targetPosition)) {
+      const [x, y] = targetPosition as IMousePositionXY;
+      const deltaX = x - windowBounds.pageXOffset;
+      const deltaY = y - windowBounds.pageYOffset;
+      return { deltaX, deltaY };
+    }
+
+    const rect = await this.lookupBoundingRect(targetPosition);
+
+    const deltaY = deltaToFullyVisible(rect.y, rect.height, windowBounds.innerHeight);
+    const deltaX = deltaToFullyVisible(rect.x, rect.width, windowBounds.innerWidth);
+
+    if (deltaY === 0 && deltaX === 0) return null;
+    return { deltaX, deltaY };
+  }
+
+  private async getPositionXY(mousePosition: IMousePosition) {
+    assert(mousePosition, 'mousePosition should not be null');
+    if (isMousePositionCoordinate(mousePosition)) {
+      const [x, y] = mousePosition as number[];
+      return { x: round(x), y: round(y) };
+    }
+    const rect = await this.tab.domEnv.getJsPathClientRect(mousePosition as IJsPath);
     if (rect.bottom === 0 && rect.height === 0 && rect.width === 0 && rect.right === 0) {
       return { x: 0, y: 0, simulateOptionClick: rect.tag === 'option' };
     }
-    const x = round(rect.left + rect.width / 2);
-    const y = round(rect.top + rect.height / 2);
+
+    // Default is to find exact middle. An emulator should replace an entry with a coordinate to avoid this functionality
+    let x = round(rect.left + rect.width / 2);
+    let y = round(rect.top + rect.height / 2);
+    // if coordinates go out of screen, bring back
+    if (x > this.viewport.width) x = this.viewport.width - 1;
+    if (y > this.viewport.height) y = this.viewport.height - 1;
     return { x, y };
   }
 
@@ -167,6 +253,25 @@ export default class Interactor {
 
 export function isMousePositionCoordinate(value: IMousePosition) {
   return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number';
+}
+
+export function deltaToFullyVisible(coordinate: number, length: number, boundaryLength: number) {
+  if (coordinate >= 0) {
+    if (length > boundaryLength) {
+      length = boundaryLength / 2;
+    }
+    const bottom = Math.round(coordinate + length);
+    // end passes boundary
+    if (bottom > boundaryLength) {
+      return -Math.round(boundaryLength - bottom);
+    }
+  } else {
+    const top = Math.round(coordinate);
+    if (top < 0) {
+      return top;
+    }
+  }
+  return 0;
 }
 
 function round(num: number) {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -461,6 +461,10 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     return await this.waitForElement(pathToNode);
   }
 
+  public async moveMouseToStartLocation() {
+    return this.interactor.initialize();
+  }
+
   /////// UTILITIES ////////////////////////////////////////////////////////////////////////////////////////////////////
 
   public async toJSON() {
@@ -497,6 +501,8 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
         });
       });
     }
+
+    await this.interactor.initialize();
   }
 
   private listen() {

--- a/core/package.json
+++ b/core/package.json
@@ -9,6 +9,7 @@
     "@secret-agent/emulate-chrome-83": "1.2.0-alpha.0",
     "@secret-agent/emulate-humans-basic": "1.2.0-alpha.0",
     "@secret-agent/emulate-humans-skipper": "1.2.0-alpha.0",
+    "@secret-agent/emulate-humans-ghost": "1.2.0-alpha.0",
     "@secret-agent/injected-scripts": "1.2.0-alpha.0",
     "@secret-agent/mitm": "1.2.0-alpha.0",
     "@secret-agent/puppet": "1.2.0-alpha.0",

--- a/core/test/DomEnv.test.ts
+++ b/core/test/DomEnv.test.ts
@@ -1,0 +1,61 @@
+import { Helpers } from '@secret-agent/testing/index';
+import Core from '../index';
+
+let koaServer;
+beforeAll(async () => {
+  await Core.prewarm();
+  koaServer = await Helpers.runKoaServer();
+});
+afterAll(Helpers.afterAll);
+afterEach(Helpers.afterEach);
+
+it('can operate when unsafe eval not on', async () => {
+  koaServer.get('/unsafe', ctx => {
+    ctx.set('Content-Security-Policy', "script-src 'self'");
+    ctx.body = `
+        <body>
+          <input type="text" />
+        </body>
+      `;
+  });
+  const inputUrl = `${koaServer.baseUrl}/unsafe`;
+  const meta = await Core.createTab();
+  const core = Core.byTabId[meta.tabId];
+
+  await core.goto(inputUrl);
+  const input = await core.execJsPath(['document', ['querySelector', 'input'], 'value']);
+  expect(input.value).toBe('');
+  const x = await core.execJsPath([['document.querySelector', 'body'], 'scrollTop']);
+  expect(x.value).toBe(0);
+  await core.close();
+});
+
+it('should be able to get window variables', async () => {
+  koaServer.get('/vars', ctx => {
+    ctx.set('Content-Security-Policy', "default-src 'self'; script-src 'unsafe-inline'");
+    ctx.body = `
+        <body>
+          <script type="text/javascript">
+          const pageClicks = [1,2,3];
+          function add(item){
+            pageClicks.push(item)
+          }
+          </script>
+        </body>
+      `;
+  });
+
+  const meta = await Core.createTab();
+  const core = Core.byTabId[meta.tabId];
+  await core.goto(`${koaServer.baseUrl}/vars`);
+  await core.waitForLoad('DomContentLoaded');
+
+  const pageClicks = await core.getJsValue('pageClicks');
+  expect(pageClicks.value).toStrictEqual([1, 2, 3]);
+
+  await core.getJsValue(`add('item4')`);
+  const pageClicks2 = await core.getJsValue('pageClicks');
+
+  expect(pageClicks2.value).toStrictEqual([1, 2, 3, 'item4']);
+  await core.close();
+});

--- a/core/test/interact.test.ts
+++ b/core/test/interact.test.ts
@@ -1,19 +1,25 @@
 import { Helpers } from '@secret-agent/testing';
 import { InteractionCommand } from '@secret-agent/core-interfaces/IInteractions';
+import HumanEmulatorGhost from '@secret-agent/emulate-humans-ghost';
 import Core from '../index';
 
 let koaServer;
 beforeAll(async () => {
   await Core.prewarm();
+
+  HumanEmulatorGhost.maxDelayBetweenInteractions = 0;
+  HumanEmulatorGhost.maxScrollDelayMillis = 0;
   koaServer = await Helpers.runKoaServer();
 });
 afterAll(Helpers.afterAll);
 afterEach(Helpers.afterEach);
 
-describe('basic Interaction tests', () => {
-  it('executes basic click command', async () => {
-    koaServer.get('/mouse', ctx => {
-      ctx.body = `
+describe.each([['ghost'], ['basic'], ['skipper']])(
+  '%s interaction tests',
+  (humanEmulatorId: string) => {
+    it('executes basic click command', async () => {
+      koaServer.get('/mouse', ctx => {
+        ctx.body = `
         <body>
           <button>Test</button>
           <script>
@@ -23,159 +29,116 @@ describe('basic Interaction tests', () => {
           </script>
         </body>
       `;
+      });
+      const meta = await Core.createTab({ humanEmulatorId });
+      const core = Core.byTabId[meta.tabId];
+      // @ts-ignore
+      const session = core.session;
+      await core.goto(`${koaServer.baseUrl}/mouse`);
+
+      const spy = jest.spyOn(session.humanEmulator, 'playInteractions');
+      await core.interact([
+        {
+          command: InteractionCommand.click,
+          mousePosition: ['window', 'document', ['querySelector', 'button']],
+        },
+      ]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const interactGroups = spy.mock.calls[0][0];
+      expect(interactGroups).toHaveLength(1);
+      expect(interactGroups[0]).toHaveLength(2);
+      expect(interactGroups[0][0].command).toBe('scroll');
+
+      const buttonClass = await core.execJsPath([
+        'document',
+        ['querySelector', 'button.clicked'],
+        'classList',
+      ]);
+      expect(buttonClass.value).toStrictEqual({ 0: 'clicked' });
+      await core.close();
     });
-    const mouseUrl = `${koaServer.baseUrl}/mouse`;
-    const meta = await Core.createTab();
-    const core = Core.byTabId[meta.tabId];
-    // @ts-ignore
-    const session = core.session;
-    await core.goto(mouseUrl);
 
-    const spy = jest.spyOn(session.humanEmulator, 'playInteractions');
-    await core.interact([
-      {
-        command: InteractionCommand.click,
-        mousePosition: ['window', 'document', ['querySelector', 'button']],
-      },
-    ]);
-
-    expect(spy).toHaveBeenCalledTimes(1);
-    const interactGroups = spy.mock.calls[0][0];
-    expect(interactGroups).toHaveLength(1);
-    expect(interactGroups[0]).toHaveLength(2);
-    expect(interactGroups[0][0].command).toBe('scroll');
-
-    const buttonClass = await core.execJsPath([
-      'document',
-      ['querySelector', 'button.clicked'],
-      'classList',
-    ]);
-    expect(buttonClass.value).toStrictEqual({ 0: 'clicked' });
-    await core.close();
-  });
-
-  it('executes basic type command', async () => {
-    koaServer.get('/input', ctx => {
-      ctx.set('Content-Security-Policy', "script-src 'unsafe-eval'");
-      ctx.body = `
+    it('executes basic type command', async () => {
+      koaServer.get('/input', ctx => {
+        ctx.set('Content-Security-Policy', "script-src 'unsafe-eval'");
+        ctx.body = `
         <body>
           <input type="text" />
         </body>
       `;
-    });
-    const inputUrl = `${koaServer.baseUrl}/input`;
-    const meta = await Core.createTab();
-    const core = Core.byTabId[meta.tabId];
+      });
+      const meta = await Core.createTab({ humanEmulatorId });
+      const core = Core.byTabId[meta.tabId];
 
-    await core.goto(inputUrl);
-    await core.execJsPath(['document', ['querySelector', 'input'], ['focus']]);
-    await core.interact([
-      {
-        command: InteractionCommand.type,
-        keyboardCommands: [{ string: 'Hello world!' }],
-      },
-    ]);
-    const inputValue = await core.execJsPath(['document', ['querySelector', 'input'], 'value']);
-    expect(inputValue.value).toBe('Hello world!');
-    await core.close();
-  });
-
-  it('can operate when unsafe eval not on', async () => {
-    koaServer.get('/unsafe', ctx => {
-      ctx.set('Content-Security-Policy', "script-src 'self'");
-      ctx.body = `
-        <body>
-          <input type="text" />
-        </body>
-      `;
-    });
-    const inputUrl = `${koaServer.baseUrl}/unsafe`;
-    const meta = await Core.createTab();
-    const core = Core.byTabId[meta.tabId];
-
-    await core.goto(inputUrl);
-    const input = await core.execJsPath(['document', ['querySelector', 'input'], 'value']);
-    expect(input.value).toBe('');
-    const x = await core.execJsPath([['document.querySelector', 'body'], 'scrollTop']);
-    expect(x.value).toBe(0);
-    await core.close();
-  });
-
-  it('should be able to get window variables', async () => {
-    koaServer.get('/vars', ctx => {
-      ctx.set('Content-Security-Policy', "default-src 'self'; script-src 'unsafe-inline'");
-      ctx.body = `
-        <body>
-          <script type="text/javascript">
-          const pageClicks = [1,2,3];
-          function add(item){
-            pageClicks.push(item)
-          }
-          </script>
-        </body>
-      `;
+      await core.goto(`${koaServer.baseUrl}/input`);
+      await core.execJsPath(['document', ['querySelector', 'input'], ['focus']]);
+      await core.interact([
+        {
+          command: InteractionCommand.type,
+          keyboardCommands: [{ string: 'Hello world!' }],
+        },
+      ]);
+      const inputValue = await core.execJsPath(['document', ['querySelector', 'input'], 'value']);
+      expect(inputValue.value).toBe('Hello world!');
+      await core.close();
     });
 
-    const meta = await Core.createTab();
-    const core = Core.byTabId[meta.tabId];
-    await core.goto(`${koaServer.baseUrl}/vars`);
-    await core.waitForLoad('DomContentLoaded');
-
-    const pageClicks = await core.getJsValue('pageClicks');
-    expect(pageClicks.value).toStrictEqual([1, 2, 3]);
-
-    await core.getJsValue(`add('item4')`);
-    const pageClicks2 = await core.getJsValue('pageClicks');
-
-    expect(pageClicks2.value).toStrictEqual([1, 2, 3, 'item4']);
-    await core.close();
-  });
-
-  it('should be able to click elements off screen', async () => {
-    koaServer.get('/longpage', ctx => {
-      ctx.body = `
+    it('should be able to click elements off screen', async () => {
+      koaServer.get('/longpage', ctx => {
+        ctx.body = `
         <body>
           <div style="height:500px">
-            <button id="button-1" onclick="click1()">Test</button>
+            <button id="button-1" onclick="click1(event)">Test</button>
           </div>
-          <div style="margin-top:1500px">
-            <button id="button-2" onclick="click2()">Test 2</button>
+          <div style="margin-top:1500px; flex: content; justify-content: center">
+            <button id="button-2" onclick="click2()" style="width: 30px; height: 20px;">Test 2</button>
+          </div>
+          <div style="margin-top:3105px; float:right;clear:both: width:20px; height: 20px;">
+            <button id="button-3" onclick="click3()">Test 3</button>
           </div>
           <script>
-            var lastClicked = '';
-            function click1() {
-              lastClicked = 'click1';
+            let lastClicked = '';
+            function click1(ev) {
+              lastClicked = 'click1' + (ev.isTrusted ? '' : '!!untrusted');
             }
             function click2() {
               lastClicked = 'click2';
             }
+            function click3() {
+              lastClicked = 'click3';
+            }
           </script>
         </body>
       `;
-    });
-    const mouseUrl = `${koaServer.baseUrl}/longpage`;
-    const meta = await Core.createTab();
-    const core = Core.byTabId[meta.tabId];
-    await core.goto(mouseUrl);
+      });
+      const meta = await Core.createTab({ humanEmulatorId });
+      const core = Core.byTabId[meta.tabId];
+      await core.goto(`${koaServer.baseUrl}/longpage`);
 
-    await core.interact([
-      {
-        command: InteractionCommand.click,
-        mousePosition: ['window', 'document', ['querySelector', '#button-1']],
-      },
-    ]);
-    let lastClicked = await core.getJsValue('lastClicked');
-    expect(lastClicked.value).toBe('click1');
+      const click = async (selector: string) => {
+        await core.interact([
+          {
+            command: InteractionCommand.click,
+            mousePosition: ['window', 'document', ['querySelector', selector]],
+          },
+        ]);
+        return await core.getJsValue('lastClicked');
+      };
 
-    await core.interact([
-      {
-        command: InteractionCommand.click,
-        mousePosition: ['window', 'document', ['querySelector', '#button-2']],
-      },
-    ]);
-    lastClicked = await core.getJsValue('lastClicked');
-    expect(lastClicked.value).toBe('click2');
+      let lastClicked = await click('#button-1');
+      expect(lastClicked.value).toBe('click1');
 
-    await core.close();
-  });
-});
+      lastClicked = await click('#button-2');
+      expect(lastClicked.value).toBe('click2');
+
+      lastClicked = await click('#button-3');
+      expect(lastClicked.value).toBe('click3');
+
+      lastClicked = await click('#button-1');
+      expect(lastClicked.value).toBe('click1');
+
+      await core.close();
+    }, 30e3);
+  },
+);

--- a/emulate-humans/basic/index.ts
+++ b/emulate-humans/basic/index.ts
@@ -1,9 +1,8 @@
-import { IInteractionGroups, IInteractionStep } from "@secret-agent/core-interfaces/IInteractions";
-import IHumanEmulator from "@secret-agent/core-interfaces/IHumanEmulator";
-import { HumanEmulatorClassDecorator } from "@secret-agent/core-interfaces/IHumanEmulatorClass";
+import { IInteractionGroups, IInteractionStep } from '@secret-agent/core-interfaces/IInteractions';
+import { HumanEmulatorClassDecorator } from '@secret-agent/core-interfaces/IHumanEmulatorClass';
 
 @HumanEmulatorClassDecorator
-export default class HumanEmulatorBasic implements IHumanEmulator {
+export default class HumanEmulatorBasic {
   public static id = 'basic';
 
   public async playInteractions(

--- a/emulate-humans/ghost/generateVector.ts
+++ b/emulate-humans/ghost/generateVector.ts
@@ -1,0 +1,111 @@
+import Bezier from 'bezier-js';
+import IPoint from '@secret-agent/core-interfaces/IPoint';
+
+const sub = (a: IPoint, b: IPoint): IPoint => ({ x: a.x - b.x, y: a.y - b.y });
+const div = (a: IPoint, b: number): IPoint => ({ x: a.x / b, y: a.y / b });
+const mult = (a: IPoint, b: number): IPoint => ({ x: a.x * b, y: a.y * b });
+const add = (a: IPoint, b: IPoint): IPoint => ({ x: a.x + b.x, y: a.y + b.y });
+
+export default function generateVector(
+  startPoint: IPoint,
+  destinationPoint: IPoint,
+  targetWidth: number,
+  overshoot: { threshold: number; radius: number; spread: number },
+) {
+  const shouldOvershoot = magnitude(direction(startPoint, destinationPoint)) > overshoot.threshold;
+
+  const firstTargetPoint = shouldOvershoot
+    ? getOvershootPoint(destinationPoint, overshoot.radius)
+    : destinationPoint;
+  const points = path(startPoint, firstTargetPoint);
+
+  if (shouldOvershoot) {
+    const correction = path(firstTargetPoint, destinationPoint, targetWidth, overshoot.spread);
+    points.push(...correction);
+  }
+  return points.map(point => {
+    return { x: Math.round(point.x * 10) / 10, y: Math.round(point.y * 10) / 10 };
+  });
+}
+
+function path(start: IPoint, end: IPoint, targetWidth = 100, spreadOverride?: number): IPoint[] {
+  const minSteps = 25;
+  const curve = bezierCurve(start, end, spreadOverride);
+  const length = curve.length() * 0.8;
+  const baseTime = Math.random() * minSteps;
+  const steps = Math.ceil((Math.log2(fitts(length, targetWidth) + 1) + baseTime) * 3);
+
+  return curve.getLUT(steps).map(vector => ({
+    x: Number.isNaN(vector.x ?? 0) ? 0 : vector.x,
+    y: Number.isNaN(vector.y ?? 0) ? 0 : vector.y,
+  }));
+}
+
+function bezierCurve(start: IPoint, finish: IPoint, overrideSpread?: number) {
+  // could be played around with
+  const min = 2;
+  const max = 200;
+  const vec = direction(start, finish);
+  const length = magnitude(vec);
+  const spread = Math.min(length, Math.max(min, max));
+  const anchors = generateBezierAnchors(start, finish, overrideSpread ?? spread);
+  return new Bezier(start, ...anchors, finish);
+}
+
+function randomVectorOnLine(a: IPoint, b: IPoint) {
+  const vec = direction(a, b);
+  const multiplier = Math.random();
+  return add(a, mult(vec, multiplier));
+}
+
+function randomNormalLine(a: IPoint, b: IPoint, range: number) {
+  const randMid = randomVectorOnLine(a, b);
+  const normalV = setMagnitude(perpendicular(direction(a, randMid)), range);
+  return [randMid, normalV];
+}
+
+function generateBezierAnchors(a: IPoint, b: IPoint, spread: number) {
+  const side = Math.round(Math.random()) === 1 ? 1 : -1;
+  const calc = (): IPoint => {
+    const [randMid, normalV] = randomNormalLine(a, b, spread);
+    const choice = mult(normalV, side);
+    return randomVectorOnLine(randMid, add(randMid, choice));
+  };
+  return [calc(), calc()].sort((sortA, sortB) => sortA.x - sortB.x);
+}
+
+function getOvershootPoint(coordinate: IPoint, radius: number) {
+  const a = Math.random() * 2 * Math.PI;
+  const rad = radius * Math.sqrt(Math.random());
+  const vector = { x: rad * Math.cos(a), y: rad * Math.sin(a) };
+  return add(coordinate, vector);
+}
+
+/**
+ * Calculate the amount of time needed to move from (x1, y1) to (x2, y2)
+ * given the width of the element being clicked on
+ * https://en.wikipedia.org/wiki/Fitts%27s_law
+ */
+function fitts(distance: number, width: number) {
+  return 2 * Math.log2(distance / width + 1);
+}
+
+function direction(a: IPoint, b: IPoint) {
+  return sub(b, a);
+}
+
+function perpendicular(a: IPoint) {
+  return { x: a.y, y: -1 * a.x };
+}
+
+function magnitude(a: IPoint) {
+  return Math.sqrt(a.x ** 2 + a.y ** 2);
+}
+
+function unit(a: IPoint) {
+  return div(a, magnitude(a));
+}
+
+function setMagnitude(a: IPoint, amount: number) {
+  return mult(unit(a), amount);
+}

--- a/emulate-humans/ghost/index.ts
+++ b/emulate-humans/ghost/index.ts
@@ -1,0 +1,373 @@
+import {
+  IInteractionGroups,
+  IInteractionStep,
+  IKeyboardCommand,
+  IMousePosition,
+  IMousePositionXY,
+  InteractionCommand,
+} from '@secret-agent/core-interfaces/IInteractions';
+import { HumanEmulatorClassDecorator } from '@secret-agent/core-interfaces/IHumanEmulatorClass';
+import IRect from '@secret-agent/core-interfaces/IRect';
+import IInteractionsHelper from '@secret-agent/core-interfaces/IInteractionsHelper';
+import IPoint from '@secret-agent/core-interfaces/IPoint';
+import IViewport from '@secret-agent/core-interfaces/IViewport';
+import generateVector from './generateVector';
+
+// ATTRIBUTION: heavily borrowed/inspired by https://github.com/Xetera/ghost-cursor
+
+@HumanEmulatorClassDecorator
+export default class HumanEmulatorGhost {
+  public static id = 'ghost';
+
+  public static overshootSpread = 2;
+  public static overshootRadius = 5;
+  public static overshootThreshold = 250;
+  public static boxPaddingPercent = 33;
+  public static maxScrollIncrement = 500;
+  public static maxScrollDelayMillis = 15;
+  public static maxDelayBetweenInteractions = 200;
+
+  public static wordsPerMinuteRange = [30, 50];
+
+  private millisPerCharacter: number;
+
+  public async getStartingMousePoint(helper: IInteractionsHelper) {
+    const viewport = helper.viewport;
+    return getRandomRectPoint({
+      x: 0,
+      y: 0,
+      width: viewport.width,
+      height: viewport.height,
+    });
+  }
+
+  public async playInteractions(
+    interactionGroups: IInteractionGroups,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+    helper: IInteractionsHelper,
+  ) {
+    const millisPerCharacter = this.calculateMillisPerChar();
+
+    for (let i = 0; i < interactionGroups.length; i += 1) {
+      if (i > 0) {
+        await delay(Math.random() * HumanEmulatorGhost.maxDelayBetweenInteractions);
+      }
+      for (const step of interactionGroups[i]) {
+        if (step.command === InteractionCommand.scroll) {
+          await this.scroll(step, run, helper);
+          continue;
+        }
+
+        if (step.command === InteractionCommand.move) {
+          await this.move(step, run, helper);
+          continue;
+        }
+
+        if (
+          step.command === InteractionCommand.click ||
+          step.command === InteractionCommand.doubleclick
+        ) {
+          await this.moveAndClick(step, run, helper);
+          continue;
+        }
+
+        if (step.command === InteractionCommand.type) {
+          for (const keyboardCommand of step.keyboardCommands) {
+            if ('string' in keyboardCommand) {
+              for (const char of keyboardCommand.string) {
+                await run(this.getKeyboardCommandWithDelay({ string: char }, millisPerCharacter));
+              }
+            } else {
+              await run(this.getKeyboardCommandWithDelay(keyboardCommand, millisPerCharacter));
+            }
+          }
+          continue;
+        }
+
+        await run(step);
+      }
+    }
+  }
+
+  protected async scroll(
+    interactionStep: IInteractionStep,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+    helper: IInteractionsHelper,
+  ) {
+    const scrollVector = await this.getScrollVector(interactionStep.mousePosition, helper);
+
+    let counter = 0;
+    for (const { x, y } of scrollVector) {
+      await delay(Math.random() * HumanEmulatorGhost.maxScrollDelayMillis);
+
+      const shouldAddMouseJitter = counter % Math.round(Math.random() * 6) === 0;
+      if (shouldAddMouseJitter) {
+        await this.jitterMouse(helper, run);
+      }
+
+      await run({
+        mousePosition: [x, y],
+        command: InteractionCommand.scroll,
+      });
+      counter += 1;
+    }
+  }
+
+  protected async moveAndClick(
+    interactionStep: IInteractionStep,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+    helper: IInteractionsHelper,
+  ) {
+    interactionStep.delayMillis = Math.floor(Math.random() * 100);
+    const targetRect = await helper.lookupBoundingRect(interactionStep.mousePosition);
+    const targetPoint = getRandomRectPoint(targetRect, HumanEmulatorGhost.boxPaddingPercent);
+    await this.moveToPoint(targetPoint, targetRect.width, run, helper);
+
+    // if this is an option element, we have to do a specialized click, so let the Interactor handle
+    if (targetRect.elementTag !== 'option') {
+      interactionStep.mousePosition = [targetPoint.x, targetPoint.y];
+    }
+    await run(interactionStep);
+  }
+
+  protected async move(
+    interactionStep: IInteractionStep,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+    helper: IInteractionsHelper,
+  ) {
+    const rect = await helper.lookupBoundingRect(interactionStep.mousePosition);
+    const targetPoint = getRandomRectPoint(rect, HumanEmulatorGhost.boxPaddingPercent);
+
+    await this.moveToPoint(targetPoint, rect.width, run, helper);
+  }
+
+  protected async moveToPoint(
+    targetPoint: IPoint,
+    targetWidth: number,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+    helper: IInteractionsHelper,
+  ) {
+    const mousePosition = helper.mousePosition;
+    const vector = generateVector(mousePosition, targetPoint, targetWidth, {
+      threshold: HumanEmulatorGhost.overshootThreshold,
+      radius: HumanEmulatorGhost.overshootRadius,
+      spread: HumanEmulatorGhost.overshootSpread,
+    });
+
+    for (const { x, y } of vector) {
+      await run({
+        mousePosition: [x, y],
+        command: InteractionCommand.move,
+      });
+    }
+  }
+
+  protected async jitterMouse(
+    helper: IInteractionsHelper,
+    run: (interactionStep: IInteractionStep) => Promise<void>,
+  ) {
+    const mousePosition = helper.mousePosition;
+    const jitterX = Math.max(mousePosition.x + Math.round(getRandomPositiveOrNegativeNumber()), 0);
+    const jitterY = Math.max(mousePosition.y + Math.round(getRandomPositiveOrNegativeNumber()), 0);
+    if (jitterX !== mousePosition.x || jitterY !== mousePosition.y) {
+      // jitter mouse
+      await run({
+        mousePosition: [jitterX, jitterY],
+        command: InteractionCommand.move,
+      });
+    }
+  }
+
+  /////// KEYBOARD /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  protected getKeyboardCommandWithDelay(keyboardCommand: IKeyboardCommand, millisPerChar: number) {
+    const randomFactor = getRandomPositiveOrNegativeNumber() * (millisPerChar / 2);
+    const delayMillis = Math.floor(randomFactor + millisPerChar);
+    const keyboardKeyupDelay = Math.max(Math.ceil(Math.random() * 60), 10);
+    return {
+      command: InteractionCommand.type,
+      keyboardCommands: [keyboardCommand],
+      keyboardDelayBetween: delayMillis - keyboardKeyupDelay,
+      keyboardKeyupDelay,
+    };
+  }
+
+  protected calculateMillisPerChar() {
+    if (!this.millisPerCharacter) {
+      const wpmRange =
+        HumanEmulatorGhost.wordsPerMinuteRange[1] - HumanEmulatorGhost.wordsPerMinuteRange[0];
+      const wpm = Math.floor(Math.random() * wpmRange) + HumanEmulatorGhost.wordsPerMinuteRange[0];
+
+      const averageWordLength = 5;
+      const charsPerSecond = (wpm * averageWordLength) / 60;
+      this.millisPerCharacter = Math.round(1000 / charsPerSecond);
+    }
+    return this.millisPerCharacter;
+  }
+
+  private async getScrollVector(mousePosition: IMousePosition, helper: IInteractionsHelper) {
+    const isCoordinates =
+      typeof mousePosition[0] === 'number' && typeof mousePosition[1] === 'number';
+    let shouldScrollX: boolean;
+    let shouldScrollY: boolean;
+    let scrollToPoint: IPoint;
+    const startScrollOffset = await helper.scrollOffset;
+
+    if (!isCoordinates) {
+      const targetRect = await helper.lookupBoundingRect(mousePosition);
+      // figure out if target is in view
+      const viewport = helper.viewport;
+      shouldScrollY = isVisible(targetRect.y, targetRect.height, viewport.height) === false;
+      shouldScrollX = isVisible(targetRect.x, targetRect.width, viewport.width) === false;
+
+      // positions are all relative to viewport, so act like we're at 0,0
+      scrollToPoint = getScrollRectPoint(targetRect, viewport);
+
+      if (shouldScrollY) scrollToPoint.y += startScrollOffset.y;
+      else scrollToPoint.y = startScrollOffset.y;
+
+      if (shouldScrollX) scrollToPoint.x += startScrollOffset.x;
+      else scrollToPoint.x = startScrollOffset.x;
+    } else {
+      const [x, y] = mousePosition as IMousePositionXY;
+      scrollToPoint = { x, y };
+      shouldScrollY = y !== startScrollOffset.y;
+      shouldScrollX = x !== startScrollOffset.x;
+    }
+
+    if (!shouldScrollY && !shouldScrollX) return [];
+
+    let lastPoint: IPoint = startScrollOffset;
+    const scrollVector = generateVector(startScrollOffset, scrollToPoint, 200, {
+      threshold: HumanEmulatorGhost.overshootThreshold,
+      radius: HumanEmulatorGhost.overshootRadius,
+      spread: HumanEmulatorGhost.overshootSpread,
+    });
+
+    const points = [];
+    for (let point of scrollVector) {
+      // convert points into deltas from previous scroll point
+      const scrollX = shouldScrollX ? Math.round(point.x) : startScrollOffset.x;
+      const scrollY = shouldScrollY ? Math.round(point.y) : startScrollOffset.y;
+      if (scrollY === lastPoint.y && scrollX === lastPoint.x) continue;
+
+      point = {
+        x: scrollX,
+        y: scrollY,
+      };
+      const newPoints: IPoint[] = [point];
+
+      const scrollYPixels = Math.abs(scrollY - lastPoint.y);
+      // if too big a jump, backfill smaller jumps
+      if (scrollYPixels > HumanEmulatorGhost.maxScrollIncrement) {
+        const isNegative = scrollY < lastPoint.y;
+        const chunks = splitIntoMaxLengthSegments(
+          scrollYPixels,
+          HumanEmulatorGhost.maxScrollIncrement,
+        );
+        for (const chunk of chunks) {
+          const deltaY = isNegative ? -chunk : chunk;
+          if (deltaY === 0) continue;
+          newPoints.unshift({
+            x: scrollX,
+            y: newPoints[0].y - deltaY,
+          });
+        }
+      }
+
+      const lastEntry = points[points.length - 1];
+      // if same point added, yank it now
+      if (lastEntry && lastEntry.x === newPoints[0].x && lastEntry.y === newPoints[0].y) {
+        newPoints.shift();
+      }
+      points.push(...newPoints);
+
+      lastPoint = point;
+    }
+    if (lastPoint.y !== scrollToPoint.y || lastPoint.x !== scrollToPoint.x) {
+      points.push(scrollToPoint);
+    }
+    return points;
+  }
+}
+
+export function isVisible(coordinate: number, length: number, boundaryLength: number) {
+  if (length > boundaryLength) {
+    length = boundaryLength;
+  }
+  const midpointOffset = Math.round(coordinate + length / 2);
+  if (coordinate >= 0) {
+    // midpoint passes end
+    if (midpointOffset >= boundaryLength) {
+      return false;
+    }
+  } else {
+    // midpoint before start
+    // eslint-disable-next-line no-lonely-if
+    if (midpointOffset <= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function delay(millis: number) {
+  if (!millis) return;
+  await new Promise<void>(resolve => setTimeout(resolve, Math.floor(millis)));
+}
+
+function splitIntoMaxLengthSegments(total: number, maxValue: number) {
+  const values: number[] = [];
+  let currentSum = 0;
+  while (currentSum < total) {
+    let nextValue = Math.round(Math.random() * maxValue * 10) / 10;
+    if (currentSum + nextValue > total) {
+      nextValue = total - currentSum;
+    }
+    currentSum += nextValue;
+    values.push(nextValue);
+  }
+  return values;
+}
+
+function getRandomPositiveOrNegativeNumber() {
+  const negativeMultiplier = Math.random() < 0.5 ? -1 : 1;
+
+  return Math.random() * negativeMultiplier;
+}
+
+function getScrollRectPoint(targetRect: IRect, viewport: IViewport) {
+  let { y, x } = targetRect;
+  const fudge = 2 * Math.random();
+  // target rect inside bounds
+  const midViewportHeight = Math.round(viewport.height / 2 + fudge);
+  const midViewportWidth = Math.round(viewport.width / 2 + fudge);
+
+  if (y < -(midViewportHeight + 1)) y -= midViewportHeight;
+  else if (y > midViewportHeight + 1) y -= midViewportHeight;
+
+  if (x < -(midViewportWidth + 1)) x -= midViewportWidth;
+  else if (x > midViewportWidth + 1) x -= midViewportWidth;
+
+  x = Math.round(x * 10) / 10;
+  y = Math.round(y * 10) / 10;
+
+  return { x, y };
+}
+
+function getRandomRectPoint(targetRect: IRect, paddingPercent?: number): IPoint {
+  const { y, x, height, width } = targetRect;
+
+  let paddingWidth = 0;
+  let paddingHeight = 0;
+
+  if (paddingPercent !== undefined && paddingPercent > 0 && paddingPercent < 100) {
+    paddingWidth = (width * paddingPercent) / 100;
+    paddingHeight = (height * paddingPercent) / 100;
+  }
+
+  return {
+    x: Math.round(x + paddingWidth / 2 + Math.random() * (width - paddingWidth)),
+    y: Math.round(y + paddingHeight / 2 + Math.random() * (height - paddingHeight)),
+  };
+}

--- a/emulate-humans/ghost/package.json
+++ b/emulate-humans/ghost/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@secret-agent/emulate-humans-ghost",
+  "version": "1.2.0-alpha.0",
+  "description": "HumanEmulator based on Xetera/ghost-cursor for SecretAgent",
+  "main": "index.js",
+  "dependencies": {
+    "@secret-agent/core-interfaces": "1.2.0-alpha.0",
+    "bezier-js": "^2.6.1"
+  }
+}

--- a/emulate-humans/ghost/test/ghost.test.ts
+++ b/emulate-humans/ghost/test/ghost.test.ts
@@ -1,0 +1,218 @@
+import { IInteractionStep, InteractionCommand } from '@secret-agent/core-interfaces/IInteractions';
+import IViewport from '@secret-agent/core-interfaces/IViewport';
+import HumanEmulatorGhost, { isVisible } from '../index';
+
+beforeAll(() => {
+  HumanEmulatorGhost.maxDelayBetweenInteractions = 0;
+  HumanEmulatorGhost.maxScrollDelayMillis = 0;
+});
+
+describe('typing', () => {
+  test('should spread out characters based on a wpm range', async () => {
+    HumanEmulatorGhost.wordsPerMinuteRange = [34, 34];
+    const ghost = new HumanEmulatorGhost();
+    const groups = [
+      [
+        {
+          command: InteractionCommand.type,
+          keyboardCommands: [{ string: 'Test typing sentence' }],
+        },
+      ],
+    ];
+    // @ts-ignore
+    const millisPerCharacter = ghost.calculateMillisPerChar(groups);
+    expect(millisPerCharacter).toBe(353);
+
+    let count = 0;
+    let totalMillis = 0;
+    await ghost.playInteractions(
+      groups,
+      async interactionStep => {
+        expect(interactionStep.keyboardKeyupDelay).toBeGreaterThanOrEqual(10);
+        expect(interactionStep.keyboardKeyupDelay).toBeLessThanOrEqual(60);
+
+        expect(interactionStep.keyboardDelayBetween).toBeGreaterThanOrEqual(353 - 60 - 353 / 2);
+        totalMillis += interactionStep.keyboardDelayBetween + interactionStep.keyboardKeyupDelay;
+        count += 1;
+        return null;
+      },
+      null,
+    );
+    const chars = 'Test typing sentence'.length;
+    expect(count).toBe(chars);
+    const charsPerSecond = totalMillis / 1000 / chars;
+    const charsPerMinute = 60 / charsPerSecond;
+    const wpm = Math.round(charsPerMinute / 5);
+    // should be close to 34 wpm
+    expect(Math.abs(34 - wpm)).toBeLessThanOrEqual(7);
+  });
+});
+
+describe('deltaToVisible', () => {
+  test('should calculate deltas correctly', async () => {
+    expect(isVisible(20, 50, 100)).toBe(true);
+    // 85 + 25 is 110. Need to scroll +10
+    expect(isVisible(85, 50, 100)).toBe(false);
+    // -30 + 25 is -5. Need to scroll up -5
+    expect(isVisible(-30, 50, 100)).toBe(false);
+  });
+
+  test('should work to find center coordinates', async () => {
+    expect(isVisible(20, 100, 100)).toBe(true);
+    expect(isVisible(85, 100, 100)).toBe(false);
+    expect(isVisible(150, 100, 100)).toBe(false);
+    expect(isVisible(-30, 100, 100)).toBe(true);
+    expect(isVisible(-51, 100, 100)).toBe(false);
+  });
+});
+
+describe('move', () => {
+  test('should break a move into a series of moves', async () => {
+    const ghost = new HumanEmulatorGhost();
+    const commands = [];
+    // @ts-ignore
+    await ghost.scroll(
+      {
+        command: 'move',
+        mousePosition: [['document', 'querySelector', 'x']],
+      },
+      async step => {
+        commands.push(step);
+      },
+      {
+        mousePosition: { x: 25, y: 25 },
+        viewport: {
+          height: 600,
+          width: 800,
+        } as IViewport,
+        async lookupBoundingRect() {
+          return {
+            elementTag: 'div',
+            height: 10,
+            width: 100,
+            x: 0,
+            y: 800,
+          };
+        },
+        scrollOffset: Promise.resolve({ x: 0, y: 0 }),
+      },
+    );
+
+    expect(commands.length).toBeGreaterThanOrEqual(25);
+  });
+});
+
+describe('scroll', () => {
+  test('should break a scroll into a curve', async () => {
+    const ghost = new HumanEmulatorGhost();
+    const commands = [];
+    // @ts-ignore
+    await ghost.scroll(
+      {
+        command: 'scroll',
+        mousePosition: [['document', 'querySelector', 'x']],
+      },
+      async step => {
+        commands.push(step);
+      },
+      {
+        mousePosition: { x: 25, y: 25 },
+        viewport: {
+          height: 600,
+          width: 800,
+        } as IViewport,
+        async lookupBoundingRect() {
+          return {
+            elementTag: 'div',
+            height: 10,
+            width: 100,
+            x: 0,
+            y: 800,
+          };
+        },
+        scrollOffset: Promise.resolve({ x: 0, y: 0 }),
+      },
+    );
+
+    expect(commands.length).toBeGreaterThan(1);
+  });
+
+  test('should not scroll if over half in screen', async () => {
+    const ghost = new HumanEmulatorGhost();
+    const commands = [];
+    // @ts-ignore
+    await ghost.scroll(
+      {
+        command: 'scroll',
+        mousePosition: [['document', 'querySelector', 'x']],
+      },
+      async step => {
+        commands.push(step);
+      },
+      {
+        mousePosition: { x: 25, y: 25 },
+        viewport: {
+          height: 600,
+          width: 800,
+        } as IViewport,
+        async lookupBoundingRect() {
+          return {
+            elementTag: 'div',
+            height: 200,
+            width: 100,
+            x: 50,
+            y: 499,
+          };
+        },
+        scrollOffset: Promise.resolve({ x: 0, y: 0 }),
+      },
+    );
+
+    expect(commands).toHaveLength(0);
+  });
+
+  test('should not exceed max pixels per scroll', async () => {
+    const ghost = new HumanEmulatorGhost();
+    const commands: IInteractionStep[] = [];
+    // @ts-ignore
+    await ghost.scroll(
+      {
+        command: 'scroll',
+        mousePosition: [['document', 'querySelector', 'x']],
+      },
+      async step => {
+        commands.push(step);
+      },
+      {
+        mousePosition: { x: 25, y: 25 },
+        viewport: {
+          height: 600,
+          width: 800,
+        } as IViewport,
+        async lookupBoundingRect() {
+          return {
+            elementTag: 'div',
+            height: 200,
+            width: 100,
+            x: 50,
+            y: 50000,
+          };
+        },
+        scrollOffset: Promise.resolve({ x: 0, y: 0 }),
+      },
+    );
+
+    expect(commands.length).toBeGreaterThanOrEqual(25);
+
+    const scrolls = commands.filter(x => x.command === 'scroll');
+    for (let i = 0; i < scrolls.length; i += 1) {
+      const current = scrolls[i];
+      const next = scrolls[i + 1];
+      if (current && next) {
+        expect(
+          Math.abs((next.mousePosition[1] as number) - (current.mousePosition[1] as number)),
+        ).toBeLessThanOrEqual(500);
+      }
+    }
+  });
+});

--- a/injected-scripts/interfaces/IMouseEvent.ts
+++ b/injected-scripts/interfaces/IMouseEvent.ts
@@ -11,6 +11,8 @@ import { CommandId, ISOTimestamp } from './GenericTypes';
 
 type PageX = number;
 type PageY = number;
+type OffsetX = number;
+type OffsetY = number;
 type NodeId = number;
 type Buttons = number;
 type RelatedNodeId = NodeId;
@@ -21,6 +23,8 @@ export type IMouseEvent = [
   MouseEventType,
   PageX,
   PageY,
+  OffsetX,
+  OffsetY,
   Buttons,
   NodeId,
   RelatedNodeId,

--- a/injected-scripts/scripts/pageEventsRecorder.ts
+++ b/injected-scripts/scripts/pageEventsRecorder.ts
@@ -108,6 +108,7 @@ class PageEventsRecorder {
 
   constructor() {
     this.observer = new MutationObserver(this.onMutation.bind(this));
+    if (window.location?.href === 'about:blank') return;
     if (document && document.childNodes.length) {
       const mutations: MutationRecord[] = [
         {
@@ -176,6 +177,9 @@ class PageEventsRecorder {
       eventType,
       mouseEvent.pageX,
       mouseEvent.pageY,
+      // might not want to do this - causes reflow
+      mouseEvent.offsetX,
+      mouseEvent.offsetY,
       mouseEvent.buttons,
       nodeId,
       relatedNodeId,

--- a/puppet-interfaces/IPuppetInput.ts
+++ b/puppet-interfaces/IPuppetInput.ts
@@ -1,15 +1,16 @@
 import { IKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import { IMouseButton } from '@secret-agent/core-interfaces/IInteractions';
+import IPoint from '@secret-agent/core-interfaces/IPoint';
 
 export interface IPuppetKeyboard {
   up(key: IKeyboardKey): Promise<void>;
   down(key: IKeyboardKey): Promise<void>;
-  press(key: IKeyboardKey): Promise<void>;
-  type(text: string, options?: { delay: number }): Promise<void>;
+  press(key: IKeyboardKey, keyupDelay?: number): Promise<void>;
   sendCharacter(char: string): Promise<void>;
 }
 
 export interface IPuppetMouse {
+  position: IPoint;
   move(x: number, y: number): Promise<void>;
   click(x: number, y: number, options?: IMouseOptions & { delay?: number }): Promise<void>;
   up(options?: IMouseOptions): Promise<void>;

--- a/puppet/test/Frames.test.ts
+++ b/puppet/test/Frames.test.ts
@@ -437,7 +437,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
     </form>`);
 
         await page.click('input[type=text]');
-        await page.keyboard.type('admin');
+        await page.type('admin');
         await page.click('input[type=submit]');
 
         await expect(page.navigate(server.emptyPage)).resolves.toBe(undefined);

--- a/puppet/test/Keyboard.test.ts
+++ b/puppet/test/Keyboard.test.ts
@@ -50,17 +50,17 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       })()`);
       await page.click('textarea');
       const text = 'Hello world. I am the text that was typed!';
-      await page.keyboard.type(text);
+      await page.type(text);
       expect(await page.evaluate(`(() => document.querySelector('textarea').value)()`)).toBe(text);
     });
 
     it('should move with the arrow keys', async () => {
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
-      await page.keyboard.type('Hello World!');
+      await page.type('Hello World!');
       expect(await page.evaluate(`document.querySelector('textarea').value`)).toBe('Hello World!');
       for (let i = 0; i < 'World!'.length; i += 1) await page.keyboard.press('ArrowLeft');
-      await page.keyboard.type('inserted ');
+      await page.type('inserted ');
       expect(await page.evaluate(`document.querySelector('textarea').value`)).toBe(
         'Hello inserted World!',
       );
@@ -131,13 +131,13 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
 
     it('should send proper codes while typing', async () => {
       await page.goto(`${server.baseUrl}/input/keyboard.html`);
-      await page.keyboard.type('!');
+      await page.type('!');
       expect(await page.evaluate('getResult()')).toBe(
         ['Keydown: ! Digit1 49 []', 'Keypress: ! Digit1 33 33 []', 'Keyup: ! Digit1 49 []'].join(
           '\n',
         ),
       );
-      await page.keyboard.type('^');
+      await page.type('^');
       expect(await page.evaluate('getResult()')).toBe(
         ['Keydown: ^ Digit6 54 []', 'Keypress: ^ Digit6 94 94 []', 'Keyup: ^ Digit6 54 []'].join(
           '\n',
@@ -149,7 +149,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       await page.goto(`${server.baseUrl}/input/keyboard.html`);
       const keyboard = page.keyboard;
       await keyboard.down('Shift');
-      await page.keyboard.type('~');
+      await page.type('~');
       expect(await page.evaluate('getResult()')).toBe(
         [
           'Keydown: Shift ShiftLeft 16 [Shift]',
@@ -174,7 +174,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
             event.preventDefault();
         }, false);
       })()`);
-      await page.keyboard.type('Hello World!');
+      await page.type('Hello World!');
       expect(await page.evaluate(`document.querySelector('textarea').value`)).toBe('He Wrd!');
     });
 
@@ -204,7 +204,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
       const text = 'This text goes onto two lines.\nThis character is 嗨.';
-      await page.keyboard.type(text);
+      await page.type(text);
       expect(await page.evaluate(`document.querySelector('textarea').value`)).toBe(text);
     });
 
@@ -264,7 +264,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
     it('should type emoji', async () => {
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
-      await page.keyboard.type('👹 Tokyo street Japan 🇯🇵');
+      await page.type('👹 Tokyo street Japan 🇯🇵');
       expect(await page.evaluate(`document.querySelector('textarea').value`)).toBe(
         '👹 Tokyo street Japan 🇯🇵',
       );
@@ -279,7 +279,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
 
       const rect = ${textArea}.focus()
     })()`);
-      await page.keyboard.type('👹 Tokyo street Japan 🇯🇵');
+      await page.type('👹 Tokyo street Japan 🇯🇵');
 
       expect(await page.evaluate(`${textArea}.value`)).toBe('👹 Tokyo street Japan 🇯🇵');
     });
@@ -289,7 +289,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
     it.skip('should handle selectAll', async () => {
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
-      await page.keyboard.type('some text');
+      await page.type('some text');
       const modifier = MAC ? 'Meta' : 'Control';
       await page.keyboard.down(modifier);
       await page.keyboard.press('a');
@@ -301,7 +301,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
     it('should be able to prevent selectAll', async () => {
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
-      await page.keyboard.type('some text');
+      await page.type('some text');
       await page.evaluate(`(() => {
         document.querySelector('textarea').addEventListener(
           'keydown',

--- a/puppet/test/Mouse.test.ts
+++ b/puppet/test/Mouse.test.ts
@@ -97,7 +97,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       await page.goto(`${server.baseUrl}/input/textarea.html`);
       await page.click('textarea');
       const text = "This is the text that we are going to try to select. Let's see how it goes.";
-      await page.keyboard.type(text);
+      await page.type(text);
       // Firefox needs an extra frame here after typing or it will fail to set the scrollTop
       await page.evaluate(`new Promise(requestAnimationFrame)`);
       await page.evaluate(`(document.querySelector('textarea').scrollTop = 0)`);

--- a/puppet/test/TestPage.ts
+++ b/puppet/test/TestPage.ts
@@ -1,8 +1,11 @@
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import { IPuppetFrame } from '@secret-agent/puppet-interfaces/IPuppetFrame';
+import { IKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
+import { keyDefinitions } from '@secret-agent/puppet-chrome/interfaces/USKeyboardLayout';
 
 export interface ITestPage extends IPuppetPage {
   click(selector: string): Promise<void>;
+  type(text: string): Promise<void>;
   attachFrame(frameId: string, url: string): Promise<IPuppetFrame>;
   detachFrame(frameId: string): Promise<void>;
   goto(url: string, waitOnLifecycle?: string): Promise<void>;
@@ -15,14 +18,22 @@ export function createTestPage(page: IPuppetPage) {
   castPage.attachFrame = attachFrame.bind(page, page);
   castPage.detachFrame = detachFrame.bind(page, page);
   castPage.click = click.bind(page, page);
+  castPage.type = type.bind(page, page);
   castPage.setContent = setContent.bind(page, page);
   castPage.waitForPopup = waitForPopup.bind(page, page);
   castPage.goto = goto.bind(page, page);
   return castPage;
 }
 
+export async function type(page: IPuppetPage, text: string) {
+  for (const char of text) {
+    if (char in keyDefinitions) await page.keyboard.press(char as IKeyboardKey);
+    else await page.keyboard.sendCharacter(char);
+  }
+}
+
 export async function click(page: IPuppetPage, selector: string) {
-  const coordinates: any = await page.evaluate(`(()=>{ 
+  const coordinates: any = await page.evaluate(`(()=>{
     const rect = document.querySelector('${selector}').getBoundingClientRect();
     return {
       x: rect.x,

--- a/replay/backend/Application.ts
+++ b/replay/backend/Application.ts
@@ -105,7 +105,7 @@ export default class Application {
       replayApi = await ReplayApi.connect(replay);
     } catch (err) {
       console.log('ERROR launching replay', err);
-      dialog.showErrorBox('Whoops, something blew up loading this replay!', err.stack);
+      dialog.showErrorBox(`Unable to Load Replay`, err.message);
       return;
     }
 
@@ -223,11 +223,11 @@ export default class Application {
 
     // TICKS
     let tickDebounce: NodeJS.Timeout;
-    ipcMain.on('on-tick', (e, tickValue) => {
+    ipcMain.on('on-tick-drag', (e, tickValue) => {
       clearTimeout(tickDebounce);
       const replayView = Window.current?.replayView;
       if (!replayView) return;
-      tickDebounce = setTimeout(() => replayView.onTick(tickValue), 10);
+      tickDebounce = setTimeout(() => replayView.onTickDrag(tickValue), 10);
     });
 
     ipcMain.handle('next-tick', () => {

--- a/replay/backend/api/ReplayResources.ts
+++ b/replay/backend/api/ReplayResources.ts
@@ -13,16 +13,12 @@ export default class ReplayResources {
   } = {};
 
   public onResource(
-    data: Buffer,
     resourceMeta: {
       url: string;
       headers: any;
-      tabId: string;
-      statusCode: number;
-      type: string;
-    },
+    } & Omit<IReplayResource, 'headers'>,
   ) {
-    const { url, headers, statusCode, type, tabId } = resourceMeta;
+    const { url, headers, statusCode, type, tabId, data } = resourceMeta;
     this.initResource(url);
 
     const headerMap = new Map<string, string>();
@@ -54,15 +50,14 @@ export default class ReplayResources {
       headers.Location = resource.headers.get('location');
     }
 
-    let readable = new PassThrough();
+    let readable: PassThrough;
+
     if (resource.type === 'Document' && !isAllowedDocumentContentType(contentType)) {
-      readable.end(`<!DOCTYPE html><html><head></head><body></body></html>`);
+      readable = new PassThrough();
+      const doctype = await getDoctype(resource);
+      readable.end(`${doctype}<html><head></head><body></body></html>`);
     } else {
-      const encoding = resource.headers.get('content-encoding');
-      if (encoding) {
-        readable = readable.pipe(getDecodeStream(resource.data, encoding));
-      }
-      readable.end(resource.data);
+      readable = getResourceStream(resource);
     }
     return {
       data: readable,
@@ -78,6 +73,34 @@ export default class ReplayResources {
   }
 }
 
+function getResourceStream(resource: IReplayResource) {
+  const encoding = resource.headers.get('content-encoding');
+  let readable = new PassThrough({ autoDestroy: true });
+  if (encoding) {
+    readable = readable.pipe(getDecodeStream(resource.data[0], encoding));
+  }
+  readable.end(resource.data);
+  return readable;
+}
+
+async function getDoctype(resource: IReplayResource) {
+  if (resource.doctype !== undefined) return resource.doctype;
+  let str = '';
+  const readable = getResourceStream(resource);
+  for await (const chunk of readable) {
+    str += chunk.toString();
+    if (str.match(/<\s*html\s+/i)) break;
+  }
+  readable.destroy();
+
+  const htmlIndex = str.toLowerCase().indexOf('<html>');
+  if (htmlIndex !== -1) {
+    resource.doctype = str.substr(0, htmlIndex);
+  }
+  resource.doctype = '';
+  return resource.doctype;
+}
+
 function isAllowedDocumentContentType(contentType: string) {
   if (!contentType) return false;
   return (
@@ -85,7 +108,7 @@ function isAllowedDocumentContentType(contentType: string) {
   );
 }
 
-function getDecodeStream(buffer: Buffer, encoding: string) {
+function getDecodeStream(firstByte: number, encoding: string) {
   if (encoding === 'gzip' || encoding === 'x-gzip') {
     const zlibOptions = {
       flush: zlib.constants.Z_SYNC_FLUSH,
@@ -95,7 +118,7 @@ function getDecodeStream(buffer: Buffer, encoding: string) {
   }
 
   if (encoding === 'deflate' || encoding === 'x-deflate') {
-    if ((buffer[0] & 0x0f) === 0x08) {
+    if ((firstByte & 0x0f) === 0x08) {
       return zlib.createInflate();
     }
     return zlib.createInflateRaw();
@@ -108,6 +131,7 @@ function getDecodeStream(buffer: Buffer, encoding: string) {
 interface IReplayResource {
   data: Buffer;
   tabId: string;
+  doctype?: string;
   headers: Map<string, string>;
   type: string;
   statusCode: number;

--- a/replay/backend/api/ReplayTabState.ts
+++ b/replay/backend/api/ReplayTabState.ts
@@ -43,6 +43,10 @@ export default class ReplayTabState extends EventEmitter {
     return this.ticks[this.currentTickIdx];
   }
 
+  public get nextTick() {
+    return this.ticks[this.currentTickIdx + 1];
+  }
+
   public isReady = getResolvable<void>();
 
   private currentTickIdx = -1;
@@ -76,12 +80,12 @@ export default class ReplayTabState extends EventEmitter {
     return this.ticks.find(x => x.commandId === pageToLoad.commandId)?.playbarOffsetPercent ?? 0;
   }
 
-  public gotoPreviousTick() {
+  public transitionToPreviousTick() {
     const prevTickIdx = this.currentTickIdx > 0 ? this.currentTickIdx - 1 : this.currentTickIdx;
     return this.loadTick(prevTickIdx);
   }
 
-  public gotoNextTick() {
+  public transitionToNextTick() {
     const result = this.loadTick(this.currentTickIdx + 1);
     if (
       this.replayTime.close &&
@@ -203,6 +207,9 @@ export default class ReplayTabState extends EventEmitter {
       frontendMouseEvent = {
         pageX: mouseEvent.pageX,
         pageY: mouseEvent.pageY,
+        offsetX: mouseEvent.offsetX,
+        offsetY: mouseEvent.offsetY,
+        targetNodeId: mouseEvent.targetNodeId,
         buttons: mouseEvent.buttons,
         viewportHeight: this.viewportHeight,
         viewportWidth: this.viewportWidth,

--- a/replay/backend/api/index.ts
+++ b/replay/backend/api/index.ts
@@ -120,7 +120,8 @@ export default class ReplayApi {
     const tabId = headers['resource-tabid'];
     const url = headers['resource-url'];
 
-    this.resources.onResource(data, {
+    this.resources.onResource({
+      data,
       url,
       tabId,
       headers: JSON.parse(headers['resource-headers']),

--- a/replay/frontend/src/pages/playbar/index.vue
+++ b/replay/frontend/src/pages/playbar/index.vue
@@ -40,7 +40,6 @@ export default class Playbar extends Vue {
   private ticks: number[] = [];
   private currentTickValue = 0;
   private isPlaying = false;
-  private intervalTime = 50;
 
   private nextTimeout: number;
 
@@ -107,12 +106,14 @@ export default class Playbar extends Vue {
 
   private async playbackTick() {
     console.log('playback tick', this.currentTickValue);
-    this.currentTickValue = await ipcRenderer.invoke('next-tick');
+    const next = await ipcRenderer.invoke('next-tick');
+    this.currentTickValue = next.playbarOffset;
     if (this.currentTickValue === 100) {
       this.pause();
     }
     if (this.isPlaying) {
-      this.nextTimeout = setTimeout(() => this.playbackTick(), this.intervalTime) as any;
+      clearTimeout(this.nextTimeout);
+      this.nextTimeout = setTimeout(() => this.playbackTick(), next.millisToNextTick ?? 50) as any;
     }
   }
 
@@ -149,7 +150,7 @@ export default class Playbar extends Vue {
   private onValueChange(value: number) {
     // this is called when someone clicks, so pause the playback
     this.pause();
-    ipcRenderer.send('on-tick', value);
+    ipcRenderer.send('on-tick-drag', value);
   }
 
   private closestTick(pos: number) {

--- a/replay/shared/interfaces/ISaSession.ts
+++ b/replay/shared/interfaces/ISaSession.ts
@@ -28,16 +28,16 @@ export interface IMouseEvent {
   commandId: number;
   pageX: number;
   pageY: number;
+  offsetX: number;
+  offsetY: number;
   buttons: number;
   targetNodeId: number;
   event: number;
   timestamp: string;
 }
 
-export interface IFrontendMouseEvent {
-  pageX: number;
-  pageY: number;
-  buttons: number;
+export interface IFrontendMouseEvent
+  extends Omit<IMouseEvent, 'commandId' | 'timestamp' | 'event'> {
   viewportWidth: number;
   viewportHeight: number;
 }

--- a/session-state/api/index.ts
+++ b/session-state/api/index.ts
@@ -28,6 +28,13 @@ export async function createReplayServer(listenPort?: number): Promise<ISessionR
 
       const session = SessionDb.findWithRelated(lookupArgs);
 
+      if (!session) {
+        res.writeHead(404);
+        return res.end(
+          JSON.stringify({ message: "There aren't any stored sessions for this script." }),
+        );
+      }
+
       const sessionLoader = new SessionLoader(session.sessionDb, session.sessionState);
 
       let hasSentSession = false;
@@ -173,12 +180,7 @@ async function http2PushResources(res: http2.Http2ServerResponse, resources: any
             return;
           }
           pushResponse.stream.respond({ ':status': 200 });
-          if (resource.type === 'Document') {
-            // body won't be rendered from resource, so just send back empty
-            pushResponse.stream.end(Buffer.from(''), resolve);
-          } else {
-            pushResponse.stream.end(resource.data, resolve);
-          }
+          pushResponse.stream.end(resource.data, resolve);
         },
       );
     });

--- a/session-state/lib/SessionDb.ts
+++ b/session-state/lib/SessionDb.ts
@@ -158,6 +158,7 @@ export default class SessionDb {
     const sessionsDb = SessionsDb.find(dataLocation);
     if (!sessionId) {
       sessionId = sessionsDb.findLatestSessionId(scriptArgs);
+      if (!sessionId) return null;
     }
 
     const activeSession = SessionState.registry.get(sessionId);

--- a/session-state/lib/SessionsDb.ts
+++ b/session-state/lib/SessionsDb.ts
@@ -29,10 +29,11 @@ export default class SessionsDb {
     const { sessionName, scriptEntrypoint, scriptInstanceId } = script;
     if (sessionName && scriptInstanceId) {
       const sessionRecord = this.sessions.findByName(sessionName, scriptInstanceId);
-      return sessionRecord.id;
+      return sessionRecord?.id;
     }
     if (scriptEntrypoint) {
       const sessionRecords = this.sessions.findByScriptEntrypoint(scriptEntrypoint);
+      if (!sessionRecords.length) return undefined;
       return sessionRecords[0].id;
     }
   }

--- a/session-state/models/MouseEventsTable.ts
+++ b/session-state/models/MouseEventsTable.ts
@@ -10,6 +10,8 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
       ['commandId', 'INTEGER'],
       ['pageX', 'INTEGER'],
       ['pageY', 'INTEGER'],
+      ['offsetX', 'INTEGER'],
+      ['offsetY', 'INTEGER'],
       ['buttons', 'INTEGER'],
       ['targetNodeId', 'INTEGER'],
       ['relatedTargetNodeId', 'INTEGER'],
@@ -23,6 +25,8 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
       event,
       pageX,
       pageY,
+      offsetX,
+      offsetY,
       buttons,
       targetNodeId,
       relatedTargetNodeId,
@@ -34,6 +38,8 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
       commandId,
       pageX,
       pageY,
+      offsetX,
+      offsetY,
       buttons,
       targetNodeId,
       relatedTargetNodeId,
@@ -49,6 +55,8 @@ export interface IMouseEventRecord {
   commandId: number;
   pageX: number;
   pageY: number;
+  offsetX: number;
+  offsetY: number;
   buttons: number;
   targetNodeId?: number;
   relatedTargetNodeId?: number;

--- a/session-state/test/domRecorder.test.ts
+++ b/session-state/test/domRecorder.test.ts
@@ -29,7 +29,9 @@ function addMe() {
 </script>
 </body>`;
     });
-    const meta = await Core.createTab();
+    const meta = await Core.createTab({
+      humanEmulatorId: 'skipper',
+    });
     const core = Core.byTabId[meta.tabId];
     await core.goto(`${koaServer.baseUrl}/test1`);
     await core.waitForLoad('DomContentLoaded');
@@ -404,7 +406,17 @@ describe('basic Mouse Event tests', () => {
 
 </body>`;
     });
-    const meta = await Core.createTab();
+    const meta = await Core.createTab({
+      humanEmulatorId: 'basic',
+      viewport: {
+        height: 800,
+        width: 1000,
+        positionY: 0,
+        positionX: 0,
+        screenHeight: 800,
+        screenWidth: 1000,
+      },
+    });
     const core = Core.byTabId[meta.tabId];
     // @ts-ignore
     const tab = core.tab;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,6 +4588,11 @@ better-sqlite3@^7.1.1:
     prebuild-install "^5.3.3"
     tar "4.4.10"
 
+bezier-js@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/bezier-js/-/bezier-js-2.6.1.tgz#ed9c6ebfcb3214794ff213cf90ee8aac644ecf7f"
+  integrity sha512-jelZM33eNzcZ9snJ/5HqJLw3IzXvA8RFcBjkdOB8SDYyOvW8Y2tTosojAiBTnD1MhbHoWUYNbxUXxBl61TxbRg==
+
 bfj@^6.1.1:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"


### PR DESCRIPTION
This PR adds a new "human-like" emulator called "ghost". The work is based off the project at @Xetera/ghost-cursor. 

Ghost has the following attributes:
1) Moves mouse in a bezier curve to random points
2) Scrolls with similar curves
3) Clicks on randomly chosen point of each element
4) Types at 30-50 wpm rate chosen per run

Ghost is now the default human emulator. This will slow down users, but will decrease detection.

To make Ghost work, "Interactor" now passes an optional helper into human emulators with the following properties/functions:
- scrollOffset
- viewport
- mousePosition
- lookupBoundingRect(mouseposition)

To make the PR "usable", I had to add a few enhancements to replay:
1) Replay runs in realtime now
2) Replay handles page offsets based on looking at offsets of elements in 100 pixel increments. This helps make sure that clicks and mouse moves are over the correct elements

