### PR TITLE
fix: emulators were failing some double-agent tests

### DIFF
--- a/client/interfaces/ISecretAgentClass.ts
+++ b/client/interfaces/ISecretAgentClass.ts
@@ -4,7 +4,7 @@ import IUserProfile from "@secret-agent/core-interfaces/IUserProfile";
 import ICreateSecretAgentOptions from "./ICreateSecretAgentOptions";
 import ISecretAgent from "./ISecretAgent";
 
-export interface ISecretAgentConfigureOptions extends Pick<ICoreConfigureOptions, 'browserEmulatorIds'> {
+export interface ISecretAgentConfigureOptions extends ICoreConfigureOptions  {
   defaultRenderingOptions: IRenderingOption[];
   defaultUserProfile: IUserProfile;
 }

--- a/emulate-browsers/base/injected-scripts/MediaRecorder.isTypeSupported.ts
+++ b/emulate-browsers/base/injected-scripts/MediaRecorder.isTypeSupported.ts
@@ -1,7 +1,7 @@
 const { supportedCodecs } = args;
 
 if ((window as any).MediaRecorder) {
-  proxyFunction((window as any).MediaRecorder, 'isTypeSupported', (func, thisArg, type) => {
+  proxyFunction((window as any).MediaRecorder, 'isTypeSupported', (func, thisArg, [type]) => {
     if (type === undefined) return ProxyOverride.callOriginal;
     return supportedCodecs.includes(type);
   });

--- a/emulate-browsers/chrome-80/index.ts
+++ b/emulate-browsers/chrome-80/index.ts
@@ -46,7 +46,7 @@ export default class Chrome80 {
 
   public readonly userAgent: IUserAgent;
   public readonly networkInterceptorDelegate: INetworkInterceptorDelegate;
-  public locale = 'en-US,en;0.9';
+  public locale = 'en-US,en';
   public userProfile: IUserProfile;
 
   protected domOverrides = new DomOverridesBuilder();

--- a/emulate-browsers/chrome-80/index.ts
+++ b/emulate-browsers/chrome-80/index.ts
@@ -44,12 +44,23 @@ export default class Chrome80 {
     return polyfillSet?.canPolyfill(this);
   }
 
+  public set locale(value: string) {
+    this._locale = value;
+    this.hasCustomLocale = true;
+  }
+
+  public get locale() {
+    return this._locale;
+  }
+
   public readonly userAgent: IUserAgent;
   public readonly networkInterceptorDelegate: INetworkInterceptorDelegate;
-  public locale = 'en-US,en';
   public userProfile: IUserProfile;
 
   protected domOverrides = new DomOverridesBuilder();
+
+  private _locale = 'en-US,en';
+  private hasCustomLocale = false;
 
   constructor(userAgent?: IUserAgent) {
     this.userAgent = userAgent ?? pickRandom(agents);
@@ -62,7 +73,7 @@ export default class Chrome80 {
         dnsOverTlsConnection: Chrome80.dnsOverTlsConnectOptions,
       },
       http: {
-        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles),
+        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles, this.hasCustomLocale),
       },
     };
     this.loadDomOverrides();

--- a/emulate-browsers/chrome-83/index.ts
+++ b/emulate-browsers/chrome-83/index.ts
@@ -47,10 +47,21 @@ export default class Chrome83 {
   public readonly userAgent: IUserAgent;
   public readonly networkInterceptorDelegate: INetworkInterceptorDelegate;
 
-  public locale = 'en-US,en';
+  public set locale(value: string) {
+    this._locale = value;
+    this.hasCustomLocale = true;
+  }
+
+  public get locale() {
+    return this._locale;
+  }
+
   public userProfile: IUserProfile;
 
   protected domOverrides = new DomOverridesBuilder();
+
+  private _locale = 'en-US,en';
+  private hasCustomLocale = false;
 
   constructor(userAgent?: IUserAgent) {
     this.userAgent = userAgent ?? pickRandom(agents);
@@ -63,7 +74,7 @@ export default class Chrome83 {
         dnsOverTlsConnection: Chrome83.dnsOverTlsConnectOptions,
       },
       http: {
-        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles),
+        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles, this.hasCustomLocale),
       },
     };
     this.loadDomOverrides();

--- a/emulate-browsers/chrome-83/index.ts
+++ b/emulate-browsers/chrome-83/index.ts
@@ -47,7 +47,7 @@ export default class Chrome83 {
   public readonly userAgent: IUserAgent;
   public readonly networkInterceptorDelegate: INetworkInterceptorDelegate;
 
-  public locale = 'en-US,en;0.9';
+  public locale = 'en-US,en';
   public userProfile: IUserProfile;
 
   protected domOverrides = new DomOverridesBuilder();
@@ -152,9 +152,10 @@ export default class Chrome83 {
         videoCodecs: agentCodecs.videoSupport,
       });
       domOverrides.add('MediaRecorder.isTypeSupported', {
-        supportedCodecs: agentCodecs.audioSupport.recordingFormats.concat(
-          agentCodecs.videoSupport.recordingFormats,
-        ),
+        supportedCodecs: [
+          ...agentCodecs.audioSupport.recordingFormats,
+          ...agentCodecs.videoSupport.recordingFormats
+        ],
       });
       domOverrides.add('RTCRtpSender.getCapabilities', {
         videoCodecs: agentCodecs.webRtcVideoCodecs,

--- a/emulate-browsers/safari-13/index.ts
+++ b/emulate-browsers/safari-13/index.ts
@@ -50,7 +50,16 @@ export default class Safari13 {
 
   public readonly userAgent: IUserAgent;
   public readonly networkInterceptorDelegate: INetworkInterceptorDelegate;
-  public locale = 'en-US';
+
+  public set locale(value: string) {
+    this._locale = value;
+    this.hasCustomLocale = true;
+  }
+
+  public get locale() {
+    return this._locale;
+  }
+
   public cookieJar = new CookieJar(null, { rejectPublicSuffixes: false });
   // track sites per safari ITP that are considered to have "first party user interaction"
   public sitesWithUserInteraction: string[] = [];
@@ -81,6 +90,9 @@ export default class Safari13 {
   protected domOverrides = new DomOverridesBuilder();
   private _userProfile: IUserProfile;
 
+  private _locale = 'en-US';
+  private hasCustomLocale = false;
+
   private readonly userInteractionTrigger: {
     [site: string]: IResolvablePromise;
   } = {};
@@ -93,7 +105,7 @@ export default class Safari13 {
         emulatorProfileId: 'Safari13',
       },
       http: {
-        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles),
+        requestHeaders: modifyHeaders.bind(this, this.userAgent, headerProfiles, this.hasCustomLocale),
         cookieHeader: this.getCookieHeader.bind(this),
         onSetCookie: this.setCookie.bind(this),
         onOriginHasFirstPartyInteraction: this.documentHasUserActivity.bind(this),

--- a/website/docs/BasicInterfaces/SecretAgent.md
+++ b/website/docs/BasicInterfaces/SecretAgent.md
@@ -317,6 +317,10 @@ Update existing settings.
   - defaultRenderingOptions `string[]` defaults to `[All]`. Controls enabled browser rendering features.
   - defaultUserProfile `IUserProfile`. Define user cookies, session, and more.
   - browserEmulatorIds `string[]`. Ids of [BrowserEmulators](../advanced/browser-emulators) to prewarm.
+  - maxConcurrentSessionsCount `number`. Limit number of concurrent sessions.
+  - localProxyPortStart `number`. Port to use for the internal MitM proxy.
+  - replayServerPort `number`. Port to use for serving Replay session data.
+  - sessionsDir `string`. Directory for storing session data.
 
 #### **Returns**: `Promise`
 

--- a/website/docs/Overview/Configuration.md
+++ b/website/docs/Overview/Configuration.md
@@ -22,7 +22,7 @@ Configurable via `Core.configure()`.
 
 ### Replay Session Port <div class="specs"><i>Core</i></div>
 
-Configures the port the Man-In-the-Middle server will listen on locally. This server will correct headers and TLS signatures sent by requests to properly emulate the desired browser engine. Default port is `0`, which will find an open port locally.
+Configures the port Replay uses to serve Session data.
 
 Configurable via [`Core.configure()`](#core-configure) or [`Core.prewarm()`](#core-prewarm).
 


### PR DESCRIPTION
- Quality score is removed from locale property of emulators
- accept-language header bypasses using default values from DA json if emulator's locale has been set
- MediaRecorder.isTypeSupported correctly accepts the type arg
- SecretAgent.configure now accepts all properties of Core.configure
- Updated website docs