### PR TITLE
Single Replay, Shared Directory withe Browsers, Better Launch errors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@secret-agent/commons": "1.2.0-alpha.4",
-    "@secret-agent/core": "1.2.0-alpha.5",
     "@secret-agent/core-interfaces": "1.2.0-alpha.4",
     "@secret-agent/replay": "1.2.0-alpha.4",
     "awaited-dom": "^1.1.10",
@@ -17,6 +16,7 @@
     "uuid": "^8.1.0"
   },
   "devDependencies": {
-    "@secret-agent/testing": "1.2.0-alpha.5"
+    "@secret-agent/testing": "1.2.0-alpha.5",
+    "@secret-agent/core": "1.2.0-alpha.5"
   }
 }

--- a/full-client/test/interact.test.ts
+++ b/full-client/test/interact.test.ts
@@ -41,7 +41,7 @@ describe('basic Interact tests', () => {
 
     await agent.close();
     await httpServer.close();
-  }, 20e3);
+  }, 30e3);
 
   it('should be able to get multiple entries out of the pool', async () => {
     const httpServer = await Helpers.runHttpServer({

--- a/mitm-socket/index.ts
+++ b/mitm-socket/index.ts
@@ -186,6 +186,7 @@ export default class MitmSocket extends TypedEventEmitter<{
     if (this.connectError)
       this.socket.destroy(buildConnectError(this.connectError, this.callStack));
     this.socket.end();
+    this.socket.unref();
     this.isConnected = false;
     unlink(this.socketPath, () => null);
     delete this.socket;

--- a/mitm/lib/MitmRequestAgent.ts
+++ b/mitm/lib/MitmRequestAgent.ts
@@ -92,7 +92,11 @@ export default class MitmRequestAgent {
   }
 
   public close(): void {
-    this.http2Sessions.map(x => x.client.destroy());
+    for (const session of this.http2Sessions) {
+      session.mitmSocket.close();
+      session.client.destroy();
+      session.client.unref();
+    }
     this.http2Sessions.length = 0;
     for (const socket of this.sockets) {
       socket.close();

--- a/puppet-chrome/index.ts
+++ b/puppet-chrome/index.ts
@@ -54,6 +54,27 @@ const PuppetLauncher: IPuppetLauncher = {
       throw error;
     }
   },
+  translateLaunchError(error: Error): Error {
+    // These error messages are taken from Chromium source code as of July, 2020:
+    // https://github.com/chromium/chromium/blob/70565f67e79f79e17663ad1337dc6e63ee207ce9/content/browser/zygote_host/zygote_host_impl_linux.cc
+    if (
+      !error.message.includes('crbug.com/357670') &&
+      !error.message.includes('No usable sandbox!') &&
+      !error.message.includes('crbug.com/638180')
+    ) {
+      return error;
+    }
+    error.stack += [
+      `\nChromium sandboxing failed!`,
+      `================================`,
+      `To workaround sandboxing issues, do either of the following:`,
+      `  - (preferred): Configure environment to support sandboxing (eg: in Docker, use custom seccomp profile + non-root user + --ipc=host)`,
+      `  - (alternative): Launch Chromium without sandbox using 'chromiumSandbox: false' option`,
+      `================================`,
+      ``,
+    ].join('\n');
+    return error;
+  },
 };
 export default PuppetLauncher;
 

--- a/puppet-interfaces/IPuppetLauncher.ts
+++ b/puppet-interfaces/IPuppetLauncher.ts
@@ -2,6 +2,7 @@ import ILaunchedProcess from './ILaunchedProcess';
 import IPuppetBrowser from './IPuppetBrowser';
 
 export default interface IPuppetLauncher {
-  getLaunchArgs(options: { proxyPort?: number; showBrowser?: boolean });
+  getLaunchArgs(options: { proxyPort?: number; showBrowser?: boolean }): string[];
   createPuppet(process: ILaunchedProcess, revision: string): Promise<IPuppetBrowser>;
+  translateLaunchError(error: Error): Error;
 }

--- a/puppet/lib/browserPaths.ts
+++ b/puppet/lib/browserPaths.ts
@@ -20,7 +20,7 @@ export function getExecutablePath(browser: string, revision: string) {
 }
 
 export function getInstallDirectory(browser: string, revision: string) {
-  return `${getCacheDirectory()}/${browser}-${revision}`;
+  return `${getCacheDirectory()}/secret-agent/${browser}-${revision}`;
 }
 
 function getCacheDirectory() {

--- a/puppet/package.json
+++ b/puppet/package.json
@@ -9,7 +9,7 @@
     "@secret-agent/puppet-interfaces": "1.2.0-alpha.4",
     "extract-zip": "^2.0.1",
     "https-proxy-agent": "5.0.0",
-    "progress": "^2.0.1",
+    "progress": "^2.0.3",
     "proxy-from-env": "^1.1.0",
     "rimraf": "^3.0.2"
   },

--- a/puppet/test/launchProcess.test.ts
+++ b/puppet/test/launchProcess.test.ts
@@ -29,7 +29,8 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
         ...defaultBrowserOptions,
         executablePath: 'random-invalid-path',
       });
-      expect(browser.start.bind(browser)).toThrow('Failed to launch');
+      await browser.start();
+      await expect(browser.isReady).rejects.toThrowError('Failed to launch');
     });
 
     it('should be callable twice', async () => {

--- a/replay/backend/api/ScriptRegistrationServer.ts
+++ b/replay/backend/api/ScriptRegistrationServer.ts
@@ -1,0 +1,39 @@
+import * as Http from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+import IReplayMeta from '~shared/interfaces/IReplayMeta';
+import ReplayApi from '~backend/api/index';
+
+export default class ScriptRegistrationServer {
+  private server: Http.Server;
+  private readonly registerReplayMeta: (replayMeta: IReplayMeta) => any;
+
+  constructor(registerReplayMeta: (replayMeta: IReplayMeta) => any) {
+    this.registerReplayMeta = registerReplayMeta;
+    this.server = new Http.Server(this.handleRequest.bind(this));
+    this.server.listen(0, () => {
+      const port = (this.server.address() as AddressInfo).port;
+      console.error(`REPLAY REGISTRATION API [http://localhost:${port}]`);
+    });
+  }
+
+  public close() {
+    this.server.close();
+  }
+
+  private async handleRequest(request: IncomingMessage, response: ServerResponse) {
+    let data = '';
+    for await (const chunk of request) {
+      data += chunk.toString();
+    }
+
+    const meta: IReplayMeta & { apiStartPath: string; nodePath: string } = JSON.parse(data);
+    console.log('ScriptInstance Registered', meta);
+
+    ReplayApi.serverStartPath = meta.apiStartPath;
+    ReplayApi.nodePath = meta.nodePath;
+    this.registerReplayMeta(meta);
+    response.writeHead(200);
+    response.end();
+  }
+}

--- a/replay/backend/api/index.ts
+++ b/replay/backend/api/index.ts
@@ -64,7 +64,6 @@ export default class ReplayApi {
     });
 
     this.websocket.once('open', () => {
-      this.isReadyResolvable.resolve();
       this.websocket.off('error', this.isReadyResolvable.reject);
     });
     this.websocket.once('error', this.isReadyResolvable.reject);
@@ -72,7 +71,7 @@ export default class ReplayApi {
     ReplayApi.websockets.add(this.websocket);
     this.websocket.on('close', () => {
       ReplayApi.websockets.delete(this.websocket);
-      console.log('Ws Session closed');
+      console.log('Ws Session closed', this.saSession.id);
     });
     this.websocket.on('message', this.onMessage.bind(this));
   }

--- a/replay/index.ts
+++ b/replay/index.ts
@@ -1,10 +1,26 @@
 import * as ChildProcess from 'child_process';
-import { getBinaryPath, isBinaryInstalled } from './install/Utils';
+import * as Fs from 'fs';
+import * as Http from 'http';
+import * as Lockfile from 'proper-lockfile';
+import { getBinaryPath, getInstallDirectory, isBinaryInstalled } from './install/Utils';
 
-const apiPath = require.resolve('@secret-agent/session-state/api/start');
 const showLogs = !!process.env.SA_REPLAY_DEBUG;
+const replayDir = getInstallDirectory();
+const replayRegistrationApiPath = `${replayDir}/api.txt`;
+const launchLockPath = `${replayDir}/launch`;
 
-export function replay(launchArgs: IReplayLaunchArgs) {
+if (!Fs.existsSync(replayDir)) Fs.mkdirSync(replayDir, { recursive: true });
+
+let sessionApiPath: string;
+try {
+  sessionApiPath = require.resolve('@secret-agent/session-state/api/start');
+} catch (err) {
+  // not installed locally (not full-client)
+}
+
+let replayRegistrationHost: string;
+
+export async function replay(launchArgs: IReplayScriptRegistration): Promise<any> {
   const {
     replayApiServer,
     sessionsDataLocation,
@@ -14,45 +30,115 @@ export function replay(launchArgs: IReplayLaunchArgs) {
     scriptStartDate,
   } = launchArgs;
 
-  const spawnArgs = [
-    '',
-    `--replay-data-location="${sessionsDataLocation}"`,
-    `--replay-session-name="${sessionName}"`,
-    `--replay-script-instance-id="${scriptInstanceId}"`,
-    `--replay-session-id="${sessionId}"`,
-    `--replay-api-path="${apiPath}"`,
-    `--replay-node-path="${process.execPath}"`,
-    `--replay-script-start-date="${scriptStartDate}"`,
-    `--replay-api-server="${replayApiServer}"`,
-    `--replay-node-path="${process.execPath}"`,
-  ];
+  const scriptMeta = {
+    sessionStateApi: replayApiServer,
+    dataLocation: sessionsDataLocation,
+    sessionName,
+    sessionId,
+    scriptStartDate,
+    scriptInstanceId,
+    apiStartPath: sessionApiPath,
+    nodePath: process.execPath,
+  };
 
-  if (isBinaryInstalled()) {
-    return spawn(getBinaryPath(), spawnArgs);
+  if (await registerScript(scriptMeta)) {
+    return;
   }
 
+  // cross-process lock around the launch process so we don't open multiple instances
+  const release = await Lockfile.lock(launchLockPath, {
+    retries: 5,
+    stale: 30e3,
+    fs: Fs,
+    realpath: false,
+  });
   try {
-    // see if we can launch from monorepo
-    spawnArgs[0] = require.resolve('@secret-agent/replay');
-
-    spawn('yarn electron', spawnArgs, true);
-  } catch (err) {
-    if (showLogs) {
-      console.log('Replay app not found');
+    // make sure last "lock holder" didn't write the
+    if (await registerScript(scriptMeta)) {
+      return;
     }
+
+    if (Fs.existsSync(replayRegistrationApiPath)) Fs.unlinkSync(replayRegistrationApiPath);
+    if (isBinaryInstalled()) {
+      await launchReplay(getBinaryPath(), ['--binary-launch']);
+    } else {
+      try {
+        const replayPath = require.resolve('@secret-agent/replay');
+        await launchReplay('yarn electron', [replayPath, '--electron-launch'], true);
+      } catch (error) {
+        if (showLogs) {
+          console.log('Replay app not found', error);
+        }
+      }
+    }
+
+    if (!(await registerScript(scriptMeta))) {
+      console.log("Couldn't register this script with the Replay app.");
+    }
+  } finally {
+    await release();
   }
 }
 
-function spawn(appPath: string, args: string[], needsShell = false) {
-  ChildProcess.spawn(appPath, args, {
+async function launchReplay(appPath: string, args: string[], needsShell = false): Promise<void> {
+  const child = ChildProcess.spawn(appPath, args, {
     detached: true,
-    stdio: showLogs ? 'inherit' : 'ignore',
+    stdio: ['ignore', showLogs ? 'inherit' : 'ignore', 'pipe'],
     shell: needsShell,
     windowsHide: false,
-  }).unref();
+  });
+  child.unref();
+  child.stderr.setEncoding('utf8');
+
+  await new Promise<void>(resolve => {
+    child.stderr.on('data', message => {
+      const matches = message.match(/.*REPLAY REGISTRATION API \[(.+)\]/);
+      if (matches?.length) {
+        Fs.writeFileSync(replayRegistrationApiPath, matches[1]);
+        child.stderr.removeAllListeners('data');
+        resolve();
+      }
+    });
+  });
 }
 
-interface IReplayLaunchArgs {
+function didLoadReplayRegistrationHost(): boolean {
+  if (replayRegistrationHost) return true;
+  if (!Fs.existsSync(replayRegistrationApiPath)) return false;
+  try {
+    replayRegistrationHost = Fs.readFileSync(replayRegistrationApiPath, 'utf8').trim();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+async function registerScript(data: any): Promise<boolean> {
+  if (!didLoadReplayRegistrationHost()) return false;
+
+  try {
+    const url = new URL(replayRegistrationHost);
+    const request = Http.request(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const response = new Promise<Http.IncomingMessage>((resolve, reject) => {
+      request.on('error', reject);
+      request.on('response', resolve);
+    });
+    request.end(JSON.stringify(data));
+    if ((await response)?.statusCode === 200) {
+      // registered successfully
+      return true;
+    }
+  } catch (err) {
+    // doesn't exist
+  }
+  replayRegistrationHost = null;
+  return false;
+}
+
+interface IReplayScriptRegistration {
   replayApiServer: string;
   sessionsDataLocation: string;
   sessionName: string;

--- a/replay/install/Utils.ts
+++ b/replay/install/Utils.ts
@@ -1,20 +1,26 @@
 import * as Path from 'path';
 import * as Fs from 'fs';
 import * as os from 'os';
+import * as Semver from 'semver';
 
 const packageJson = require('../package.json');
 
 const { version } = packageJson;
 
-const distDir = Path.join(__dirname, '..', 'dist');
+export function getInstallDirectory() {
+  return Path.join(getCacheDirectory(), 'secret-agent', 'replay');
+}
 
-export { version, distDir };
+export { version };
 
 export function isBinaryInstalled() {
   try {
-    if (Fs.readFileSync(`${distDir}/version`, 'utf-8').trim() !== version) {
-      return false;
-    }
+    const installedVersion = Fs.readFileSync(`${getInstallDirectory()}/version`, 'utf-8').trim();
+
+    const comparison = Semver.compare(installedVersion, version);
+    // 1 means installedVersion > version
+    // -1 means installedVersion < version
+    if (comparison >= 0) return true;
   } catch (ignored) {
     return false;
   }
@@ -23,12 +29,12 @@ export function isBinaryInstalled() {
 }
 
 export function recordVersion() {
-  Fs.writeFileSync(`${distDir}/version`, version);
+  Fs.writeFileSync(`${getInstallDirectory()}/version`, version);
 }
 
 export function getBinaryPath() {
   const platformPath = getPlatformExecutable();
-  return Path.join(distDir, platformPath);
+  return Path.join(getInstallDirectory(), platformPath);
 }
 
 function getPlatformExecutable() {
@@ -47,4 +53,20 @@ function getPlatformExecutable() {
     default:
       throw new Error(`SecretAgent Replay builds are not available on platform: ${platform}`);
   }
+}
+
+function getCacheDirectory(): string {
+  if (process.platform === 'linux') {
+    return process.env.XDG_CACHE_HOME || Path.join(os.homedir(), '.cache');
+  }
+
+  if (process.platform === 'darwin') {
+    return Path.join(os.homedir(), 'Library', 'Caches');
+  }
+
+  if (process.platform === 'win32') {
+    return process.env.LOCALAPPDATA || Path.join(os.homedir(), 'AppData', 'Local');
+  }
+
+  throw new Error(`Unsupported platform: ${process.platform}`);
 }

--- a/replay/package.dist.json
+++ b/replay/package.dist.json
@@ -4,8 +4,9 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "axios": "^0.21.1",
     "progress": "^2.0.3",
-    "tar-fs": "^2.1.0"
+    "tar-fs": "^2.1.0",
+    "semver": "^7.3.4",
+    "proper-lockfile": "^4.1.1"
   }
 }

--- a/replay/package.json
+++ b/replay/package.json
@@ -55,7 +55,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime-corejs3": "^7.11.2",
-    "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "electron-log": "^4.2.1",
     "moment": "^2.24.0",
@@ -63,11 +62,15 @@
     "source-map-support": "^0.5.19",
     "tar-fs": "^2.1.0",
     "ws": "^7.4.2",
-    "uuid": "^8.3.1"
+    "proper-lockfile": "^4.1.1",
+    "uuid": "^8.3.1",
+    "semver": "^7.3.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.113",
     "@types/node": "^13.13.34",
+    "@types/semver": "^7.3.4",
+    "@types/proper-lockfile": "^4.1.1",
     "concurrently": "^5.2.0",
     "core-js": "^3.6.5",
     "cross-env": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,6 +3122,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/proper-lockfile@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/proper-lockfile/-/proper-lockfile-4.1.1.tgz#99f026cbfdbe6305bdd454ffd5fefc1bd064beb1"
+  integrity sha512-HAjVfDa73pFgivViHyDu8HHHcds+W4MgOuZZAdyFJrHS8ngtCXmhl4hc2YXqSOwO6Bsa+iF2Sgxb2+gv874VOQ==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
@@ -3144,6 +3151,16 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/retry@*":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/semver@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
+  integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
 
 "@types/serve-static@*":
   version "1.13.5"
@@ -4501,13 +4518,6 @@ axe-core@^4.0.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
-
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -8749,11 +8759,6 @@ follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
-
-follow-redirects@^1.10.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
-  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -14970,7 +14975,7 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
-progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -15018,6 +15023,15 @@ prop-types@^15.5.10, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+proper-lockfile@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.1.tgz#284cf9db9e30a90e647afad69deb7cb06881262c"
+  integrity sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==
+  dependencies:
+    graceful-fs "^4.1.11"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 property-information@^4.0.0:
   version "4.2.0"
@@ -16288,6 +16302,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
This PR addresses a few things with our external dependencies:
*Replay*
- Replay now has single install for all core versions in a project (the newest will be installed)
- Replay lives in the same directory as the Chrome engines
- Replay locks on files to create a path to an api server where scripts register. This prevents the electron bug for popping up so many processes to try to determine if a new one should launch. Scripts now register over http calls instead

*Puppet:*
- Clean up sandbox errors (copied from playwright)
- Better error handling if a chrome version is not installed (previously was showing an ENOENT error without explicitly saying what was happening)
- Puppet engines share a common directory inside app cache (secret-agent)