### PR TITLE
feat(client): export required enums and consts

### DIFF
--- a/client/index.mjs
+++ b/client/index.mjs
@@ -1,12 +1,5 @@
 import client from './index.js';
 
-export const {
-  IAgentCreateOptions,
-  ICoreConnectionOptions,
-  Handler,
-  Agent,
-  LocalCoreConnection,
-  RemoteCoreConnection,
-} = client;
+export * from './index.js';
 
 export default client.default;

--- a/client/index.ts
+++ b/client/index.ts
@@ -1,6 +1,15 @@
 // setup must go first
 import './lib/SetupAwaitedHandler';
-
+import { BlockedResourceType } from '@secret-agent/core-interfaces/ITabOptions';
+import { KeyboardKeys } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
+import ResourceType from '@secret-agent/core-interfaces/ResourceType';
+import { InteractionCommand, MouseButton } from '@secret-agent/core-interfaces/IInteractions';
+import { Node, XPathResult } from '@secret-agent/core-interfaces/AwaitedDom';
+import {
+  LocationStatus,
+  LocationTrigger,
+  PipelineStatus,
+} from '@secret-agent/core-interfaces/Location';
 import IAgentCreateOptions from './interfaces/IAgentCreateOptions';
 import ICoreConnectionOptions from './interfaces/ICoreConnectionOptions';
 import Handler from './lib/Handler';
@@ -11,10 +20,20 @@ import LocalCoreConnection from './connections/LocalCoreConnection';
 export default new Agent();
 
 export {
-  IAgentCreateOptions,
-  ICoreConnectionOptions,
   Handler,
   Agent,
   RemoteCoreConnection,
   LocalCoreConnection,
+  InteractionCommand,
+  MouseButton,
+  ResourceType,
+  KeyboardKeys,
+  BlockedResourceType,
+  IAgentCreateOptions,
+  ICoreConnectionOptions,
+  Node,
+  XPathResult,
+  LocationStatus,
+  LocationTrigger,
+  PipelineStatus,
 };

--- a/full-client/index.mjs
+++ b/full-client/index.mjs
@@ -1,11 +1,5 @@
 import fullClient from './index.js';
 
-export const {
-  IAgentCreateOptions,
-  ICoreConnectionOptions,
-  Handler,
-  Agent,
-  RemoteCoreConnection,
-} = fullClient;
+export * from './index.js';
 
 export default fullClient.default;

--- a/full-client/index.ts
+++ b/full-client/index.ts
@@ -1,12 +1,5 @@
 import 'source-map-support/register';
-import agent, {
-  Handler,
-  Agent,
-  IAgentCreateOptions,
-  ICoreConnectionOptions,
-  RemoteCoreConnection,
-  LocalCoreConnection,
-} from '@secret-agent/client';
+import agent, { ICoreConnectionOptions, LocalCoreConnection } from '@secret-agent/client';
 import Core from '@secret-agent/core';
 
 LocalCoreConnection.create = (options: ICoreConnectionOptions) => {
@@ -14,5 +7,5 @@ LocalCoreConnection.create = (options: ICoreConnectionOptions) => {
   return new LocalCoreConnection(options, coreServerConnection);
 };
 
-export { IAgentCreateOptions, ICoreConnectionOptions, Handler, Agent, RemoteCoreConnection };
+export * from '@secret-agent/client';
 export default agent;

--- a/session-state/api/SessionLoader.ts
+++ b/session-state/api/SessionLoader.ts
@@ -141,7 +141,7 @@ export default class SessionLoader extends EventEmitter {
   public checkState() {
     if (!this.sessionState || this.session.closeDate) return;
     const scriptState = this.sessionState.checkForResponsive();
-    const lastState = { ...(this.lastScriptState ?? {}) };
+    const lastState = <IScriptState>{ ...(this.lastScriptState ?? {}) };
 
     this.lastScriptState = scriptState;
     if (


### PR DESCRIPTION
This PR adds exports to the client libs for constants and enums that you might want to pass into our apis.