### PR TITLE
feat(core): friendly message setting cookies

### DIFF
--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -354,11 +354,20 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     options?: ISetCookieOptions,
   ): Promise<boolean> {
     await this.navigationsObserver.waitForReady();
+    const url = this.puppetPage.mainFrame.url;
+    if (url === 'about:blank') {
+      throw new Error(`Chrome won't allow you to set cookies on a blank tab.
+
+SecretAgent supports two options to set cookies:
+a) Goto a url first and then set cookies on the activeTab
+b) Use the UserProfile feature to set cookies for 1 or more domains before they're loaded (https://secretagent.dev/docs/advanced/user-profile)
+      `);
+    }
     await this.session.browserContext.addCookies([
       {
         name,
         value,
-        url: this.puppetPage.mainFrame.url,
+        url,
         ...options,
       },
     ]);

--- a/full-client/test/basic.test.ts
+++ b/full-client/test/basic.test.ts
@@ -169,6 +169,15 @@ describe('basic Full Client tests', () => {
     }
   });
 
+  it('should send a friendly message if trying to set cookies before a url is loaded', async () => {
+    const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
+
+    await expect(agent.activeTab.cookieStorage.setItem('test', 'test')).rejects.toThrowError(
+      "Chrome won't allow you to set cookies on a blank tab.",
+    );
+  });
+
   it('can get and set localStorage', async () => {
     const agent = await handler.createAgent();
     Helpers.needsClosing.push(agent);


### PR DESCRIPTION
Adding messages directing users how to set cookies before a page has loaded.

fix for #142