### PR TITLE
Bug fixes: isVisible fix, scroll below 0 fix, nested commands fix

### DIFF
--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -141,6 +141,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
       this.waitForLocation,
       this.waitForNewTab,
       this.waitForResource,
+      // DO NOT ADD waitForReady
     ]);
   }
 
@@ -226,7 +227,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     let finalResourceId = resourceid;
     // if no resource id, this is a request for the default resource (page)
     if (!resourceid) {
-      await this.waitForLoad('READY');
+      await this.locationTracker.waitFor('READY');
       finalResourceId = await this.locationTracker.waitForLocationResourceId();
     }
 
@@ -294,7 +295,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
   ): Promise<IExecJsPathResult<T>> {
     // if nothing loaded yet, return immediately
     if (!this.navigationTracker.top) return null;
-    await this.waitForLoad('READY');
+    await this.locationTracker.waitFor('READY');
     return this.domEnv.execJsPath<T>(jsPath, propertiesToExtract);
   }
 
@@ -307,12 +308,12 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
   }
 
   public async getLocationHref(): Promise<string> {
-    await this.waitForLoad('READY');
+    await this.locationTracker.waitFor('READY');
     return this.domEnv.locationHref();
   }
 
   public async getCookies(): Promise<ICookie[]> {
-    await this.waitForLoad('READY');
+    await this.locationTracker.waitFor('READY');
     return await this.session.browserContext.getCookies(
       new URL(this.puppetPage.mainFrame.securityOrigin ?? this.puppetPage.mainFrame.url),
     );
@@ -323,7 +324,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     value: string,
     options?: ISetCookieOptions,
   ): Promise<boolean> {
-    await this.waitForLoad('READY');
+    await this.locationTracker.waitFor('READY');
     await this.session.browserContext.addCookies([
       {
         name,
@@ -431,7 +432,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     return this.waitForDom(jsPath, options);
   }
 
-  public waitForLoad(status: ILocationStatus | 'READY', options?: IWaitForOptions): Promise<void> {
+  public waitForLoad(status: ILocationStatus, options?: IWaitForOptions): Promise<void> {
     return this.locationTracker.waitFor(status, options);
   }
 

--- a/emulate-humans/ghost/index.ts
+++ b/emulate-humans/ghost/index.ts
@@ -252,6 +252,7 @@ export default class HumanEmulatorGhost {
       const scrollX = shouldScrollX ? Math.round(point.x) : startScrollOffset.x;
       const scrollY = shouldScrollY ? Math.round(point.y) : startScrollOffset.y;
       if (scrollY === lastPoint.y && scrollX === lastPoint.x) continue;
+      if (scrollY < 0 || scrollX < 0) continue;
 
       point = {
         x: scrollX,

--- a/injected-scripts/scripts/jsPath.ts
+++ b/injected-scripts/scripts/jsPath.ts
@@ -307,7 +307,12 @@ class ObjectAtPath {
       const rect = this.boundingClientRect;
       const hasDimensions = rect.width && rect.height;
       if (!hasDimensions) return false;
-      return rect.bottom < window.innerHeight && rect.right < window.innerWidth;
+      return (
+        rect.top > 0 &&
+        rect.bottom < window.innerHeight &&
+        rect.left > 0 &&
+        rect.right < window.innerWidth
+      );
     }
     return false;
   }


### PR DESCRIPTION
This PR has 3 small bug fixes:

1. Nesting commands in the new core/Tab structure causing issues double-counting commands
2. elementIsVisible was not properly checking if elements were "on screen"
3. ghost human emulator causing a lot of excess scrolls that were trying to scroll to negative positions (ie, -26px)