### PR TITLE
Convert RemoteServer/Client and Replay API to use Web Sockets

### DIFF
--- a/client/connections/CoreClientConnection.ts
+++ b/client/connections/CoreClientConnection.ts
@@ -19,7 +19,7 @@ export default abstract class CoreClientConnection {
   public readonly commandQueue: CoreCommandQueue;
   public options: ICoreConnectionOptions;
 
-  protected connectPromise: Promise<Error | null>;
+  private connectPromise: Promise<Error | null>;
 
   private coreSessions: CoreSessions;
   private readonly pendingRequestsById = new Map<string, IResolvablePromiseWithId>();

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "@secret-agent/core-interfaces": "1.2.0-alpha.4",
     "@secret-agent/replay": "1.2.0-alpha.4",
     "awaited-dom": "^1.1.10",
-    "json-socket": "^0.3.0",
+    "ws": "^7.4.2",
     "uuid": "^8.1.0"
   },
   "devDependencies": {

--- a/commons/SqliteTable.ts
+++ b/commons/SqliteTable.ts
@@ -1,4 +1,4 @@
-import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
+import type { Database as SqliteDatabase, Statement } from 'better-sqlite3';
 
 type SqliteTypes = 'INTEGER' | 'TEXT' | 'BLOB';
 type IRecord = (string | number | Buffer)[];
@@ -35,6 +35,10 @@ export default abstract class SqliteTable<T> {
     const pendingRecords = this.pendingInserts.map(x => this.insertToObject(x));
     this.lastSubscriptionPublishTime = new Date();
     process.nextTick(callbackFn, this.all().concat(pendingRecords));
+  }
+
+  public unsubscribe(): void {
+    this.insertCallbackFn = null;
   }
 
   public flush(): void {
@@ -81,6 +85,7 @@ export default abstract class SqliteTable<T> {
   }
 
   private publishPendingRecords(): void {
+    if (!this.insertCallbackFn) return;
     const records = [...this.insertSubscriptionRecords];
     this.insertSubscriptionRecords.length = 0;
     this.lastSubscriptionPublishTime = new Date();

--- a/commons/package.json
+++ b/commons/package.json
@@ -4,7 +4,9 @@
   "description": "Common utilities for Secret Agent",
   "main": "index.js",
   "dependencies": {
-    "@secret-agent/core-interfaces": "1.2.0-alpha.4",
-    "better-sqlite3": "^7.1.2"
+    "@secret-agent/core-interfaces": "1.2.0-alpha.4"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^5.4.1"
   }
 }

--- a/core/lib/RemoteServer.ts
+++ b/core/lib/RemoteServer.ts
@@ -1,29 +1,36 @@
-import JsonSocket from 'json-socket';
-import Net, { AddressInfo, NetConnectOpts } from 'net';
+import { AddressInfo, ListenOptions } from 'net';
+import WebSocket from 'ws';
 import Log from '@secret-agent/commons/Logger';
+import * as http from 'http';
+import * as url from 'url';
 import Core from '../index';
 
 const { log } = Log(module);
 
 export default class RemoteServer {
   public get port() {
-    return (this.netServer.address() as AddressInfo).port;
+    return (this.httpServer.address() as AddressInfo).port;
   }
 
-  private readonly netServer: Net.Server;
-  private netConnectionsById: { [id: string]: Net.Socket } = {};
-  private lastConnectionId = 0;
+  public get hasConnections() {
+    return this.wsServer.clients.size > 0;
+  }
+
+  private readonly wsServer: WebSocket.Server;
+  private readonly httpServer: http.Server;
 
   constructor() {
-    this.netServer = Net.createServer(this.handleNetConnection.bind(this));
+    this.httpServer = new http.Server();
+    this.wsServer = new WebSocket.Server({ server: this.httpServer });
+    this.wsServer.on('connection', this.handleConnection);
   }
 
-  public listen(options: NetConnectOpts): Promise<AddressInfo> {
+  public listen(options: ListenOptions): Promise<AddressInfo> {
     return new Promise<AddressInfo>((resolve, reject) => {
-      this.netServer.on('error', reject);
-      this.netServer.listen(options, () => {
-        this.netServer.off('error', reject);
-        resolve(this.netServer.address() as AddressInfo);
+      this.httpServer.on('error', reject);
+      this.httpServer.listen(options, () => {
+        this.httpServer.off('error', reject);
+        resolve(this.httpServer.address() as AddressInfo);
       });
     });
   }
@@ -31,8 +38,8 @@ export default class RemoteServer {
   public close(): Promise<void> {
     return new Promise<void>(resolve => {
       try {
-        const promises = Object.values(this.netConnectionsById).map(netSocket => netSocket.end());
-        this.netServer.close(async () => {
+        const promises = [...this.wsServer.clients].map(ws => ws.terminate());
+        this.httpServer.close(async () => {
           await Promise.all(promises);
           setImmediate(resolve);
         });
@@ -46,29 +53,30 @@ export default class RemoteServer {
     });
   }
 
-  private handleNetConnection(netConnection: Net.Socket): void {
-    const jsonSocket = new JsonSocket(netConnection);
-    const coreConnection = Core.addConnection();
-    const id = (this.lastConnectionId += 1).toString();
+  private handleConnection(ws: WebSocket, request: http.IncomingMessage): void {
+    const requestUrl = url.parse(request.url);
 
-    this.netConnectionsById[id] = netConnection;
-
-    coreConnection.on('message', payload => {
-      jsonSocket.sendMessage(payload, error => {
-        if (error) {
-          log.error('Error sending message', {
-            error,
-            sessionId: null,
-          });
-          jsonSocket.destroy(error);
-        }
+    if (requestUrl.pathname === '/') {
+      const coreConnection = Core.addConnection();
+      ws.on('message', message => {
+        const payload = JSON.parse(message.toString());
+        return coreConnection.handleRequest(payload);
       });
-    });
-    jsonSocket.on('message', payload => coreConnection.handleRequest(payload));
 
-    jsonSocket.on('end', () => {
-      delete this.netConnectionsById[id];
-      coreConnection.disconnect();
-    });
+      coreConnection.on('message', payload => {
+        const json = JSON.stringify(payload);
+        ws.send(json, error => {
+          if (error) {
+            log.error('Error sending message', {
+              error,
+              sessionId: null,
+            });
+            ws.close(500, JSON.stringify({ message: error.message }));
+          }
+        });
+      });
+    } else if (requestUrl.pathname === '/replay') {
+      // tbd:
+    }
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.24.0",
     "regenerator-runtime": "^0.13.7",
     "typeson": "^5.18.2",
-    "json-socket": "^0.3.0",
+    "ws": "^7.4.2",
     "typeson-registry": "^1.0.0-alpha.38",
     "uuid": "^8.1.0"
   },

--- a/core/test/remote.test.ts
+++ b/core/test/remote.test.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   httpServer = await Helpers.runHttpServer({ onlyCloseOnFinal: true });
   remoteServer = new RemoteServer();
   Helpers.onClose(() => remoteServer.close(), true);
-  await remoteServer.listen({ port: 0, host: '127.0.0.1' });
+  await remoteServer.listen({ port: 0 });
 });
 afterAll(Helpers.afterAll);
 afterEach(Helpers.afterEach);
@@ -20,7 +20,7 @@ describe('basic remote connection tests', () => {
     // bind a core server to core
 
     const handler = new Handler({
-      host: `127.0.0.1:${remoteServer.port}`,
+      host: `ws://127.0.0.1:${remoteServer.port}`,
     });
     const handlerAgent = await handler.createAgent();
     const sessionId = await handlerAgent.sessionId;

--- a/replay/backend/api/index.ts
+++ b/replay/backend/api/index.ts
@@ -1,5 +1,4 @@
-import * as http2 from 'http2';
-import { ClientHttp2Stream, IncomingHttpHeaders, IncomingHttpStatusHeader } from 'http2';
+import * as WebSocket from 'ws';
 import { ChildProcess, spawn } from 'child_process';
 import * as Path from 'path';
 import ISaSession from '~shared/interfaces/ISaSession';
@@ -13,7 +12,7 @@ export default class ReplayApi {
   public static serverProcess: ChildProcess;
   public static serverStartPath: string;
   public static nodePath: string;
-  private static sessions = new Set<http2.ClientHttp2Session>();
+  private static websockets = new Set<WebSocket>();
   private static localApiHost: string;
 
   public readonly saSession: ISaSession;
@@ -37,7 +36,7 @@ export default class ReplayApi {
   private replayTime: ReplayTime;
   private readonly isReadyResolvable = getResolvable<void>();
 
-  private readonly http2Session: http2.ClientHttp2Session;
+  private readonly websocket: WebSocket;
 
   private resources: ReplayResources = new ReplayResources();
 
@@ -49,40 +48,33 @@ export default class ReplayApi {
       id: replay.sessionId,
     } as any;
 
-    this.http2Session = http2.connect(apiHost, () => console.log('Reply API connected'));
+    const headers: any = {};
+    for (const [key, value] of Object.entries({
+      'data-location': this.saSession.dataLocation,
+      'session-name': this.saSession.name,
+      'session-id': this.saSession.id,
+      'script-instance-id': this.saSession.scriptInstanceId,
+      'script-entrypoint': this.saSession.scriptEntrypoint,
+    })) {
+      if (value) headers[key] = value;
+    }
 
-    ReplayApi.sessions.add(this.http2Session);
-    this.http2Session.on('close', () => {
-      ReplayApi.sessions.delete(this.http2Session);
-      this.http2Session.unref();
-      console.log('Http2 Session closed');
+    this.websocket = new WebSocket(apiHost, {
+      headers,
     });
-    this.http2Session.on('stream', this.onStream.bind(this));
 
-    const request = this.http2Session
-      .request(
-        {
-          ':path': `/`,
-          'data-location': this.saSession.dataLocation,
-          'session-name': this.saSession.name,
-          'session-id': this.saSession.id,
-          'script-instance-id': this.saSession.scriptInstanceId,
-          'script-entrypoint': this.saSession.scriptEntrypoint,
-        },
-        { waitForTrailers: true },
-      )
-      .on('response', async headers => {
-        const status = headers[':status'];
-        if (status !== 200) {
-          const data = await streamToJson<{ message: string }>(request);
-          this.isReadyResolvable.reject(new Error(data.message ?? 'Unexpected Error'));
-        }
-      })
-      .on('trailers', trailers => {
-        console.log('Got Replay API Trailer', trailers);
-        this.hasAllData = true;
-        for (const tab of this.tabs) tab.hasAllData = true;
-      });
+    this.websocket.once('open', () => {
+      this.isReadyResolvable.resolve();
+      this.websocket.off('error', this.isReadyResolvable.reject);
+    });
+    this.websocket.once('error', this.isReadyResolvable.reject);
+
+    ReplayApi.websockets.add(this.websocket);
+    this.websocket.on('close', () => {
+      ReplayApi.websockets.delete(this.websocket);
+      console.log('Ws Session closed');
+    });
+    this.websocket.on('message', this.onMessage.bind(this));
   }
 
   public getResource(url: string): Promise<IReplayHttpResource> {
@@ -92,59 +84,43 @@ export default class ReplayApi {
   public close(): void {
     if (this.tabs.some(x => x.isActive)) return;
 
-    this.http2Session.removeAllListeners();
-    this.http2Session.destroy();
-    ReplayApi.sessions.delete(this.http2Session);
+    this.websocket.close();
+    ReplayApi.websockets.delete(this.websocket);
   }
 
   public getTab(tabId: string): ReplayTabState {
     return this.tabs.find(x => x.tabId === tabId);
   }
 
-  private async onStream(
-    stream: ClientHttp2Stream,
-    headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
-  ): Promise<void> {
-    const path = headers[':path'];
+  private async onMessage(messageData: WebSocket.Data): Promise<void> {
+    const { event, data } = parseJSON(messageData);
 
-    if (path === '/session') {
-      const data = await streamToJson<ISaSession>(stream);
+    if (event === 'trailer') {
+      this.hasAllData = true;
+      for (const tab of this.tabs) tab.hasAllData = true;
+      console.log('All data received', data);
+      return;
+    }
+
+    if (event === 'error') {
+      this.isReadyResolvable.reject(data.message);
+      return;
+    }
+
+    if (event === 'session') {
       this.onSession(data);
       return;
     }
 
     // don't load api data until the session is ready
     await this.isReady;
-
-    if (path === '/resource') {
-      const data = await readStream(stream);
-      this.onResource(data, headers as any);
-    } else {
-      const json = await streamToJson(stream);
-      this.onApiFeed(path, json);
-    }
+    this.onApiFeed(event, data);
   }
 
-  private onResource(data: Buffer, headers: { [key: string]: string }): void {
-    const type = headers['resource-type'];
-    const statusCode = parseInt(headers['resource-status-code'] ?? '404', 10);
-    const tabId = headers['resource-tabid'];
-    const url = headers['resource-url'];
-
-    this.resources.onResource({
-      data,
-      url,
-      tabId,
-      headers: JSON.parse(headers['resource-headers']),
-      statusCode,
-      type,
-    });
-  }
-
-  private onApiFeed(dataPath: string, data: any) {
-    console.log('Replay Api Feed', dataPath);
+  private onApiFeed(eventName: string, data: any) {
+    console.log('Replay Api Feed', eventName);
     const tabsWithChanges = new Set<ReplayTabState>();
-    if (dataPath === '/script-state') {
+    if (eventName === 'script-state') {
       console.log('ScriptState', data);
       const closeDate = data.closeDate ? new Date(data.closeDate) : null;
       this.replayTime.update(closeDate);
@@ -168,11 +144,13 @@ export default class ReplayApi {
           this.tabs.push(tab);
         }
         tabsWithChanges.add(tab);
-        if (dataPath === '/dom-changes') tab.loadDomChange(event);
-        else if (dataPath === '/commands') tab.loadCommand(event);
-        else if (dataPath === '/mouse-events') tab.loadPageEvent('mouse', event);
-        else if (dataPath === '/focus-events') tab.loadPageEvent('focus', event);
-        else if (dataPath === '/scroll-events') tab.loadPageEvent('scroll', event);
+
+        if (eventName === 'resources') this.resources.onResource(event);
+        else if (eventName === 'dom-changes') tab.loadDomChange(event);
+        else if (eventName === 'commands') tab.loadCommand(event);
+        else if (eventName === 'mouse-events') tab.loadPageEvent('mouse', event);
+        else if (eventName === 'focus-events') tab.loadPageEvent('focus', event);
+        else if (eventName === 'scroll-events') tab.loadPageEvent('scroll', event);
       }
     }
     for (const tab of tabsWithChanges) tab.sortTicks();
@@ -203,9 +181,9 @@ export default class ReplayApi {
     console.log(
       'Shutting down Replay API. Process? %s. Open Sessions: %s',
       !!ReplayApi.serverProcess,
-      ReplayApi.sessions.size,
+      ReplayApi.websockets.size,
     );
-    for (const session of ReplayApi.sessions) session.destroy();
+    for (const socket of ReplayApi.websockets) socket.terminate();
     if (ReplayApi.serverProcess) ReplayApi.serverProcess.kill();
   }
 
@@ -256,19 +234,21 @@ export default class ReplayApi {
       });
     });
 
-    this.localApiHost = `http://localhost:${await promise}`;
+    this.localApiHost = `ws://localhost:${await promise}`;
     return child;
   }
 }
 
-async function readStream(stream: http2.Http2Stream): Promise<Buffer> {
-  const data: Buffer[] = [];
-  for await (const chunk of stream) data.push(chunk);
-  return Buffer.concat(data);
-}
-
-async function streamToJson<T>(stream: http2.Http2Stream): Promise<T> {
-  const data = await readStream(stream);
-  const json = data.toString('utf8');
-  return JSON.parse(json);
+function parseJSON(data: WebSocket.Data) {
+  return JSON.parse(data.toString(), (key, value) => {
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      value.type === 'Buffer' &&
+      Array.isArray(value.data)
+    ) {
+      return Buffer.from(value.data);
+    }
+    return value;
+  });
 }

--- a/replay/package.json
+++ b/replay/package.json
@@ -62,6 +62,7 @@
     "progress": "^2.0.3",
     "source-map-support": "^0.5.19",
     "tar-fs": "^2.1.0",
+    "ws": "^7.4.2",
     "uuid": "^8.3.1"
   },
   "devDependencies": {

--- a/session-state/api/index.ts
+++ b/session-state/api/index.ts
@@ -1,257 +1,50 @@
-import * as http2 from 'http2';
+import * as http from 'http';
+import WebSocket from 'ws';
 import Logger from '@secret-agent/commons/Logger';
 import { AddressInfo } from 'net';
-import * as eventUtils from '@secret-agent/commons/eventUtils';
-import IRegisteredEventListener from '@secret-agent/core-interfaces/IRegisteredEventListener';
-import { createPromise } from '@secret-agent/commons/utils';
-import SessionLoader from './SessionLoader';
-import SessionDb from '../lib/SessionDb';
 import ISessionReplayServer from '../interfaces/ISessionReplayServer';
+import sendSessionOverWs from './sendSessionOverWs';
 
 const { log } = Logger(module);
 
 export async function createReplayServer(listenPort?: number): Promise<ISessionReplayServer> {
-  const activeClients = new Map<
-    string,
-    { stream: http2.ServerHttp2Stream; pendingPushes: Promise<any>[] }
-  >();
-  const server = http2.createServer();
+  const completionPromiseBySocket = new WeakMap<WebSocket, Promise<void>>();
+  const server = await startServer(listenPort);
 
+  const ws = new WebSocket.Server({ server });
+  ws.on('connection', async (webSocket, request) => {
+    const isComplete = sendSessionOverWs(webSocket, request);
+    completionPromiseBySocket.set(webSocket, isComplete);
+    webSocket.once('close', () => completionPromiseBySocket.delete(webSocket));
+    await isComplete;
+    if (webSocket.readyState === WebSocket.OPEN) webSocket.close();
+  });
+
+  const port = (server.address() as AddressInfo).port;
+  return {
+    async close(waitForOpenConnections = false): Promise<void> {
+      log.info('ReplayServer.closeSessions', { waitForOpenConnections, sessionId: null });
+      for (const webSocket of ws.clients) {
+        if (waitForOpenConnections) {
+          await completionPromiseBySocket.get(webSocket);
+        }
+        if (webSocket.readyState === WebSocket.OPEN) webSocket.terminate();
+      }
+      server.unref().close();
+    },
+    url: `ws://127.0.0.1:${port}`,
+    port,
+  };
+}
+
+async function startServer(port: number): Promise<http.Server> {
+  const server = http.createServer();
   server.on('error', err => {
     log.error('Replay server error', {
       error: err,
       sessionId: null,
     });
   });
-
-  server.on('stream', (stream, headers) => {
-    const pendingPushes: Promise<any>[] = [];
-    const sessionId = headers['session-id'] as string;
-
-    activeClients.set(sessionId, { stream, pendingPushes });
-    const listeners: IRegisteredEventListener[] = [];
-    const lookupArgs = {
-      scriptInstanceId: headers['script-instance-id'] as string,
-      scriptEntrypoint: headers['script-entrypoint'] as string,
-      sessionName: headers['session-name'] as string,
-      dataLocation: headers['data-location'] as string,
-      sessionId,
-    };
-    log.stats('ReplayApi', lookupArgs);
-
-    try {
-      const session = SessionDb.findWithRelated(lookupArgs);
-
-      if (!session) {
-        stream.respond({ ':status': 404 });
-        stream.end(
-          JSON.stringify({ message: "There aren't any stored sessions for this script." }),
-        );
-        stream.close();
-        return;
-      }
-
-      const sessionLoader = new SessionLoader(session.sessionDb, session.sessionState);
-
-      const closedPromise = createPromise();
-      pendingPushes.push(closedPromise.promise);
-
-      let hasSentSession = false;
-
-      listeners.push(
-        eventUtils.addEventListener(sessionLoader, 'resources', resource => {
-          const promise = http2PushResources(stream, resource);
-          pendingPushes.push(promise);
-        }),
-      );
-
-      for (const event of SessionLoader.eventStreams) {
-        const registration = eventUtils.addEventListener(sessionLoader, event, data => {
-          const promise = http2PushJson(stream, event, data);
-          pendingPushes.push(promise);
-          if (event === 'script-state') {
-            if (data?.closeDate) {
-              closedPromise.resolve();
-            }
-          }
-        });
-
-        listeners.push(registration);
-      }
-
-      stream.on('error', err => {
-        activeClients.delete(sessionId);
-        log.error('Replay Server Error', {
-          error: err,
-          sessionId,
-        });
-      });
-
-      stream.on('close', () => {
-        log.info('Replay Server Closed', { sessionId });
-        eventUtils.removeEventListeners(listeners);
-        activeClients.delete(sessionId);
-        stream.session?.close();
-        stream.session?.unref();
-      });
-
-      sessionLoader.on('tab-ready', () => {
-        if (hasSentSession) return;
-        hasSentSession = true;
-
-        const promise = http2PushJson(stream, 'session', {
-          ...sessionLoader.session,
-          tabs: [...sessionLoader.tabs.values()],
-          dataLocation: session.dataLocation,
-          relatedScriptInstances: session.relatedScriptInstances,
-          relatedSessions: session.relatedSessions,
-        });
-        pendingPushes.push(promise);
-      });
-
-      const readyForTrailers = createPromise();
-      pendingPushes.push(readyForTrailers.promise);
-      stream.on('wantTrailers', () => {
-        readyForTrailers.resolve();
-        // need this even so http2 doesn't auto-close the session
-      });
-
-      sessionLoader.listen();
-
-      if (sessionLoader.session.closeDate) {
-        closedPromise.resolve();
-      }
-      // wait for trailers will stop connection from closing pre-emptively
-      stream.respond({ ':status': 200 }, { waitForTrailers: true });
-      stream.end();
-
-      return checkForClose(sessionId);
-    } catch (error) {
-      stream.respond({ ':status': 500 });
-      stream.end(JSON.stringify({ message: `ERROR loading session ${error.stack}` }));
-      stream.close();
-      log.error('SessionState.ErrorLoadingSession', {
-        error,
-        ...headers,
-        sessionId,
-      });
-    }
-  });
-
-  const address = await new Promise<AddressInfo>(resolve =>
-    server.listen(listenPort, () => {
-      resolve(server.address() as AddressInfo);
-    }),
-  );
-
-  async function checkForClose(sessionId: string) {
-    const client = activeClients.get(sessionId);
-    if (!client) return;
-
-    const { pendingPushes, stream } = client;
-
-    const resolvedPromises: Set<Promise<any>> = new Set();
-    // this can get called 2x, so if you take out of pendingPromises, it might not get waited for
-    // on Core.close -> ReplayServer.close
-    while (pendingPushes.length > resolvedPromises.size) {
-      const allPending = [...pendingPushes];
-      await Promise.all(allPending.map(x => x.catch(err => err)));
-      for (const pending of allPending) resolvedPromises.add(pending);
-      await new Promise(setImmediate);
-    }
-
-    if (!stream.destroyed) {
-      stream.sendTrailers({ 'pushes-sent': resolvedPromises.size });
-    }
-    activeClients.delete(sessionId);
-  }
-
-  return {
-    close: closeServer.bind(this, server, activeClients, checkForClose.bind(this)),
-    hasClients() {
-      return activeClients.size > 0;
-    },
-    url: `http://127.0.0.1:${address.port}`,
-    port: address.port,
-  };
-}
-
-async function closeServer(
-  server: http2.Http2Server,
-  activeClients: Map<string, { stream: http2.ServerHttp2Stream; pendingPushes: Promise<any>[] }>,
-  checkForClose: (sessionId: string) => Promise<any>,
-  waitForOpenConnections = false,
-) {
-  log.info('ReplayServer.closeSessions', { waitForOpenConnections, sessionId: null });
-  for (const [id, { stream }] of activeClients) {
-    if (waitForOpenConnections) {
-      await checkForClose(id);
-    }
-    stream.session?.unref();
-    stream.session?.close();
-    stream.destroy();
-  }
-  server.unref().close();
-}
-
-function http2PushJson(stream: http2.ServerHttp2Stream, event: string, data: any): Promise<void> {
-  if (Array.isArray(data) && data.length === 0) return Promise.resolve();
-  const json = JSON.stringify(data, (_, value) => {
-    if (value !== null) return value;
-  });
-  return sendHttp2Push(stream, event, json).catch(error => {
-    log.warn(`Error sending event to Replay`, {
-      error,
-      event,
-      sessionId: this.sessionId,
-    });
-  });
-}
-
-async function http2PushResources(
-  stream: http2.ServerHttp2Stream,
-  resources: any[],
-): Promise<void> {
-  if (stream.closed) return;
-  let promises: Promise<any>[] = [];
-  for (const resource of resources) {
-    const headers: any = {
-      'resource-url': resource.url,
-      'resource-type': resource.type,
-      'resource-status-code': resource.status,
-      'resource-headers': JSON.stringify(resource.headers),
-      'resource-tabid': resource.tabId,
-    };
-    const promise = sendHttp2Push(stream, 'resource', resource.data, headers).catch(error => {
-      log.warn(`Error sending resource to Replay`, {
-        error,
-        url: resource.url,
-        sessionId: this.sessionId,
-      });
-    });
-    promises.push(promise);
-    if (promises.length === 10) {
-      await Promise.all(promises);
-      promises = [];
-    }
-  }
-  await Promise.all(promises);
-}
-
-function sendHttp2Push(
-  stream: http2.ServerHttp2Stream,
-  event: string,
-  data: any,
-  headers: object = {},
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (stream.closed) return;
-    stream.pushStream({ ':path': `/${event}`, ...headers }, (error, pushStream) => {
-      if (error) return reject(error);
-
-      pushStream.once('error', reject);
-      pushStream.respond({ ':status': 200 });
-      pushStream.end(data, resolve);
-    });
-  });
+  await new Promise<void>(resolve => server.listen(port, resolve));
+  return server;
 }

--- a/session-state/api/sendSessionOverWs.ts
+++ b/session-state/api/sendSessionOverWs.ts
@@ -1,0 +1,123 @@
+import { IncomingMessage } from 'http';
+import WebSocket from 'ws';
+import Logger from '@secret-agent/commons/Logger';
+import SessionLoader from './SessionLoader';
+import SessionDb from '../lib/SessionDb';
+
+const { log } = Logger(module);
+const CLOSE_UNEXPECTED_ERROR = 1011;
+
+export default async function sendSessionOverWs(
+  websocket: WebSocket,
+  request: IncomingMessage,
+): Promise<void> {
+  const { headers } = request;
+  const lookupArgs = {
+    scriptInstanceId: headers['script-instance-id'] as string,
+    scriptEntrypoint: headers['script-entrypoint'] as string,
+    sessionName: headers['session-name'] as string,
+    dataLocation: headers['data-location'] as string,
+    sessionId: headers['session-id'] as string,
+  };
+  log.stats('ReplayApi', lookupArgs);
+
+  const { sessionId } = lookupArgs;
+
+  let sessionLoader: SessionLoader;
+  websocket.once('close', (error?: Error) => {
+    sessionLoader?.close();
+    sessionLoader = null;
+    log.info('Replay Session Closed', { error, sessionId });
+  });
+
+  try {
+    const session = SessionDb.findWithRelated(lookupArgs);
+
+    if (!session) {
+      await send(websocket, 'error', {
+        message: "There aren't any stored sessions for this script.",
+      });
+      websocket.close();
+      return;
+    }
+
+    sessionLoader = new SessionLoader(session.sessionDb, session.sessionState);
+
+    const closedPromise = new Promise(resolve => sessionLoader.once('closed', resolve));
+    const pendingPushes: Promise<any>[] = [closedPromise];
+
+    for (const event of SessionLoader.eventStreams) {
+      sessionLoader.on(event, data => {
+        if (websocket.readyState !== WebSocket.OPEN) {
+          websocket.close();
+          return;
+        }
+        const promise = send(websocket, event, data).catch(error => {
+          log.warn(`Error sending event to Replay`, {
+            error,
+            event,
+            sessionId,
+          });
+        });
+        pendingPushes.push(promise);
+      });
+    }
+
+    const tabReadyPromise = new Promise<void>(resolve => {
+      sessionLoader.once('tab-ready', () =>
+        send(websocket, 'session', {
+          ...sessionLoader.session,
+          tabs: [...sessionLoader.tabs.values()],
+          dataLocation: session.dataLocation,
+          relatedScriptInstances: session.relatedScriptInstances,
+          relatedSessions: session.relatedSessions,
+        }).finally(resolve),
+      );
+    });
+    pendingPushes.push(tabReadyPromise);
+
+    sessionLoader.listen();
+
+    await waitUntilAllComplete(pendingPushes);
+
+    await send(websocket, 'trailer', { messages: pendingPushes.length });
+    websocket.close();
+  } catch (error) {
+    if (websocket.readyState === WebSocket.OPEN) {
+      await send(websocket, 'error', { message: error.message });
+      websocket.close(CLOSE_UNEXPECTED_ERROR);
+    }
+    log.error('SessionState.ErrorLoadingSession', {
+      error,
+      ...headers,
+      sessionId,
+    });
+  }
+}
+
+function send(websocket: WebSocket, event: string, data: any): Promise<void> {
+  if (websocket.readyState !== WebSocket.OPEN) return;
+  if (Array.isArray(data) && data.length === 0) return Promise.resolve();
+
+  const json = JSON.stringify({ event, data }, (_, value) => {
+    if (value !== null) return value;
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    websocket.send(json, error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function waitUntilAllComplete(pendingPushes: Promise<any>[]) {
+  const resolvedPromises = new Set<Promise<any>>();
+  // sort of complicated, but we're checking that everything has been sent and completed
+  while (pendingPushes.length > resolvedPromises.size) {
+    const allPending = [...pendingPushes];
+    await Promise.all(allPending.map(x => x.catch(err => err)));
+    for (const pending of allPending) resolvedPromises.add(pending);
+    await new Promise(setImmediate);
+  }
+}

--- a/session-state/interfaces/ISessionReplayServer.ts
+++ b/session-state/interfaces/ISessionReplayServer.ts
@@ -1,6 +1,5 @@
 export default interface ISessionReplayServer {
   port: number;
   url: string;
-  hasClients: () => boolean;
   close: (waitForOpenConnections: boolean) => Promise<void>;
 }

--- a/session-state/package.json
+++ b/session-state/package.json
@@ -9,6 +9,7 @@
     "@secret-agent/injected-scripts": "1.2.0-alpha.4",
     "@secret-agent/mitm": "1.2.0-alpha.5",
     "better-sqlite3": "^7.1.2",
+    "ws": "^7.4.2",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/website/docs/Advanced/Remote.md
+++ b/website/docs/Advanced/Remote.md
@@ -1,6 +1,6 @@
 # Remote
 
-SecretAgent comes out of the box ready to act as a remote process that can communicate over a tcp socket to a client.
+SecretAgent comes out of the box ready to act as a remote process that can communicate over a WebSocket to a client.
 
 You'll need a simple script to start the server on the machine where the `secret-agent` npm package is installed. Make sure to open the port you allocate on any firewall that a client might have to pass through:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11720,11 +11720,6 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-socket@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/json-socket/-/json-socket-0.3.0.tgz#f4b953c685bb8e8bd0b72438f5208d9a0799ae07"
-  integrity sha512-jc8ZbUnYIWdxERFWQKVgwSLkGSe+kyzvmYxwNaRgx/c8NNyuHes4UHnPM3LUrAFXUx1BhNJ94n1h/KCRlbvV0g==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -19333,6 +19328,11 @@ ws@^7.2.3, ws@^7.3.0, ws@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
+ws@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
+  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
 x-is-string@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,6 +2809,13 @@
   dependencies:
     "@types/integer" "*"
 
+"@types/better-sqlite3@^5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-5.4.1.tgz#d45600bc19f8f41397263d037ca9b0d05df85e58"
+  integrity sha512-8hje3Rhsg/9veTkALfCwiWn7VMrP1QDwHhBSgerttYPABEvrHsMQnU9dlqoM6QX3x4uw3Y06dDVz8uDQo1J4Ng==
+  dependencies:
+    "@types/integer" "*"
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"


### PR DESCRIPTION
This PR moves the Core Api and Replay Api to use websockets instead of http2/json-socket.