### PR TITLE
Http2 bug fix

### DIFF
--- a/emulate-browsers/base/test/iframe.test.ts
+++ b/emulate-browsers/base/test/iframe.test.ts
@@ -26,6 +26,27 @@ test('should have a chrome object on iframes', async () => {
   expect(frameType).toBe('object');
 });
 
+test('should not break toString across frames', async () => {
+  const page = await createPage();
+
+  const toStrings = await page.evaluate(`(() => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+
+  const contentWindow = iframe.contentWindow;
+  const fnCallWithFrame = contentWindow.Function.prototype.toString.call(Function.prototype.toString);
+  const fnToString = Function.toString + '';
+
+  return {
+    fnToString,
+    fnCallWithFrame
+  }
+})();`);
+
+  const { fnToString, fnCallWithFrame } = toStrings as any;
+  expect(fnToString).toBe(fnCallWithFrame);
+});
+
 test('should not break iframe functions', async () => {
   const page = await createPage();
 

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -104,7 +104,7 @@ export default class HeadersHandler {
       if (nodeCommon._checkInvalidHeaderChar(value)) continue;
 
       if (Array.isArray(value)) {
-        if (singleValueHttp2Headers.has(key)) {
+        if (singleValueHttp2Headers.has(key.toLowerCase())) {
           headers[canonizedKey] = value[0];
         } else {
           headers[canonizedKey] = [...value];

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -113,11 +113,11 @@ export class BrowserContext
     }
   }
 
-  onWorkerAttached(cdpSession: CDPSession, worker: Worker, pageTargetId: string) {
+  onWorkerAttached(cdpSession: CDPSession, workerTargetId: string, pageTargetId: string) {
     this.subscribeToDevtoolsMessages(cdpSession, {
       sessionType: 'worker' as const,
       pageTargetId,
-      workerTargetId: worker.id,
+      workerTargetId,
     });
   }
 

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -288,6 +288,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     const cdpSession = this.cdpSession.connection.getSession(sessionId);
 
     if (targetInfo.type === 'service_worker' || targetInfo.type === 'worker') {
+      this.browserContext.onWorkerAttached(cdpSession, targetInfo.targetId, this.targetId);
       const worker = new Worker(
         this.browserContext,
         this.networkManager,
@@ -295,7 +296,6 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
         this.logger,
         targetInfo,
       );
-      this.browserContext.onWorkerAttached(cdpSession, worker, this.targetId);
       const targetId = targetInfo.targetId;
       this.workersById.set(targetId, worker);
 


### PR DESCRIPTION
Fixes bugs from #111 

- capitalized http2 headers cause us to copy a header 2x that can only exist once in an http2 response
- mitm is checking certificates for validity and golang doesn't like the Commodo certs, so throwing up on a mac. Turned off certificate checking by default, even though long term, this creates a hole we'll want to plug