### PR TITLE
fix(client): fix reviving stack traces in typeson

### DIFF
--- a/client/lib/Handler.ts
+++ b/client/lib/Handler.ts
@@ -1,10 +1,13 @@
 import { createPromise, pickRandom } from '@secret-agent/commons/utils';
 import ShutdownHandler from '@secret-agent/commons/ShutdownHandler';
+import Log from '@secret-agent/commons/Logger';
 import IAgentCreateOptions from '../interfaces/IAgentCreateOptions';
 import IConnectionToCoreOptions from '../interfaces/IConnectionToCoreOptions';
 import Agent from './Agent';
 import ConnectionToCore from '../connections/ConnectionToCore';
 import ConnectionFactory from '../connections/ConnectionFactory';
+
+const { log } = Log(module);
 
 export default class Handler {
   public defaultAgentOptions: IAgentCreateOptions = {};
@@ -99,6 +102,10 @@ export default class Handler {
   }
 
   private async logUnhandledError(error: Error): Promise<void> {
+    // if error and there are remote connections, log error here
+    if (error && this.connections.some(x => !!x.options.host)) {
+      log.error('UnhandledRejection', { error, sessionId: null });
+    }
     // eslint-disable-next-line promise/no-promise-in-callback
     await Promise.all(this.connections.map(x => x.logUnhandledError(error)));
   }

--- a/commons/TypeSerializer.ts
+++ b/commons/TypeSerializer.ts
@@ -15,7 +15,28 @@ const buffer = {
   },
 };
 
-const TSON = new Typeson().register(TypesonRegistry).register(buffer);
+const error = {
+  error: {
+    test(x) {
+      return Typeson.toStringTag(x) === 'Error';
+    },
+    replace({ name, message, stack }) {
+      return { name, message, stack };
+    },
+    revive({ name, message, stack }) {
+      let Constructor = Error;
+      if (global[name]) {
+        Constructor = global[name];
+      }
+      const e = new Constructor(message);
+      e.name = name;
+      if (stack) e.stack = stack;
+      return e;
+    },
+  },
+};
+
+const TSON = new Typeson().register(TypesonRegistry).register(buffer).register(error);
 
 export default class TypeSerializer {
   static stringify(object: any): string {


### PR DESCRIPTION
Revives stack traces for errors instead of using a typeson, confusing stack. If Core is not running in a "child process", also log unhandled errors locally.