### PR TITLE
fix(emulators): safari cookie handling fix

### DIFF
--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -142,13 +142,18 @@ describe('UserProfile cookie tests', () => {
       const core = Session.getTab(meta);
       koaServer.get('/safari-cookie', ctx => {
         ctx.cookies.set('safari', 'cookie');
-        ctx.body = `<body><h1>safari page</h1></body>`;
+        ctx.body = `<body><h1>safari page</h1>
+<script type="text/javascript">
+document.cookie = 'secondcookie=1'
+</script>
+
+</body>`;
       });
 
       await core.goto(`${koaServer.baseUrl}/safari-cookie`);
       await core.waitForLoad('AllContentLoaded');
       profile = await connection.exportUserProfile(meta);
-      expect(profile.cookies).toHaveLength(1);
+      expect(profile.cookies).toHaveLength(2);
       await core.close();
     }
     {

--- a/emulate-browsers/base/injected-scripts/_proxyUtils.ts
+++ b/emulate-browsers/base/injected-scripts/_proxyUtils.ts
@@ -172,9 +172,9 @@ function proxySetter<T, K extends keyof T>(
   const { descriptorOwner, descriptor } = descriptorInHierarchy;
   const toString = descriptor.set.toString();
   descriptor.set = new Proxy(descriptor.set, {
-    apply(_, thisArg) {
+    apply(target, thisArg, args) {
       if (!overrideOnlyForInstance || thisArg === thisObject) {
-        const result = overrideFn(...arguments);
+        const result = overrideFn(target as any, thisArg, ...args);
         if (result !== ProxyOverride.callOriginal) return result;
       }
       return ReflectCached.apply(...arguments);

--- a/emulate-browsers/safari-13/index.ts
+++ b/emulate-browsers/safari-13/index.ts
@@ -24,7 +24,8 @@ import IHttpResourceLoadDetails from '@secret-agent/core-interfaces/IHttpResourc
 import IResolvablePromise from '@secret-agent/core-interfaces/IResolvablePromise';
 import { createPromise, pickRandom } from '@secret-agent/commons/utils';
 import IUserProfile from '@secret-agent/core-interfaces/IUserProfile';
-import IWindowFraming from "@secret-agent/core-interfaces/IWindowFraming";
+import IWindowFraming from '@secret-agent/core-interfaces/IWindowFraming';
+import Log from '@secret-agent/commons/Logger';
 import pkg from './package.json';
 import headerProfiles from './data/headers.json';
 import userAgentOptions from './data/user-agent-options.json';
@@ -36,6 +37,7 @@ const windowNavigatorData = new DataLoader(`${__dirname}/data`, 'window-navigato
 const codecsData = new DataLoader(`${__dirname}/data`, 'codecs');
 
 const cookieCallbackName = 'SecretAgentSetCookie';
+const { log } = Log(module);
 
 @BrowserEmulatorClassDecorator
 export default class Safari13 {
@@ -135,7 +137,14 @@ export default class Safari13 {
     const result = this.domOverrides.build();
     Object.assign(result[0], {
       callback: ({ cookie, origin }) => {
-        this.cookieJar.setCookie(cookie, origin);
+        try {
+          this.cookieJar.setCookie(cookie, origin);
+        } catch (error) {
+          log.warn('Error setting cookie from page', {
+            error,
+            sessionId: null, // TODO: @caleb - can you plug in sessionid to the emulators (or a child logger)
+          });
+        }
       },
       callbackWindowName: cookieCallbackName,
     });


### PR DESCRIPTION
Safari has specific handling around cookies that didn't really have anything exercising page triggered cookies. Tweaked the test to make sure we hit this code branch, and fixed the error.

NOTE: this has a todo for you @calebjclark to inject either a sessionid or a logger to the emulators. I thought doing too much in here in this PR might break your stuff.