### PR TITLE
Timeout mouse

### DIFF
--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -440,6 +440,7 @@ describe('PaintingStable tests', () => {
     koaServer.get('/grid/:filename', async ctx => {
       const filename = ctx.params.filename;
       if (filename === 'data.json') {
+        await new Promise(resolve => setTimeout(resolve, 100));
         const records = [];
         for (let i = 0; i < 200; i += 1) {
           records.push(

--- a/examples/ulixee.org.ts
+++ b/examples/ulixee.org.ts
@@ -27,4 +27,5 @@ import { Handler, Agent } from 'secret-agent';
   });
 
   await handler.waitForAllDispatches();
+  await handler.close();
 })();

--- a/puppet-chrome/lib/Browser.ts
+++ b/puppet-chrome/lib/Browser.ts
@@ -77,7 +77,9 @@ export class Browser extends TypedEventEmitter<IBrowserEvents> implements IPuppe
   private onAttachedToTarget(event: Protocol.Target.AttachedToTargetEvent) {
     const { targetInfo, sessionId } = event;
 
-    assert(targetInfo.browserContextId, `targetInfo: ${JSON.stringify(targetInfo, null, 2)}`);
+    if (!targetInfo.browserContextId) {
+      assert(targetInfo.browserContextId, `targetInfo: ${JSON.stringify(targetInfo, null, 2)}`);
+    }
 
     if (targetInfo.type === 'page') {
       const cdpSession = this.connection.getSession(sessionId);

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -15,7 +15,6 @@ import { IBoundLog } from '@secret-agent/core-interfaces/ILog';
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import IRegisteredEventListener from '@secret-agent/core-interfaces/IRegisteredEventListener';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
-import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import { Page } from './Page';
 import { Browser } from './Browser';
 import { CDPSession } from './CDPSession';

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -15,6 +15,7 @@ import { IBoundLog } from '@secret-agent/core-interfaces/ILog';
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import IRegisteredEventListener from '@secret-agent/core-interfaces/IRegisteredEventListener';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import { Page } from './Page';
 import { Browser } from './Browser';
 import { CDPSession } from './CDPSession';
@@ -41,6 +42,7 @@ export class BrowserContext
 
   private _emulation: IBrowserEmulationSettings;
 
+  private readonly createdTargetIds = new Set<string>();
   private readonly pages: Page[] = [];
   private readonly browser: Browser;
   private readonly id: string;
@@ -76,6 +78,7 @@ export class BrowserContext
       url: 'about:blank',
       browserContextId: this.id,
     });
+    this.createdTargetIds.add(targetId);
 
     await this.attachToTarget(targetId);
 
@@ -111,7 +114,7 @@ export class BrowserContext
 
     let opener = targetInfo.openerId ? this.getPageWithId(targetInfo.openerId) || null : null;
     // make the first page the active page
-    if (!opener && this.pages.length) opener = this.pages[0];
+    if (!opener && !this.createdTargetIds.has(targetInfo.targetId)) opener = this.pages[0];
     const page = new Page(cdpSession, targetInfo.targetId, this, this.logger, opener);
     this.pages.push(page);
     // eslint-disable-next-line promise/catch-or-return

--- a/puppet-chrome/lib/CDPSession.ts
+++ b/puppet-chrome/lib/CDPSession.ts
@@ -18,9 +18,10 @@
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import { Protocol } from 'devtools-protocol';
 import { EventEmitter } from 'events';
-import { IConnectionCallback } from '@secret-agent/puppet-interfaces/IConnectionCallback';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import { TypedEventEmitter } from '@secret-agent/commons/eventUtils';
+import IResolvablePromise from '@secret-agent/core-interfaces/IResolvablePromise';
+import { createPromise } from '@secret-agent/commons/utils';
 import ProtocolError from './ProtocolError';
 import { Connection } from './Connection';
 import RemoteObject = Protocol.Runtime.RemoteObject;
@@ -39,7 +40,10 @@ export class CDPSession extends EventEmitter {
 
   private readonly sessionId: string;
   private readonly targetType: string;
-  private readonly pendingMessages: Map<number, IConnectionCallback> = new Map();
+  private readonly pendingMessages: Map<
+    number,
+    { resolvable: IResolvablePromise<any>; method: string }
+  > = new Map();
 
   constructor(connection: Connection, targetType: string, sessionId: string) {
     super();
@@ -54,7 +58,7 @@ export class CDPSession extends EventEmitter {
     sendInitiator?: object,
   ): Promise<ProtocolMapping.Commands[T]['returnType']> {
     if (!this.isConnected()) {
-      throw new CanceledPromiseError(`Session closed before api call (${method})`);
+      throw new CanceledPromiseError(`${method} called after session closed (${this.sessionId})`);
     }
 
     const message = {
@@ -71,28 +75,29 @@ export class CDPSession extends EventEmitter {
       },
       sendInitiator,
     );
+    const resolvable = createPromise<ProtocolMapping.Commands[T]['returnType']>();
 
-    return await new Promise((resolve, reject) => {
-      this.pendingMessages.set(id, { resolve, reject, error: new CanceledPromiseError(), method });
-    });
+    this.pendingMessages.set(id, { resolvable, method });
+    return await resolvable.promise;
   }
 
   onMessage(object: ICDPSendResponseMessage & ICDPEventMessage): void {
     this.messageEvents.emit('receive', { ...object });
     if (!object.id) {
-      setImmediate(() => this.emit(object.method, object.params));
+      this.emit(object.method, object.params);
       return;
     }
 
-    const callback = this.pendingMessages.get(object.id);
-    if (!callback) return;
+    const pending = this.pendingMessages.get(object.id);
+    if (!pending) return;
+
+    const { resolvable, method } = pending;
 
     this.pendingMessages.delete(object.id);
     if (object.error) {
-      const protocolError = new ProtocolError(callback.error.stack, callback.method, object.error);
-      setImmediate(() => callback.reject(protocolError));
+      resolvable.reject(new ProtocolError(resolvable.stack, method, object.error));
     } else {
-      setImmediate(() => callback.resolve(object.result));
+      resolvable.resolve(object.result);
     }
   }
 
@@ -105,10 +110,13 @@ export class CDPSession extends EventEmitter {
   }
 
   onClosed(): void {
-    for (const callback of this.pendingMessages.values()) {
-      const error = callback.error;
-      error.message = `Cancel Pending Promise (${callback.method}): Target closed.`;
-      callback.reject(error);
+    for (const { resolvable, method } of this.pendingMessages.values()) {
+      const error = new CanceledPromiseError(`Cancel Pending Promise (${method}): Target closed.`);
+      error.stack += `\n${'------DEVTOOLS'.padEnd(
+        50,
+        '-',
+      )}\n${`------DEVTOOLS-SESSION-ID =${this.sessionId}`.padEnd(50, '-')}\n${resolvable.stack}`;
+      resolvable.reject(error);
     }
     this.pendingMessages.clear();
     this.connection = null;

--- a/puppet-chrome/lib/Connection.ts
+++ b/puppet-chrome/lib/Connection.ts
@@ -22,14 +22,13 @@ import {
 import IConnectionTransport, {
   IConnectionTransportEvents,
 } from '@secret-agent/puppet-interfaces/IConnectionTransport';
-import { IPuppetConnectionEvents } from '@secret-agent/puppet-interfaces/IPuppetConnection';
 import IRegisteredEventListener from '@secret-agent/core-interfaces/IRegisteredEventListener';
 import Log from '@secret-agent/commons/Logger';
 import { CDPSession } from './CDPSession';
 
 const { log } = Log(module);
 
-export class Connection extends TypedEventEmitter<IPuppetConnectionEvents> {
+export class Connection extends TypedEventEmitter<{ disconnected: void }> {
   public readonly rootSession: CDPSession;
   public isClosed = false;
 
@@ -85,7 +84,6 @@ export class Connection extends TypedEventEmitter<IPuppetConnectionEvents> {
 
     const cdpSession = this.sessionsById.get(object.sessionId || '');
     if (cdpSession) {
-      // make asynchronous so we don't have accidental bugs where things are behaving synchronous until stack backs up
       cdpSession.onMessage(object);
     } else {
       log.warn('MessageWithUnknownSession', { sessionId: null, message: object });

--- a/puppet-interfaces/IConnectionCallback.ts
+++ b/puppet-interfaces/IConnectionCallback.ts
@@ -1,6 +1,0 @@
-export interface IConnectionCallback {
-  resolve: Function;
-  reject: Function;
-  error: Error;
-  method: string;
-}

--- a/puppet-interfaces/IPuppetConnection.ts
+++ b/puppet-interfaces/IPuppetConnection.ts
@@ -1,7 +1,0 @@
-import ITypedEventEmitter from '@secret-agent/core-interfaces/ITypedEventEmitter';
-
-export default interface IPuppetConnection extends ITypedEventEmitter<IPuppetConnectionEvents> {}
-
-export interface IPuppetConnectionEvents {
-  disconnected: void;
-}

--- a/puppet-interfaces/IPuppetEngine.ts
+++ b/puppet-interfaces/IPuppetEngine.ts
@@ -1,4 +1,0 @@
-export default interface IPuppetEngine {
-  browser: string;
-  revision: string;
-}

--- a/puppet-interfaces/IPuppetWorker.ts
+++ b/puppet-interfaces/IPuppetWorker.ts
@@ -4,6 +4,7 @@ export interface IPuppetWorker extends ITypedEventEmitter<IPuppetWorkerEvents> {
   id: string;
   url: string;
   type: string;
+  isReady: Promise<Error | null>;
   evaluate<T>(expression: string): Promise<T>;
 }
 

--- a/puppet/lib/PipeTransport.ts
+++ b/puppet/lib/PipeTransport.ts
@@ -44,6 +44,7 @@ export class PipeTransport
         log.error('PipeTransport.WriteError', { error, sessionId: null }),
       ),
     );
+    this.emit = this.emit.bind(this);
   }
 
   send(message: string) {
@@ -68,15 +69,19 @@ export class PipeTransport
       return;
     }
     const message = this.pendingMessage + buffer.toString(undefined, 0, end);
-    this.emit('message', message);
+    this.emitMessage(message);
 
     let start = end + 1;
     end = buffer.indexOf('\0', start);
     while (end !== -1) {
-      this.emit('message', buffer.toString(undefined, start, end));
+      this.emitMessage(buffer.toString(undefined, start, end));
       start = end + 1;
       end = buffer.indexOf('\0', start);
     }
     this.pendingMessage = buffer.toString(undefined, start);
+  }
+
+  private emitMessage(message: string): void {
+    setImmediate(this.emit, 'message', message);
   }
 }

--- a/puppet/test/Worker.test.ts
+++ b/puppet/test/Worker.test.ts
@@ -49,7 +49,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       const worker = page.workers[0];
       expect(worker.url).toContain('worker.js');
 
-      await new Promise(setImmediate);
+      await worker.isReady;
 
       expect(await worker.evaluate(`self.workerFunction()`)).toBe('worker function result');
 

--- a/website/docs/Advanced/Remote.md
+++ b/website/docs/Advanced/Remote.md
@@ -6,7 +6,7 @@ You'll need a simple script to start the server on the machine where the `secret
 
 ## Setting Up a Server Process
 
-Below is code you can use to start Core in your own server process.
+Below is code you can use to start Core in your own server process. NOTE: you can also simply run the 'start.js' script that is packaged with `@secret-agent/core` at `@secret-agent/core/start`;
 
 ```javascript
 // SERVER ip is 122.22.232.1
@@ -17,7 +17,7 @@ const Core = require('@secret-agent/core');
     log.info('Exiting Core Process');
     process.exit();
   };
-  await Core.start({ port: 7007 });
+  await Core.start({ coreServerPort: 7007 });
 })();
 ```
 


### PR DESCRIPTION
Fixes 2 issues:
1) If you open multiple windows (or links have not cleaned up old ones yet), you can end up with an "opener" of a popup being another regular window. This means closing can have weird effects (like in the Page.popups tests that occasionally failed for this reason)
2) If the page navigates out under you, we need to cancel pending interactions