### PR TITLE
Timeouts, Replay Bin, Reload

### DIFF
--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -224,16 +224,20 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
 
   /////// METHODS THAT DELEGATE TO ACTIVE TAB //////////////////////////////////////////////////////////////////////////
 
-  public goto(href: string): Promise<Resource> {
-    return this.activeTab.goto(href);
+  public goto(href: string, timeoutMs?: number): Promise<Resource> {
+    return this.activeTab.goto(href, timeoutMs);
   }
 
-  public goBack(): Promise<string> {
-    return this.activeTab.goBack();
+  public goBack(timeoutMs?: number): Promise<string> {
+    return this.activeTab.goBack(timeoutMs);
   }
 
-  public goForward(): Promise<string> {
-    return this.activeTab.goForward();
+  public goForward(timeoutMs?: number): Promise<string> {
+    return this.activeTab.goForward(timeoutMs);
+  }
+
+  public reload(timeoutMs?: number): Promise<void> {
+    return this.activeTab.reload(timeoutMs);
   }
 
   public fetch(request: Request | string, init?: IRequestInit): Promise<Response> {
@@ -273,10 +277,6 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
 
   public waitForMillis(millis: number): Promise<void> {
     return this.activeTab.waitForMillis(millis);
-  }
-
-  public waitForWebSocket(url: string | RegExp): Promise<void> {
-    return this.activeTab.waitForWebSocket(url);
   }
 
   /////// THENABLE ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/client/lib/CoreTab.ts
+++ b/client/lib/CoreTab.ts
@@ -77,16 +77,20 @@ export default class CoreTab implements IJsPathEventTarget {
     return await this.commandQueue.run('getLocationHref');
   }
 
-  public async goto(href: string): Promise<IResourceMeta> {
-    return await this.commandQueue.run('goto', href);
+  public async goto(href: string, timeoutMs?: number): Promise<IResourceMeta> {
+    return await this.commandQueue.run('goto', href, timeoutMs);
   }
 
-  public async goBack(): Promise<string> {
-    return await this.commandQueue.run('goBack');
+  public async goBack(timeoutMs?: number): Promise<string> {
+    return await this.commandQueue.run('goBack', timeoutMs);
   }
 
-  public async goForward(): Promise<string> {
-    return await this.commandQueue.run('goForward');
+  public async goForward(timeoutMs?: number): Promise<string> {
+    return await this.commandQueue.run('goForward', timeoutMs);
+  }
+
+  public async reload(timeoutMs?: number): Promise<void> {
+    return await this.commandQueue.run('reload', timeoutMs);
   }
 
   public async interact(interactionGroups: IInteractionGroups): Promise<void> {
@@ -138,10 +142,6 @@ export default class CoreTab implements IJsPathEventTarget {
 
   public async waitForMillis(millis: number): Promise<void> {
     await this.commandQueue.run('waitForMillis', millis);
-  }
-
-  public async waitForWebSocket(url: string | RegExp): Promise<void> {
-    await this.commandQueue.run('waitForWebSocket', url);
   }
 
   public async waitForNewTab(opts: IWaitForOptions): Promise<CoreTab> {

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -129,20 +129,25 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     ) as CSSStyleDeclaration;
   }
 
-  public async goto(href: string): Promise<Resource> {
+  public async goto(href: string, timeoutMs?: number): Promise<Resource> {
     const coreTab = await getCoreTab(this);
-    const resource = await coreTab.goto(href);
+    const resource = await coreTab.goto(href, timeoutMs);
     return createResource(resource, Promise.resolve(coreTab));
   }
 
-  public async goBack(): Promise<string> {
+  public async goBack(timeoutMs?: number): Promise<string> {
     const coreTab = await getCoreTab(this);
-    return coreTab.goBack();
+    return coreTab.goBack(timeoutMs);
   }
 
-  public async goForward(): Promise<string> {
+  public async goForward(timeoutMs?: number): Promise<string> {
     const coreTab = await getCoreTab(this);
-    return coreTab.goForward();
+    return coreTab.goForward(timeoutMs);
+  }
+
+  public async reload(timeoutMs?: number): Promise<void> {
+    const coreTab = await getCoreTab(this);
+    return coreTab.reload(timeoutMs);
   }
 
   public async getJsValue<T>(path: string): Promise<{ value: T; type: string }> {
@@ -193,11 +198,6 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   public async waitForMillis(millis: number): Promise<void> {
     const coreTab = await getCoreTab(this);
     await coreTab.waitForMillis(millis);
-  }
-
-  public async waitForWebSocket(url: string | RegExp): Promise<void> {
-    const coreTab = await getCoreTab(this);
-    await coreTab.waitForWebSocket(url);
   }
 
   public focus(): Promise<void> {

--- a/commons/Timer.ts
+++ b/commons/Timer.ts
@@ -10,8 +10,9 @@ export default class Timer {
   private readonly expirePromise = createPromise();
 
   constructor(readonly timeoutMillis: number, readonly registry?: IRegistry[]) {
-    this.timeout = setTimeout(this.expire.bind(this), timeoutMillis).unref();
-    if (registry) {
+    this.timeout =
+      timeoutMillis > 0 ? setTimeout(this.expire.bind(this), timeoutMillis).unref() : null;
+    if (registry && this.timeout) {
       registry.push({ reject: this.expirePromise.reject, timeout: this.timeout });
     }
   }

--- a/copy-dist.js
+++ b/copy-dist.js
@@ -4,6 +4,7 @@ const copyfiles = require('copyfiles');
 copyfiles(
   [
     '-e "node_modules/**"',
+    '-e "**/node_modules/**"',
     '-e "build/**"',
     '-e "build-dist/**"',
     '-e "mitm-socket/dist"',

--- a/core/lib/LocationTracker.ts
+++ b/core/lib/LocationTracker.ts
@@ -96,7 +96,7 @@ export default class LocationTracker {
       }
     }
 
-    const resolvablePromise = createPromise<void>(options.timeoutMs);
+    const resolvablePromise = createPromise<void>(options.timeoutMs ?? 30e3);
     this.waitForCbs[status].push(resolvablePromise);
     return resolvablePromise.promise;
   }

--- a/core/test/location.test.ts
+++ b/core/test/location.test.ts
@@ -3,7 +3,6 @@ import { LocationStatus, LocationTrigger } from '@secret-agent/core-interfaces/L
 import { InteractionCommand } from '@secret-agent/core-interfaces/IInteractions';
 import { ITestKoaServer } from '@secret-agent/testing/helpers';
 import ICreateSessionOptions from '@secret-agent/core-interfaces/ICreateSessionOptions';
-import { Readable } from 'stream';
 import Core, { Tab } from '../index';
 import LocationTracker from '../lib/LocationTracker';
 import ConnectionToClient from '../server/ConnectionToClient';

--- a/core/test/tab.test.ts
+++ b/core/test/tab.test.ts
@@ -46,6 +46,7 @@ describe('basic Tab tests', () => {
     const tab = Session.getTab(meta);
     Helpers.needsClosing.push(tab.session);
     await tab.goto(`${koaServer.baseUrl}/test2`);
+    await tab.waitForLoad('DomContentLoaded');
 
     await expect(
       tab.waitForElement(['document', ['querySelector', 'a#notthere']], { timeoutMs: 500 }),

--- a/full-client/test/websocket.test.ts
+++ b/full-client/test/websocket.test.ts
@@ -30,11 +30,11 @@ describe('Websocket tests', () => {
     const serverMessagePromise = createPromise();
     const wss = new WebSocket.Server({ noServer: true });
 
-    let receivedMessages = 0;
+    const receivedMessages: string[] = [];
     koaServer.server.on('upgrade', (request, socket, head) => {
       wss.handleUpgrade(request, socket, head, async (ws: WebSocket) => {
         ws.on('message', msg => {
-          receivedMessages += 1;
+          receivedMessages.push(msg.toString());
           if (msg === 'Echo Message19') {
             serverMessagePromise.resolve();
           }
@@ -69,7 +69,7 @@ describe('Websocket tests', () => {
 
     await agent.waitForElement(agent.document.querySelector('h1'));
     await serverMessagePromise.promise;
-    expect(receivedMessages).toBe(20);
+    expect(receivedMessages).toHaveLength(20);
 
     expect(upgradeSpy).toHaveBeenCalledTimes(1);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "build:ci": "yarn tsc && cd build && yarn install",
     "copy:node_modules": "shx cp -r node_modules \"build/node_modules\"",
     "copy:build": "node copy-build.js",
-    "replay": "yarn workspace @secret-agent/replay start",
     "tsc": "tsc -b tsconfig.json && yarn copy:build && node prepare-build.js && yarn workspace @secret-agent/replay build:backend",
     "watch": "tsc-watch -b -w tsconfig.json --onSuccess \"yarn workspace @secret-agent/replay build:backend-paths\"",
     "watch:dist": "tsc -b -w tsconfig.dist.json",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bump-version": "lerna version prerelease --no-push --conventional-commits",
     "build": "yarn tsc && yarn workspace @secret-agent/replay build:frontend && cd build && yarn",
     "build:dist": "shx rm -rf build-dist && tsc -b tsconfig.dist.json && node copy-dist.js && node prepare-dist.js && shx cp package.dist.json build-dist/package.json",
-    "build:dist-local": "yarn build && yarn build:dist && yarn workspace @secret-agent/replay build:pack && cd build-dist && SA_REBUILD_MITM_SOCKET=1 yarn",
+    "build:dist-local": "yarn build:dist && yarn workspace @secret-agent/replay build:dist-local && cd build-dist && SA_REBUILD_MITM_SOCKET=1 yarn",
     "rebuild:dist": "tsc -b tsconfig.dist.json",
     "build:docker": "yarn build:dist && docker build -t secret-agent .",
     "build:ci": "yarn tsc && cd build && yarn install",

--- a/prepare-dist.js
+++ b/prepare-dist.js
@@ -47,6 +47,7 @@ function processPackageJson(packagePath) {
     scripts: overridesJson.scripts,
     dependencies: overridesJson.dependencies || packageJson.dependencies,
     engine: packageJson.engine, // this is used by emulators
+    bin: packageJson.bin,
   };
 
   // check if index exists

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -202,6 +202,10 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     return this.navigateToHistory(+1);
   }
 
+  reload(): Promise<void> {
+    return this.cdpSession.send('Page.reload');
+  }
+
   async bringToFront(): Promise<void> {
     await this.cdpSession.send('Page.bringToFront');
   }

--- a/puppet-interfaces/IPuppetPage.ts
+++ b/puppet-interfaces/IPuppetPage.ts
@@ -19,6 +19,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
   navigate(url: string, options?: { referrer?: string }): Promise<void>;
   goBack(): Promise<void>;
   goForward(): Promise<void>;
+  reload(): Promise<void>;
   close(): Promise<void>;
   bringToFront(): Promise<void>;
   popupInitializeFn?: (

--- a/replay/backend/Application.ts
+++ b/replay/backend/Application.ts
@@ -47,7 +47,17 @@ export default class Application {
     await this.overlayManager.start();
     this.registrationServer = new ScriptRegistrationServer(this.registerScript.bind(this));
     Menu.setApplicationMenu(generateAppMenu());
-    if (process.argv.length <= 2) this.createWindowIfNeeded();
+
+    const defaultNodePath = process.argv.find(x => x.startsWith('--sa-default-node-path='));
+
+    if (defaultNodePath) {
+      const nodePath = defaultNodePath.split('--sa-default-node-path=').pop();
+      console.log('Default nodePath provided', nodePath);
+      ReplayApi.nodePath = nodePath;
+    }
+    if (process.argv.length <= 2 || process.argv.includes('--sa-show-dashboard')) {
+      this.createWindowIfNeeded();
+    }
   }
 
   public getPageUrl(page: string) {
@@ -96,7 +106,7 @@ export default class Application {
       replayApi = await ReplayApi.connect(replay);
     } catch (err) {
       console.log('ERROR launching replay', err);
-      dialog.showErrorBox(`Unable to Load Replay`, err.message);
+      dialog.showErrorBox(`Unable to Load Replay`, err.message ?? String(err));
       return;
     }
 

--- a/replay/backend/api/index.ts
+++ b/replay/backend/api/index.ts
@@ -146,8 +146,10 @@ export default class ReplayApi {
 
         if (eventName === 'resources') this.resources.onResource(event);
         else if (eventName === 'dom-changes') tab.loadDomChange(event);
-        else if (eventName === 'commands') tab.loadCommand(event);
-        else if (eventName === 'mouse-events') tab.loadPageEvent('mouse', event);
+        else if (eventName === 'commands') {
+          if (!this.replayTime.close) this.replayTime.update();
+          tab.loadCommand(event);
+        } else if (eventName === 'mouse-events') tab.loadPageEvent('mouse', event);
         else if (eventName === 'focus-events') tab.loadPageEvent('focus', event);
         else if (eventName === 'scroll-events') tab.loadPageEvent('scroll', event);
       }

--- a/replay/bin.ts
+++ b/replay/bin.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
-import { replay } from './index';
+import { openReplayApp } from './index';
 
-replay({} as any).catch(console.error);
+openReplayApp('--sa-show-dashboard', `--sa-default-node-path="${process.execPath}"`).catch(
+  console.error,
+);

--- a/replay/bin.ts
+++ b/replay/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { replay } from './index';
+
+replay({} as any).catch(console.error);

--- a/replay/index.ts
+++ b/replay/index.ts
@@ -93,30 +93,7 @@ export async function replay(launchArgs: IReplayScriptRegistration): Promise<any
       return;
     }
 
-    Fs.writeFileSync(registrationApiFilepath, '');
-
-    if (hasLocalReplay) {
-      const replayPath = require.resolve('@secret-agent/replay');
-      await launchReplay('yarn electron', [replayPath, '--electron-launch'], true);
-    } else if (isLocalBuildPresent()) {
-      await launchReplay(getLocalBuildPath(), ['--local-build-launch']);
-    } else if (isBinaryInstalled()) {
-      await launchReplay(getBinaryPath(), ['--binary-launch']);
-    }
-
-    // wait for change
-    await new Promise<void>(resolve => {
-      const watcher = Fs.watch(
-        registrationApiFilepath,
-        { persistent: false, recursive: false },
-        () => {
-          if (resolveHost()) {
-            resolve();
-            watcher.close();
-          }
-        },
-      );
-    });
+    await openReplayApp();
 
     if (!(await registerScript(scriptMeta))) {
       console.log("Couldn't register this script with the Replay app.", scriptMeta);
@@ -128,6 +105,33 @@ export async function replay(launchArgs: IReplayScriptRegistration): Promise<any
   } finally {
     if (release) await release();
   }
+}
+
+export async function openReplayApp(...extraArgs: string[]) {
+  Fs.writeFileSync(registrationApiFilepath, '');
+
+  if (isLocalBuildPresent()) {
+    await launchReplay(getLocalBuildPath(), ['--local-build-launch', ...extraArgs]);
+  } else if (hasLocalReplay) {
+    const replayPath = require.resolve('@secret-agent/replay');
+    await launchReplay('yarn electron', [replayPath, '--electron-launch', ...extraArgs], true);
+  } else if (isBinaryInstalled()) {
+    await launchReplay(getBinaryPath(), ['--binary-launch', ...extraArgs]);
+  }
+
+  // wait for change
+  await new Promise<void>(resolve => {
+    const watcher = Fs.watch(
+      registrationApiFilepath,
+      { persistent: false, recursive: false },
+      () => {
+        if (resolveHost()) {
+          resolve();
+          watcher.close();
+        }
+      },
+    );
+  });
 }
 
 function launchReplay(appPath: string, args: string[], needsShell = false): void {

--- a/replay/index.ts
+++ b/replay/index.ts
@@ -2,7 +2,13 @@ import * as ChildProcess from 'child_process';
 import * as Fs from 'fs';
 import * as Http from 'http';
 import * as Lockfile from 'proper-lockfile';
-import { getBinaryPath, getInstallDirectory, isBinaryInstalled } from '~install/Utils';
+import {
+  getBinaryPath,
+  getInstallDirectory,
+  getLocalBuildPath,
+  isBinaryInstalled,
+  isLocalBuildPresent,
+} from './install/Utils';
 
 const replayDir = getInstallDirectory();
 const registrationApiFilepath = `${replayDir}/api.txt`;
@@ -92,6 +98,8 @@ export async function replay(launchArgs: IReplayScriptRegistration): Promise<any
     if (hasLocalReplay) {
       const replayPath = require.resolve('@secret-agent/replay');
       await launchReplay('yarn electron', [replayPath, '--electron-launch'], true);
+    } else if (isLocalBuildPresent()) {
+      await launchReplay(getLocalBuildPath(), ['--local-build-launch']);
     } else if (isBinaryInstalled()) {
       await launchReplay(getBinaryPath(), ['--binary-launch']);
     }

--- a/replay/install/Utils.ts
+++ b/replay/install/Utils.ts
@@ -29,6 +29,35 @@ export function recordVersion() {
   Fs.writeFileSync(`${getInstallDirectory()}/version`, version);
 }
 
+export function isLocalBuildPresent() {
+  return Fs.existsSync(getLocalBuildPath());
+}
+
+export function getLocalBuildPath() {
+  const platformPath = getPlatformExecutable();
+
+  const distDir = Path.join(__dirname, '..', 'dist', getDistDir());
+
+  return Path.join(distDir, platformPath);
+}
+
+function getDistDir() {
+  const platform = process.env.npm_config_platform || os.platform();
+
+  switch (platform) {
+    case 'mas':
+    case 'darwin':
+      return 'mac';
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return `linux-unpacked`;
+    case 'win32':
+      return `win-unpacked`;
+    default:
+      return '';
+  }
+}
 export function getBinaryPath() {
   const platformPath = getPlatformExecutable();
   return Path.join(getInstallDirectory(), platformPath);

--- a/replay/package.json
+++ b/replay/package.json
@@ -5,12 +5,16 @@
     "Caleb Clark",
     "Blake Byrnes"
   ],
+  "bin": {
+    "replay": "./bin.js"
+  },
   "repository": "git@github.com:ulixee/secret-agent.git",
   "description": "A browser for visually replaying your scraper scripts",
   "version": "1.2.0-alpha.4",
   "main": "./app.js",
   "files": [
     "index.js",
+    "bin.js",
     "install/*"
   ],
   "build": {

--- a/replay/package.json
+++ b/replay/package.json
@@ -47,6 +47,7 @@
     "build:backend": "tsc -b tsconfig.json && yarn build:backend-paths && shx cp package.json ../build/replay && shx cp -r *.png ../build/replay",
     "build:icons": "electron-icon-builder -f --input=./icon@2x.png --output=../build/replay/build",
     "build:dist": "yarn build:frontend && yarn build:backend",
+    "build:dist-local": "yarn build:dist && cd ../build/replay && yarn electron-builder && shx cp -r dist ../../build-dist/replay",
     "build": "yarn build:dist",
     "build:pack": "yarn build:icons && shx cp pack.sh ../build/replay/pack.sh && cd ../build/replay && electron-builder -mwl && ./pack.sh",
     "clean": "shx rm -rf ../build/replay/static && shx rm -rf ../build/replay/dist && tsc -b --clean tsconfig.json && tsc -b --clean frontend/tsconfig.json",

--- a/replay/tsconfig.dist.json
+++ b/replay/tsconfig.dist.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../build-dist/replay"
   },
-  "include": ["index.ts", "install/*.ts", ".eslintrc.js", "*.json"],
+  "include": ["index.ts", "bin.ts", "install/*.ts", ".eslintrc.js", "*.json"],
   "exclude": [
     "dist",
     "node_modules",

--- a/replay/tsconfig.json
+++ b/replay/tsconfig.json
@@ -30,6 +30,7 @@
     "shared/**/*.ts",
     "frontend/src/constants",
     "app.ts",
+    "bin.ts",
     "index.ts",
     "install/*.ts",
     ".eslintrc.js"

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -91,19 +91,19 @@ Alias for [activeTab.lastCommandId](./tab#lastCommandId)
 ### agent.meta {#meta}
 
 Retrieves metadata about the agent configuration:
-  - sessionId `string`. The session identifier.
-  - sessionName `string`. The unique session name that will be visible in Replay.
-  - browserEmulatorId `string`. The id of the [Browser Emulator](../advanced/browser-emulators) in use.
-  - humanEmulatorId `string`. The id of the [Human Emulator](../advanced/human-emulators) in use.
-  - timezoneId `string`. The configured unicode TimezoneId or host default (eg, America/New_York).
-  - locale `string`. The configured locale in use (eg, en-US).
-  - viewport `IViewport`. The emulated viewport size and location.
-  - blockedResourceTypes `BlockedResourceType[]`. The blocked resource types.
-  - upstreamProxyUrl `string`. The proxy url in use for this agent.
-  - userAgentString `string`. The user agent string used in Http requests and within the DOM.
+
+- sessionId `string`. The session identifier.
+- sessionName `string`. The unique session name that will be visible in Replay.
+- browserEmulatorId `string`. The id of the [Browser Emulator](../advanced/browser-emulators) in use.
+- humanEmulatorId `string`. The id of the [Human Emulator](../advanced/human-emulators) in use.
+- timezoneId `string`. The configured unicode TimezoneId or host default (eg, America/New_York).
+- locale `string`. The configured locale in use (eg, en-US).
+- viewport `IViewport`. The emulated viewport size and location.
+- blockedResourceTypes `BlockedResourceType[]`. The blocked resource types.
+- upstreamProxyUrl `string`. The proxy url in use for this agent.
+- userAgentString `string`. The user agent string used in Http requests and within the DOM.
 
 #### **Type**: `Promise<IAgentMeta>`
-
 
 ### agent.sessionId {#sessionId}
 
@@ -280,21 +280,25 @@ Alias for [Tab.getComputedStyle()](./tab#get-computed-style)
 
 Alias for [Tab.getJsValue()](./tab#get-js-value)
 
-### agent.goBack*()*
+### agent.goBack*(timeoutMs?)*
 
 Alias for [Tab.goBack](./tab#back)
 
-### agent.goForward*()*
+### agent.goForward*(timeoutMs?)*
 
 Alias for [Tab.goForward](./tab#forward)
 
-### agent.goto*(href)* {#goto}
+### agent.goto*(href, timeoutMs?)* {#goto}
 
 Alias for [Tab.goto](./tab#goto)
 
 ### agent.isElementVisible*(element)*
 
 Alias for [Tab.isElementVisible](./tab#is-element-visible)
+
+### agent.reload*(timeoutMs?)*
+
+Alias for [Tab.reload](./tab#reload)
 
 ### agent.waitForAllContentLoaded*()*
 
@@ -315,7 +319,3 @@ Alias for [Tab.waitForLocation](./tab#wait-for-location)
 ### agent.waitForMillis*(millis)*
 
 Alias for [Tab.waitForMillis](./tab#wait-for-millis)
-
-### agent.waitForWebSocket*(filename)*
-
-Alias for [Tab.waitForWebSocket](./tab#wait-for-websocket)

--- a/website/docs/BasicInterfaces/Tab.md
+++ b/website/docs/BasicInterfaces/Tab.md
@@ -150,25 +150,34 @@ await agent.goto('https://dataliberationfoundation.org');
 const navigatorAgent = await agent.activeTab.getJsValue(`navigator.userAgent`);
 ```
 
-### tab.goBack*()* {#back}
+### tab.goBack*(timeoutMs)* {#back}
 
 Navigates to a previous url in the navigation history.
 
+#### **Arguments**:
+
+- timeoutMs `number`. Optional timeout milliseconds. Default `30,000`. A value of `0` will never timeout.
+
 #### **Returns**: `Promise<string>` The new document url.
 
-### tab.goForward*()* {#forward}
+### tab.goForward*(timeoutMs)* {#forward}
 
 Navigates forward in the navigation history stack.
 
+#### **Arguments**:
+
+- timeoutMs `number`. Optional timeout milliseconds. Default `30,000`. A value of `0` will never timeout.
+
 #### **Returns**: `Promise<string>` The new document url.
 
-### tab.goto*(locationHref)* {#goto}
+### tab.goto*(locationHref, timeoutMs?)* {#goto}
 
 Executes a navigation request for the document associated with the parent SecretAgent instance.
 
 #### **Arguments**:
 
 - locationHref `string` The location to navigate to.
+- timeoutMs `number`. Optional timeout milliseconds. Default `30,000`. A value of `0` will never timeout.
 
 #### **Returns**: [`Promise<Resource>`](../advanced/resource) The loaded resource representing this page.
 
@@ -187,13 +196,23 @@ Determines if an element is visible to an end user. This method checks whether a
 
 #### **Returns**: `Promise<boolean>` Whether the element is visible to an end user.
 
+### tab.reload*(timeoutMs?)* {#reload}
+
+Reload the currently loaded url.
+
+#### **Arguments**:
+
+- timeoutMs `number`. Optional timeout milliseconds. Default `30,000`. A value of `0` will never timeout.
+
+#### **Returns**: [`Promise<Resource>`](../advanced/resource) The loaded resource representing this page.
+
 ### tab.waitForAllContentLoaded*(options)* {#wait-for-all-content}
 
 Wait for the "load" DOM event. We renamed this to be more explicit because we're always mixing up DOMContentLoaded and load.
 
 #### **Arguments**:
 
-- options `object`
+- options `object` Optional
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - sinceCommandId `number`. A `commandId` from which to look for load status changes.
 
@@ -337,16 +356,6 @@ Waits for the specified number of milliseconds.
 - millis `number`
 
 #### **Returns**: `Promise`
-
-### tab.waitForWebSocket*(filename)* {#wait-for-websocket}
-
-Waits until the specified web socket has been received.
-
-#### **Arguments**:
-
-- filename `number | RegExp`
-
-#### **Returns**: [`Promise<WebSocketResource>`](../advanced/websocket-resource)
 
 ## Events
 


### PR DESCRIPTION
This PR adds a few small features:
- goto, goBack, goForward all have optional timeoutMs params. Default to 30 seconds. 0 will clear out any timeout
- Tab.reload: ability to trigger a reload
- Replay will now load from a local dist build if present (order of precedence is 1) local build, 2) monorepo, 3) binary
- Replay has a "bin" that will be distributed with replay, so you can run `yarn replay` from anywhere you've installed secret-agent/replay (note: this will work from the build directory, but not the top level of the monorepo). It opens to the dashboard and loads up a default node-path so it can launch core

Closes #112 