### PR TITLE
fix(client): error handling for session connect

### DIFF
--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -22,20 +22,17 @@ export default class ScriptInstance {
   public launchReplay(sessionName: string, coreSession: Promise<CoreSession>): void {
     // eslint-disable-next-line global-require
     const { replay } = require('@secret-agent/replay/index');
-    coreSession
-      .then(session => {
-        return replay({
-          scriptInstanceId: this.id,
-          scriptStartDate: this.startDate,
-          sessionsDataLocation: session.sessionsDataLocation,
-          replayApiServer: session.replayApiServer,
-          sessionId: session.sessionId,
-          sessionName,
-        });
-      })
-      .catch(err => {
-        log.warn('Unable to connect to CoreTab', { error: err, sessionId: this.id });
+    // eslint-disable-next-line promise/catch-or-return
+    coreSession.then(session => {
+      return replay({
+        scriptInstanceId: this.id,
+        scriptStartDate: this.startDate,
+        sessionsDataLocation: session.sessionsDataLocation,
+        replayApiServer: session.replayApiServer,
+        sessionId: session.sessionId,
+        sessionName,
       });
+    });
   }
 
   public generateSessionName(name: string, shouldCleanName = true): string {

--- a/client/test/basic.test.ts
+++ b/client/test/basic.test.ts
@@ -44,7 +44,7 @@ describe('basic SecretAgent tests', () => {
         });
       }
     }
-    const agent = new Agent({ coreConnection: new Piper() });
+    const agent = await new Agent({ coreConnection: new Piper() });
     await agent.close();
 
     const outgoingCommands = outgoing.mock.calls;


### PR DESCRIPTION
This PR fixes two issues:
1 - don't connect to an agent just to disconnect
2 - handle capturing errors connecting and throw them only when a connection is requested (this is using our funky delayed-connect process that allows a default agent to exist without connecting until it's actually used)