### PR TITLE
Emulator Fixes

### DIFF
--- a/emulate-browsers/base/test/iframe.test.ts
+++ b/emulate-browsers/base/test/iframe.test.ts
@@ -26,6 +26,27 @@ test('should have a chrome object on iframes', async () => {
   expect(frameType).toBe('object');
 });
 
+test('should not break toString across frames', async () => {
+  const page = await createPage();
+
+  const toStrings = await page.evaluate(`(() => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+
+  const contentWindow = iframe.contentWindow;
+  const fnCallWithFrame = contentWindow.Function.prototype.toString.call(Function.prototype.toString);
+  const fnToString = Function.toString + '';
+
+  return {
+    fnToString,
+    fnCallWithFrame
+  }
+})();`);
+
+  const { fnToString, fnCallWithFrame } = toStrings as any;
+  expect(fnToString).toBe(fnCallWithFrame);
+});
+
 test('should not break iframe functions', async () => {
   const page = await createPage();
 

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -113,11 +113,11 @@ export class BrowserContext
     }
   }
 
-  onWorkerAttached(cdpSession: CDPSession, worker: Worker, pageTargetId: string) {
+  onWorkerAttached(cdpSession: CDPSession, workerTargetId: string, pageTargetId: string) {
     this.subscribeToDevtoolsMessages(cdpSession, {
       sessionType: 'worker' as const,
       pageTargetId,
-      workerTargetId: worker.id,
+      workerTargetId,
     });
   }
 

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -288,6 +288,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     const cdpSession = this.cdpSession.connection.getSession(sessionId);
 
     if (targetInfo.type === 'service_worker' || targetInfo.type === 'worker') {
+      this.browserContext.onWorkerAttached(cdpSession, targetInfo.targetId, this.targetId);
       const worker = new Worker(
         this.browserContext,
         this.networkManager,
@@ -295,7 +296,6 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
         this.logger,
         targetInfo,
       );
-      this.browserContext.onWorkerAttached(cdpSession, worker, this.targetId);
       const targetId = targetInfo.targetId;
       this.workersById.set(targetId, worker);
 


### PR DESCRIPTION
Fixes 2 small bugs:
1) creepjs #108 was detecting a diff in toString across frames
2) worker devtools api calls weren't tracking to the correct session db during creation