### PR TITLE
fix(mitm): preflight requests not always sent

### DIFF
--- a/puppet-chrome/index.ts
+++ b/puppet-chrome/index.ts
@@ -89,7 +89,7 @@ const defaultArgs = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  '--disable-features=TranslateUI,site-per-process',
+  '--disable-features=TranslateUI,site-per-process,OutOfBlinkCors',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',
   '--disable-prompt-on-repost',

--- a/session-state/models/ResourcesTable.ts
+++ b/session-state/models/ResourcesTable.ts
@@ -17,6 +17,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
         ['type', 'TEXT'],
         ['receivedAtCommandId', 'INTEGER'],
         ['seenAtCommandId', 'INTEGER'],
+        ['requestMethod', 'TEXT'],
         ['requestUrl', 'TEXT'],
         ['requestHeaders', 'TEXT'],
         ['requestTrailers', 'TEXT'],
@@ -79,6 +80,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
       meta.type,
       meta.receivedAtCommandId,
       null,
+      meta.request.method,
       meta.request.url,
       JSON.stringify(meta.request.headers ?? {}),
       JSON.stringify(meta.request.trailers ?? {}),
@@ -134,6 +136,7 @@ export interface IResourcesRecord {
   type: ResourceType;
   receivedAtCommandId: number;
   seenAtCommandId: number;
+  requestMethod: string;
   requestUrl: string;
   requestHeaders: string;
   requestTrailers?: string;


### PR DESCRIPTION
Chrome 80 and 81 had an experimental "OutOfBlinkCors" feature that meant certain requests never registered a Preflight inside of devtools. Disabled this feature.