### PR TITLE
Worker UserAgents/Platform, Bug fixes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -59,7 +59,7 @@ jobs:
   test:
     name: Test Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
     needs: lint
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -62,11 +62,12 @@ export default abstract class ConnectionToCore {
         return this.internalSendRequestAndWait({
           command: 'connect',
           args: [
-            <ICoreConfigureOptions>{
+            <ICoreConfigureOptions & { isPersistent: boolean }>{
               coreServerPort: this.options.coreServerPort,
               browserEmulatorIds: this.options.browserEmulatorIds,
               localProxyPortStart: this.options.localProxyPortStart,
               sessionsDir: this.options.sessionsDir,
+              isPersistent: this.options.isPersistent,
             },
           ],
         });

--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -7,6 +7,7 @@ import Log from '@secret-agent/commons/Logger';
 import ICreateSessionOptions from '@secret-agent/core-interfaces/ICreateSessionOptions';
 import ISessionMeta from '@secret-agent/core-interfaces/ISessionMeta';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+import ICoreConfigureOptions from '@secret-agent/core-interfaces/ICoreConfigureOptions';
 import IConnectionToCoreOptions from '../interfaces/IConnectionToCoreOptions';
 import CoreCommandQueue from '../lib/CoreCommandQueue';
 import CoreSession from '../lib/CoreSession';
@@ -60,7 +61,14 @@ export default abstract class ConnectionToCore {
         if (err) throw err;
         return this.internalSendRequestAndWait({
           command: 'connect',
-          args: [this.options],
+          args: [
+            <ICoreConfigureOptions>{
+              coreServerPort: this.options.coreServerPort,
+              browserEmulatorIds: this.options.browserEmulatorIds,
+              localProxyPortStart: this.options.localProxyPortStart,
+              sessionsDir: this.options.sessionsDir,
+            },
+          ],
         });
       })
       .then(result => this.onConnected(result.data))

--- a/client/lib/ResourceResponse.ts
+++ b/client/lib/ResourceResponse.ts
@@ -2,6 +2,7 @@ import initializeConstantsAndProperties from 'awaited-dom/base/initializeConstan
 import StateMachine from 'awaited-dom/base/StateMachine';
 import IResourceHeaders from '@secret-agent/core-interfaces/IResourceHeaders';
 import IResourceResponse from '@secret-agent/core-interfaces/IResourceResponse';
+import IHttpResourceLoadDetails from '@secret-agent/core-interfaces/IHttpResourceLoadDetails';
 import CoreSession from './CoreTab';
 
 const { getState, setState } = StateMachine<ResourceResponse, IState>();
@@ -18,12 +19,24 @@ const propertyKeys: (keyof ResourceResponse)[] = [
   'remoteAddress',
   'statusCode',
   'statusMessage',
+  'browserLoadFailure',
+  'browserServedFromCache',
   'data',
 ];
 
 export default class ResourceResponse {
   constructor() {
     initializeConstantsAndProperties(this, [], propertyKeys);
+  }
+
+  public get browserServedFromCache(): Promise<
+    null | IHttpResourceLoadDetails['browserServedFromCache']
+  > {
+    return getResponseProperty(this, 'browserServedFromCache');
+  }
+
+  public get browserLoadFailure(): Promise<string> {
+    return getResponseProperty(this, 'browserLoadFailure');
   }
 
   public get headers(): Promise<IResourceHeaders> {

--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -96,12 +96,13 @@ class Log implements ILog {
 
       const params = Object.keys(printData).length ? [printData] : [];
       if (error) params.push(error);
+      const useColors = process.env.NODE_DISABLE_COLORS !== 'true';
       // eslint-disable-next-line no-console
       console.log(
         `${entry.timestamp.toISOString()} ${entry.level.toUpperCase()} [${printablePath}] ${
           entry.action
         }`,
-        ...params.map(x => inspect(x, false, null, true)),
+        ...params.map(x => inspect(x, false, null, useColors)),
       );
     }
     LogEvents.broadcast(entry);

--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -96,7 +96,8 @@ class Log implements ILog {
 
       const params = Object.keys(printData).length ? [printData] : [];
       if (error) params.push(error);
-      const useColors = process.env.NODE_DISABLE_COLORS !== 'true';
+      const useColors =
+        process.env.NODE_DISABLE_COLORS !== 'true' && process.env.NODE_DISABLE_COLORS !== '1';
       // eslint-disable-next-line no-console
       console.log(
         `${entry.timestamp.toISOString()} ${entry.level.toUpperCase()} [${printablePath}] ${

--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -2,6 +2,8 @@
 import ILog, { ILogData } from '@secret-agent/core-interfaces/ILog';
 import { inspect } from 'util';
 
+const hasBeenLoggedSymbol = Symbol.for('hasBeenLogged');
+
 let logId = 0;
 class Log implements ILog {
   public readonly level: string = process.env.DEBUG ? 'stats' : 'error';
@@ -81,6 +83,10 @@ class Log implements ILog {
         if (value === undefined || value === null) continue;
         if (value instanceof Error) {
           printData[key] = value.toString();
+          Object.defineProperty(value, hasBeenLoggedSymbol, {
+            enumerable: false,
+            value: true,
+          });
           error = value;
         } else if ((value as any).toJSON) {
           printData[key] = (value as any).toJSON();
@@ -148,7 +154,7 @@ class LogEvents {
   }
 }
 
-export { LogEvents, loggerSessionIdNames };
+export { LogEvents, loggerSessionIdNames, hasBeenLoggedSymbol };
 
 export function injectLogger(builder: (module: NodeModule) => ILogBuilder): void {
   logCreator = builder;

--- a/core-interfaces/IAgentMeta.ts
+++ b/core-interfaces/IAgentMeta.ts
@@ -3,5 +3,6 @@ import ICreateSessionOptions from './ICreateSessionOptions';
 export default interface IAgentMeta
   extends Omit<Required<ICreateSessionOptions>, 'userProfile' | 'scriptInstanceMeta'> {
   userAgentString: string;
+  osPlatform: string;
   sessionId: string;
 }

--- a/core-interfaces/IBrowserEmulator.ts
+++ b/core-interfaces/IBrowserEmulator.ts
@@ -1,7 +1,8 @@
+import { IPuppetWorker } from '@secret-agent/puppet-interfaces/IPuppetWorker';
 import INetworkInterceptorDelegate from './INetworkInterceptorDelegate';
 import IUserProfile from './IUserProfile';
 import INewDocumentInjectedScript from './INewDocumentInjectedScript';
-import IWindowFraming from "./IWindowFraming";
+import IWindowFraming from './IWindowFraming';
 
 export default interface IBrowserEmulator {
   readonly userAgentString: string;
@@ -15,4 +16,7 @@ export default interface IBrowserEmulator {
   sessionId?: string;
 
   newDocumentInjectedScripts(): Promise<INewDocumentInjectedScript[]>;
+  newWorkerInjectedScripts(
+    workerType: IPuppetWorker['type'],
+  ): Promise<INewDocumentInjectedScript[]>;
 }

--- a/core-interfaces/IHttpResourceLoadDetails.ts
+++ b/core-interfaces/IHttpResourceLoadDetails.ts
@@ -39,7 +39,7 @@ export default interface IHttpResourceLoadDetails {
   responseTrailers?: IResourceHeaders;
   resourceType?: ResourceType;
   browserRequestId?: string;
-  browserServedFromCache?: 'service-worker' | 'disk' | 'prefetch' | 'unspecified';
+  browserServedFromCache?: 'service-worker' | 'disk' | 'prefetch' | 'memory';
   browserLoadFailure?: string;
   browserBlockedReason?: string;
   browserCanceled?: boolean;

--- a/core-interfaces/IResourceResponse.ts
+++ b/core-interfaces/IResourceResponse.ts
@@ -1,10 +1,13 @@
 import IResourceHeaders from './IResourceHeaders';
+import IHttpResourceLoadDetails from './IHttpResourceLoadDetails';
 
 export default interface IResourceResponse {
   url: string;
   timestamp: string;
   headers: IResourceHeaders;
   trailers?: IResourceHeaders;
+  browserServedFromCache?: IHttpResourceLoadDetails['browserServedFromCache'];
+  browserLoadFailure?: string;
   remoteAddress: string;
   statusCode: number;
   statusMessage?: string;

--- a/core/index.ts
+++ b/core/index.ts
@@ -1,6 +1,6 @@
 import ICoreConfigureOptions from '@secret-agent/core-interfaces/ICoreConfigureOptions';
 import { LocationTrigger } from '@secret-agent/core-interfaces/Location';
-import Log from '@secret-agent/commons/Logger';
+import Log, { hasBeenLoggedSymbol } from '@secret-agent/commons/Logger';
 import ConnectionToClient from './server/ConnectionToClient';
 import CoreServer from './server';
 import Session from './lib/Session';
@@ -98,8 +98,7 @@ export default class Core {
   public static logUnhandledError(clientError: Error, fatalError = false): void {
     if (fatalError) {
       log.error('UnhandledError(fatal)', { clientError, sessionId: null });
-    } else {
-      if ((clientError as any).handled) return;
+    } else if (!clientError[hasBeenLoggedSymbol]) {
       log.error('UnhandledErrorOrRejection', { clientError, sessionId: null });
     }
   }

--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -220,6 +220,9 @@ export default class SessionState {
     const resource = this.resourceEventToMeta(tabId, resourceEvent);
     this.db.resources.insert(tabId, resource, null, resourceEvent, error);
 
+    if (!this.resources.some(x => x.id === resourceEvent.id)) {
+      this.resources.push(resource);
+    }
     const navigations = this.navigationsByTabId[tabId];
     if (!navigations) return;
 
@@ -301,7 +304,7 @@ export default class SessionState {
       },
     } as IResourceMeta;
 
-    if (response?.statusCode) {
+    if (response?.statusCode || response?.browserServedFromCache || response?.browserLoadFailure) {
       resource.response = response;
       if (response.url) resource.url = response.url;
       else resource.response.url = request.url;

--- a/core/server/ConnectionToClient.ts
+++ b/core/server/ConnectionToClient.ts
@@ -145,6 +145,7 @@ export default class ConnectionToClient extends TypedEventEmitter<{
       blockedResourceTypes: session.options.blockedResourceTypes,
       upstreamProxyUrl: session.upstreamProxyUrl,
       userAgentString: session.browserEmulator.userAgentString,
+      osPlatform: session.browserEmulator.osPlatform,
     };
   }
 

--- a/core/server/ConnectionToClient.ts
+++ b/core/server/ConnectionToClient.ts
@@ -101,15 +101,22 @@ export default class ConnectionToClient extends TypedEventEmitter<{
 
   public logUnhandledError(error: Error, fatalError = false): void {
     if (fatalError) {
-      log.error('Client.UnhandledError(fatal)', { clientError: error, sessionId: null });
+      log.error('ConnectionToClient.UnhandledError(fatal)', {
+        clientError: error,
+        sessionId: null,
+      });
     } else {
-      log.error('Client.UnhandledErrorOrRejection', { clientError: error, sessionId: null });
+      log.error('ConnectionToClient.UnhandledErrorOrRejection', {
+        clientError: error,
+        sessionId: null,
+      });
     }
   }
 
   public async disconnect(fatalError?: Error): Promise<void> {
     if (this.isClosing) return;
     this.isClosing = true;
+    const logId = log.stats('ConnectionToClient.Disconnecting', { sessionId: null, fatalError });
     clearTimeout(this.autoShutdownTimer);
     const closeAll: Promise<any>[] = [];
     for (const id of this.sessionIds) {
@@ -119,6 +126,7 @@ export default class ConnectionToClient extends TypedEventEmitter<{
     await Promise.all(closeAll);
     this.isPersistent = false;
     this.emit('close', { fatalError });
+    log.stats('ConnectionToClient.Disconnected', { sessionId: null, parentLogId: logId });
   }
 
   public isActive() {

--- a/core/test/basic.test.ts
+++ b/core/test/basic.test.ts
@@ -47,6 +47,7 @@ describe('basic Core tests', () => {
 
     expect(shutdownSpy).toHaveBeenCalledTimes(1);
     expect(connectionCloseSpy).toHaveBeenCalled();
+    await Core.shutdown();
   });
 
   it('will not shutdown if start called and there are no open connections', async () => {

--- a/core/test/domRecorder.test.ts
+++ b/core/test/domRecorder.test.ts
@@ -246,6 +246,7 @@ function sort() {
     const domFrames = domChanges.filter(x => x.tagName === 'IFRAME');
     expect(domFrames).toHaveLength(3);
 
+    await tab.puppetPage.frames[3].waitForLoad();
     const frames = state.db.frames.all();
     expect(frames).toHaveLength(4);
     const test1 = frames.find(x => x.name === 'test1');

--- a/emulate-browsers/base/injected-scripts/.eslintrc.js
+++ b/emulate-browsers/base/injected-scripts/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'prefer-rest-params': 'off',
     'max-classes-per-file': 'off',
     'func-names': 'off',
+    'no-restricted-globals': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
   },
 };

--- a/emulate-browsers/base/injected-scripts/Document.prototype.cookie.ts
+++ b/emulate-browsers/base/injected-scripts/Document.prototype.cookie.ts
@@ -1,12 +1,12 @@
 declare let args: any;
 const triggerName = args.callbackName;
 
-if (!window[triggerName]) throw new Error('No cookie trigger');
-const cookieTrigger = ((window[triggerName] as unknown) as Function).bind(window);
+if (!self[triggerName]) throw new Error('No cookie trigger');
+const cookieTrigger = ((self[triggerName] as unknown) as Function).bind(self);
 
-delete window[triggerName];
+delete self[triggerName];
 
 proxySetter(Document.prototype, 'cookie', (target, thisArg, cookie) => {
-  cookieTrigger(JSON.stringify({ cookie, origin: window.location.origin }));
+  cookieTrigger(JSON.stringify({ cookie, origin: self.location.origin }));
   return ProxyOverride.callOriginal;
 });

--- a/emulate-browsers/base/injected-scripts/Error.captureStackTrace.ts
+++ b/emulate-browsers/base/injected-scripts/Error.captureStackTrace.ts
@@ -1,4 +1,4 @@
-proxyFunction(window.Error, 'captureStackTrace', (target, thisArg, argArray) => {
+proxyFunction(self.Error, 'captureStackTrace', (target, thisArg, argArray) => {
   if (argArray.length < 1) return target.apply(thisArg, argArray);
 
   const [addToObject] = argArray;

--- a/emulate-browsers/base/injected-scripts/Error.constructor.ts
+++ b/emulate-browsers/base/injected-scripts/Error.constructor.ts
@@ -1,4 +1,4 @@
-proxyConstructor(window, 'Error', function() {
+proxyConstructor(self, 'Error', function () {
   const err = ReflectCached.construct(...arguments);
   cleanErrorStack(err);
   return err;

--- a/emulate-browsers/base/injected-scripts/HTMLIFrameElement.prototype.ts
+++ b/emulate-browsers/base/injected-scripts/HTMLIFrameElement.prototype.ts
@@ -9,9 +9,9 @@ proxyGetter(HTMLIFrameElement.prototype, 'contentWindow', (target, iframe) => {
   return ProxyOverride.callOriginal;
 });
 
-proxySetter(HTMLIFrameElement.prototype, 'srcdoc', function(_, iframe) {
+proxySetter(HTMLIFrameElement.prototype, 'srcdoc', function (_, iframe) {
   if (!frameWindowProxies.has(iframe)) {
-    const proxy = new Proxy(window, {
+    const proxy = new Proxy(self, {
       get(target, key) {
         if (key === 'self') {
           return iframe.contentWindow;
@@ -23,7 +23,7 @@ proxySetter(HTMLIFrameElement.prototype, 'srcdoc', function(_, iframe) {
         if (key === 'frameElement') {
           return iframe;
         }
-        return ReflectCached.get(window, key);
+        return ReflectCached.get(self, key);
       },
     });
 

--- a/emulate-browsers/base/injected-scripts/MediaRecorder.isTypeSupported.ts
+++ b/emulate-browsers/base/injected-scripts/MediaRecorder.isTypeSupported.ts
@@ -1,8 +1,13 @@
 const { supportedCodecs } = args;
 
-if ((window as any).MediaRecorder) {
-  proxyFunction((window as any).MediaRecorder, 'isTypeSupported', (func, thisArg, [type]) => {
+if ('MediaRecorder' in self) {
+  proxyFunction((self as any).MediaRecorder, 'isTypeSupported', (func, thisArg, [type]) => {
     if (type === undefined) return ProxyOverride.callOriginal;
     return supportedCodecs.includes(type);
   });
 }
+
+proxyFunction(self.MediaSource, 'isTypeSupported', (func, thisArg, [type]) => {
+  if (type === undefined) return ProxyOverride.callOriginal;
+  return supportedCodecs.includes(type);
+});

--- a/emulate-browsers/base/injected-scripts/_descriptorBuilder.ts
+++ b/emulate-browsers/base/injected-scripts/_descriptorBuilder.ts
@@ -13,7 +13,7 @@ function createError(message: string, type?: { new (message: string): any }) {
     if (match.length) {
       message = message.replace(`${match[1]}: `, '');
       try {
-        type = window[match[1]];
+        type = self[match[1]];
       } catch (err) {
         // ignore
       }
@@ -151,7 +151,7 @@ function breakdownPath(path: string, propsToLeave) {
   }
 
   const parts = path.split(/\.Symbol\(([\w.]+)\)|\.(\w+)/).filter(Boolean);
-  let obj: any = window;
+  let obj: any = self;
   while (parts.length > propsToLeave) {
     let next: string | symbol = parts.shift();
     if (next === 'window') continue;

--- a/emulate-browsers/base/injected-scripts/_proxyUtils.ts
+++ b/emulate-browsers/base/injected-scripts/_proxyUtils.ts
@@ -6,23 +6,35 @@ let nativeToStringFunctionString = `${Function.toString}`;
 const overriddenFns = new Map<Function, string>();
 
 // eslint-disable-next-line no-extend-native
-Function.prototype.toString = new Proxy(Function.prototype.toString, {
-  apply(target: () => string, thisArg: any, args?: any): any {
-    if (overriddenFns.has(thisArg)) {
-      return overriddenFns.get(thisArg);
-    }
-    // from puppeteer-stealth: Check if the toString prototype of the context is the same as the global prototype,
-    // if not indicates that we are doing a check across different windows
-    const hasSameProto = Object.getPrototypeOf(Function.prototype.toString).isPrototypeOf(
-      thisArg.toString,
-    );
-    if (hasSameProto === false) {
-      // Pass the call on to the local Function.prototype.toString instead
-      return thisArg.toString(...(args ?? []));
-    }
-
-    return target.apply(thisArg, args);
-  },
+Object.defineProperty(Function.prototype, 'toString', {
+  ...Object.getOwnPropertyDescriptor(Function.prototype, 'toString'),
+  value: new Proxy(Function.prototype.toString, {
+    apply(target: () => string, thisArg: any, args?: any): any {
+      if (overriddenFns.has(thisArg)) {
+        return overriddenFns.get(thisArg);
+      }
+      // from puppeteer-stealth: Check if the toString prototype of the context is the same as the global prototype,
+      // if not indicates that we are doing a check across different windows
+      const hasSameProto = Object.getPrototypeOf(Function.prototype.toString).isPrototypeOf(
+        thisArg.toString,
+      );
+      if (hasSameProto === false) {
+        // Pass the call on to the local Function.prototype.toString instead
+        return thisArg.toString(...(args ?? []));
+      }
+      try {
+        return target.apply(thisArg, args);
+      } catch (error) {
+        cleanErrorStack(error, (line, i) => {
+          if (line.includes('Object.toString') && i === 1) {
+            return line.replace('Object.toString', 'Function.toString');
+          }
+          return line;
+        });
+        throw error;
+      }
+    },
+  }),
 });
 overriddenFns.set(Function.prototype.toString, nativeToStringFunctionString);
 
@@ -44,18 +56,21 @@ enum ProxyOverride {
 
 declare let sourceUrl: string;
 
-function cleanErrorStack(error: Error) {
+function cleanErrorStack(error: Error, replaceLineFn?: (line: string, index: number) => string) {
   if (!error.stack) return error;
 
+  const split = error.stack.includes('\r\n') ? '\r\n' : '\n';
   const stack = error.stack.split(/\r?\n/);
   const newStack = [];
   for (let i = 0; i < stack.length; i += 1) {
-    if (stack[i].includes(sourceUrl)) {
+    let line = stack[i];
+    if (line.includes(sourceUrl)) {
       continue;
     }
-    newStack.push(stack[i]);
+    if (replaceLineFn) line = replaceLineFn(line, i);
+    newStack.push(line);
   }
-  error.stack = newStack.join('\n');
+  error.stack = newStack.join(split);
   return error;
 }
 

--- a/emulate-browsers/base/injected-scripts/_proxyUtils.ts
+++ b/emulate-browsers/base/injected-scripts/_proxyUtils.ts
@@ -240,7 +240,7 @@ function addDescriptorAfterProperty(
   }
 }
 
-if (typeof window === 'undefined') {
+if (typeof module === 'object' && typeof module.exports === 'object') {
   module.exports = {
     proxyFunction,
   };

--- a/emulate-browsers/base/injected-scripts/navigator.deviceMemory.ts
+++ b/emulate-browsers/base/injected-scripts/navigator.deviceMemory.ts
@@ -1,4 +1,8 @@
-if ('WorkerGlobalScope' in self || self.location.protocol === 'https:') {
+if (
+  'WorkerGlobalScope' in self ||
+  self.location.protocol === 'https:' ||
+  'deviceMemory' in navigator
+) {
   // @ts-ignore
   proxyGetter(navigator, 'deviceMemory', () => args.memory, true);
 }

--- a/emulate-browsers/base/injected-scripts/navigator.deviceMemory.ts
+++ b/emulate-browsers/base/injected-scripts/navigator.deviceMemory.ts
@@ -1,4 +1,4 @@
-if (window.location?.protocol === 'https:') {
+if ('WorkerGlobalScope' in self || self.location.protocol === 'https:') {
   // @ts-ignore
-  proxyGetter(window.navigator, 'deviceMemory', () => args.memory, true);
+  proxyGetter(navigator, 'deviceMemory', () => args.memory, true);
 }

--- a/emulate-browsers/base/injected-scripts/navigator.plugins.ts
+++ b/emulate-browsers/base/injected-scripts/navigator.plugins.ts
@@ -105,9 +105,6 @@ const pluginList: Plugin[] = args.plugins.map(fakeP => {
     true,
   );
 
-  // @ts-ignore - Typescript has problems pulling in extensions like Symbol.iterator
-  // proxyFunction(plugin, Symbol.iterator, () => [...pluginMimes.map(createMime)], true);
-
   plugin = new Proxy(plugin, {
     get(target, p) {
       if (mimeProps.includes(p)) {
@@ -131,5 +128,5 @@ const navigatorPlugins = createNamedNodeMap(
   'name',
 ) as PluginArray;
 
-proxyGetter(window.navigator, 'mimeTypes', () => mimes, true);
-proxyGetter(window.navigator, 'plugins', () => navigatorPlugins, true);
+proxyGetter(navigator, 'mimeTypes', () => mimes, true);
+proxyGetter(navigator, 'plugins', () => navigatorPlugins, true);

--- a/emulate-browsers/base/injected-scripts/navigator.ts
+++ b/emulate-browsers/base/injected-scripts/navigator.ts
@@ -1,0 +1,12 @@
+if (args.userAgentString && self.navigator?.userAgent !== args.userAgentString) {
+  proxyGetter(self.navigator, 'userAgent', () => args.userAgentString, true);
+  proxyGetter(
+    self.navigator,
+    'appVersion',
+    () => args.userAgentString.replace('Mozilla/', ''),
+    true,
+  );
+}
+if (args.platform && self.navigator?.platform !== args.platform) {
+  proxyGetter(self.navigator, 'platform', () => args.platform, true);
+}

--- a/emulate-browsers/base/lib/DomOverridesBuilder.ts
+++ b/emulate-browsers/base/lib/DomOverridesBuilder.ts
@@ -11,9 +11,16 @@ const utilsScript = [
 ].join('\n');
 
 export default class DomOverridesBuilder {
-  private readonly scripts: string[] = [];
+  private readonly scriptsByName = new Map<string, string>();
 
-  public build(): INewDocumentInjectedScript[] {
+  public build(scriptNames?: string[]): INewDocumentInjectedScript[] {
+    const scripts = [];
+    for (const [name, script] of this.scriptsByName) {
+      const shouldIncludeScript = scriptNames ? scriptNames.includes(name) : true;
+      if (shouldIncludeScript) {
+        scripts.push(script);
+      }
+    }
     return [
       {
         // NOTE: don't make this async. It can cause issues if you read a frame right after creation, for instance
@@ -21,7 +28,7 @@ export default class DomOverridesBuilder {
   const sourceUrl = '${injectedSourceUrl}';
   ${utilsScript}
 
-   ${this.scripts.join('\n\n')}
+   ${scripts.join('\n\n')}
 })();
 //# sourceURL=${injectedSourceUrl}`.replace(/\/\/# sourceMap.+/g, ''),
       },
@@ -60,7 +67,7 @@ export default class DomOverridesBuilder {
   }
 `;
     }
-    this.scripts.push(wrapper);
+    this.scriptsByName.set(name, wrapper);
   }
 }
 

--- a/emulate-browsers/chrome-80/index.ts
+++ b/emulate-browsers/chrome-80/index.ts
@@ -14,7 +14,7 @@ import IUserAgentOption from '@secret-agent/core-interfaces/IUserAgentOption';
 import { randomBytes } from 'crypto';
 import IUserProfile from '@secret-agent/core-interfaces/IUserProfile';
 import { pickRandom } from '@secret-agent/commons/utils';
-import IWindowFraming from "@secret-agent/core-interfaces/IWindowFraming";
+import IWindowFraming from '@secret-agent/core-interfaces/IWindowFraming';
 import pkg from './package.json';
 
 const config = require('./config.json');
@@ -104,6 +104,22 @@ export default class Chrome80 {
     return this.domOverrides.build();
   }
 
+  public async newWorkerInjectedScripts() {
+    const result = this.domOverrides.build([
+      'Error.captureStackTrace',
+      'Error.constructor',
+      'navigator.deviceMemory',
+      'navigator',
+      'MediaDevices.prototype.enumerateDevices',
+      'Notification.permission',
+      'Permission.prototype.query',
+      'WebGLRenderingContext.prototype.getParameter',
+      'HTMLMediaElement.prototype.canPlayType',
+      'RTCRtpSender.getCapabilities',
+    ]);
+    return result;
+  }
+
   protected loadDomOverrides(operatingSystemId: string) {
     const domOverrides = this.domOverrides;
 
@@ -114,6 +130,10 @@ export default class Chrome80 {
 
     const deviceMemory = Math.ceil(Math.random() * 4) * 2;
     domOverrides.add('navigator.deviceMemory', { memory: deviceMemory });
+    domOverrides.add('navigator', {
+      userAgentString: this.userAgentString,
+      platform: this.osPlatform,
+    });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {
       videoDevice: {
@@ -168,8 +188,12 @@ export default class Chrome80 {
     domOverrides.add('HTMLIFrameElement.prototype');
     domOverrides.add('Element.prototype.attachShadow');
 
-    domOverrides.add('window.outerWidth', { frameBorderWidth: this.windowFraming.frameBorderWidth });
-    domOverrides.add('window.outerHeight', { frameBorderHeight: this.windowFraming.frameBorderHeight });
+    domOverrides.add('window.outerWidth', {
+      frameBorderWidth: this.windowFraming.frameBorderWidth,
+    });
+    domOverrides.add('window.outerHeight', {
+      frameBorderHeight: this.windowFraming.frameBorderHeight,
+    });
 
     const agentCodecs = codecsData.get(operatingSystemId);
     if (agentCodecs) {

--- a/emulate-browsers/chrome-81/index.ts
+++ b/emulate-browsers/chrome-81/index.ts
@@ -14,7 +14,7 @@ import IUserAgentOption from '@secret-agent/core-interfaces/IUserAgentOption';
 import { randomBytes } from 'crypto';
 import IUserProfile from '@secret-agent/core-interfaces/IUserProfile';
 import { pickRandom } from '@secret-agent/commons/utils';
-import IWindowFraming from "@secret-agent/core-interfaces/IWindowFraming";
+import IWindowFraming from '@secret-agent/core-interfaces/IWindowFraming';
 import pkg from './package.json';
 
 const config = require('./config.json');
@@ -31,7 +31,7 @@ const domDiffsData = new DomDiffLoader(`${__dirname}/data`);
 const engineObj = {
   browser: config.browserEngine.name,
   revision: config.browserEngine.revision,
-}
+};
 
 @BrowserEmulatorClassDecorator
 export default class Chrome81 {
@@ -104,6 +104,22 @@ export default class Chrome81 {
     return this.domOverrides.build();
   }
 
+  public async newWorkerInjectedScripts() {
+    const result = this.domOverrides.build([
+      'Error.captureStackTrace',
+      'Error.constructor',
+      'navigator.deviceMemory',
+      'navigator',
+      'MediaDevices.prototype.enumerateDevices',
+      'Notification.permission',
+      'Permission.prototype.query',
+      'WebGLRenderingContext.prototype.getParameter',
+      'HTMLMediaElement.prototype.canPlayType',
+      'RTCRtpSender.getCapabilities',
+    ]);
+    return result;
+  }
+
   protected loadDomOverrides(operatingSystemId: string) {
     const domOverrides = this.domOverrides;
 
@@ -114,6 +130,10 @@ export default class Chrome81 {
 
     const deviceMemory = Math.ceil(Math.random() * 4) * 2;
     domOverrides.add('navigator.deviceMemory', { memory: deviceMemory });
+    domOverrides.add('navigator', {
+      userAgentString: this.userAgentString,
+      platform: this.osPlatform,
+    });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {
       videoDevice: {
@@ -168,8 +188,12 @@ export default class Chrome81 {
     domOverrides.add('HTMLIFrameElement.prototype');
     domOverrides.add('Element.prototype.attachShadow');
 
-    domOverrides.add('window.outerWidth', { frameBorderWidth: this.windowFraming.frameBorderWidth });
-    domOverrides.add('window.outerHeight', { frameBorderHeight: this.windowFraming.frameBorderHeight });
+    domOverrides.add('window.outerWidth', {
+      frameBorderWidth: this.windowFraming.frameBorderWidth,
+    });
+    domOverrides.add('window.outerHeight', {
+      frameBorderHeight: this.windowFraming.frameBorderHeight,
+    });
 
     const agentCodecs = codecsData.get(operatingSystemId);
     if (agentCodecs) {

--- a/emulate-browsers/chrome-83/index.ts
+++ b/emulate-browsers/chrome-83/index.ts
@@ -14,7 +14,7 @@ import IUserAgentOption from '@secret-agent/core-interfaces/IUserAgentOption';
 import { randomBytes } from 'crypto';
 import IUserProfile from '@secret-agent/core-interfaces/IUserProfile';
 import { pickRandom } from '@secret-agent/commons/utils';
-import IWindowFraming from "@secret-agent/core-interfaces/IWindowFraming";
+import IWindowFraming from '@secret-agent/core-interfaces/IWindowFraming';
 import pkg from './package.json';
 
 const config = require('./config.json');
@@ -104,6 +104,22 @@ export default class Chrome83 {
     return this.domOverrides.build();
   }
 
+  public async newWorkerInjectedScripts() {
+    const result = this.domOverrides.build([
+      'Error.captureStackTrace',
+      'Error.constructor',
+      'navigator.deviceMemory',
+      'navigator',
+      'MediaDevices.prototype.enumerateDevices',
+      'Notification.permission',
+      'Permission.prototype.query',
+      'WebGLRenderingContext.prototype.getParameter',
+      'HTMLMediaElement.prototype.canPlayType',
+      'RTCRtpSender.getCapabilities',
+    ]);
+    return result;
+  }
+
   protected loadDomOverrides(operatingSystemId: string) {
     const domOverrides = this.domOverrides;
 
@@ -114,6 +130,10 @@ export default class Chrome83 {
 
     const deviceMemory = Math.ceil(Math.random() * 4) * 2;
     domOverrides.add('navigator.deviceMemory', { memory: deviceMemory });
+    domOverrides.add('navigator', {
+      userAgentString: this.userAgentString,
+      platform: this.osPlatform,
+    });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {
       videoDevice: {
@@ -168,8 +188,12 @@ export default class Chrome83 {
     domOverrides.add('HTMLIFrameElement.prototype');
     domOverrides.add('Element.prototype.attachShadow');
 
-    domOverrides.add('window.outerWidth', { frameBorderWidth: this.windowFraming.frameBorderWidth });
-    domOverrides.add('window.outerHeight', { frameBorderHeight: this.windowFraming.frameBorderHeight });
+    domOverrides.add('window.outerWidth', {
+      frameBorderWidth: this.windowFraming.frameBorderWidth,
+    });
+    domOverrides.add('window.outerHeight', {
+      frameBorderHeight: this.windowFraming.frameBorderHeight,
+    });
 
     const agentCodecs = codecsData.get(operatingSystemId);
     if (agentCodecs) {

--- a/emulate-browsers/safari-13/index.ts
+++ b/emulate-browsers/safari-13/index.ts
@@ -153,6 +153,17 @@ export default class Safari13 {
     return result;
   }
 
+  public async newWorkerInjectedScripts() {
+    const result = this.domOverrides.build([
+      'Error.captureStackTrace',
+      'Error.constructor',
+      'navigator.deviceMemory',
+      'navigator',
+      'WebGLRenderingContext.prototype.getParameter',
+    ]);
+    return result;
+  }
+
   protected loadDomOverrides(operatingSystemId: string) {
     const domOverrides = this.domOverrides;
     domOverrides.add('Error.captureStackTrace');
@@ -162,6 +173,10 @@ export default class Safari13 {
 
     const deviceMemory = Math.ceil(Math.random() * 4) * 2;
     domOverrides.add('navigator.deviceMemory', { memory: deviceMemory });
+    domOverrides.add('navigator', {
+      userAgentString: this.userAgentString,
+      platform: this.osPlatform,
+    });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {
       videoDevice: {
@@ -185,8 +200,12 @@ export default class Safari13 {
 
     domOverrides.add('Element.prototype.attachShadow');
 
-    domOverrides.add('window.outerWidth', { frameBorderWidth: this.windowFraming.frameBorderWidth });
-    domOverrides.add('window.outerHeight', { frameBorderHeight: this.windowFraming.frameBorderHeight });
+    domOverrides.add('window.outerWidth', {
+      frameBorderWidth: this.windowFraming.frameBorderWidth,
+    });
+    domOverrides.add('window.outerHeight', {
+      frameBorderHeight: this.windowFraming.frameBorderHeight,
+    });
 
     const agentCodecs = codecsData.get(operatingSystemId);
     if (agentCodecs) {

--- a/full-client/test/detection.test.ts
+++ b/full-client/test/detection.test.ts
@@ -95,7 +95,7 @@ test('should pass FpScanner', async () => {
   expect(data).toBeTruthy();
 }, 30e3);
 
-test('should not be denied for notifications, but prompt for permissions', async () => {
+test('should not be denied for notifications but prompt for permissions', async () => {
   const agent = await handler.createAgent();
   await agent.goto(`${koaServer.baseUrl}`);
   const activeTab = await agent.activeTab;

--- a/full-client/test/emulate.test.ts
+++ b/full-client/test/emulate.test.ts
@@ -193,3 +193,277 @@ describe('mouse', () => {
     expect(await getQueryValue(`matchMedia('(any-pointer: fine)').matches`)).toBe(true);
   });
 });
+
+describe('user agent and platform', () => {
+  const propsToGet = `appVersion, platform, userAgent`.split(',').map(x => x.trim());
+
+  it('should add user agent and platform to window & frames', async () => {
+    const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+
+    const requestUserAgentStrings: string[] = [];
+
+    koaServer.get('/agent-test', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html lang="en">
+<h1>Agent Test</h1>
+<iframe src="/frame"></iframe>
+</html>`;
+    });
+
+    koaServer.get('/frame', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html><body>
+<script>
+  const { ${propsToGet.join(',')} } = navigator;
+  fetch('${koaServer.baseUrl}/frame-xhr', {
+   method: 'POST',
+   body: JSON.stringify({ ${propsToGet.join(',')} })
+  });
+</script>
+</body></html>`;
+    });
+
+    const frameXhr = new Promise<object>(resolve => {
+      koaServer.post('/frame-xhr', async ctx => {
+        requestUserAgentStrings.push(ctx.get('user-agent'));
+        const body = JSON.parse((await Helpers.readableToBuffer(ctx.req)).toString());
+        resolve(body);
+        ctx.body = 'Ok';
+      });
+    });
+
+    /////// TEST BEGIN /////
+
+    await agent.goto(`${koaServer.baseUrl}/agent-test`);
+    const frameParams = await frameXhr;
+
+    for (const useragent of requestUserAgentStrings) {
+      expect(useragent).toBe(agentMeta.userAgentString);
+    }
+
+    async function getJsValue(jsValue: string) {
+      const result = await agent.getJsValue(jsValue);
+      return result.value;
+    }
+
+    const windowParams: any = {};
+    for (const prop of propsToGet) {
+      windowParams[prop] = await getJsValue(`navigator.${prop}`);
+    }
+
+    expect(agentMeta.userAgentString).toBe(windowParams.userAgent);
+    expect(agentMeta.osPlatform).toBe(windowParams.platform);
+
+    for (const prop of propsToGet) {
+      expect(frameParams[prop]).toStrictEqual(windowParams[prop]);
+    }
+  });
+
+  it('should maintain user agent and platform across navigations', async () => {
+    const agent = await handler.createAgent({ browserEmulatorId: 'chrome-80' });
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+
+    const requestUserAgentStrings: string[] = [];
+
+    const httpsServer = await Helpers.runHttpsServer(async (req, res) => {
+      requestUserAgentStrings.push(req.headers['user-agent']);
+      if (req.url === '/s2-page1') {
+        res.end(
+          `<html lang="en">
+<script>
+  const { ${propsToGet.join(',')} } = navigator;
+  var startPageVars = { ${propsToGet.join(',')} };
+</script>
+<body><a href="${koaServer.baseUrl}/page2">link</a></body></html>`,
+        );
+      } else {
+        res.writeHead(404).end();
+      }
+    });
+
+    koaServer.get('/page1', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html lang="en"><body><a href="${httpsServer.baseUrl}/s2-page1">link</a></body></html>`;
+    });
+
+    koaServer.get('/page2', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html lang="en"><body><h1>Last Page</h1></body></html>`;
+    });
+
+    async function getParams() {
+      const windowParams: any = {};
+      for (const prop of propsToGet) {
+        windowParams[prop] = (await agent.getJsValue(`navigator.${prop}`)).value;
+      }
+      return windowParams;
+    }
+
+    await agent.goto(`${koaServer.baseUrl}/page1`);
+
+    const page1WindowParams = await getParams();
+
+    expect(agentMeta.userAgentString).toBe(page1WindowParams.userAgent);
+    expect(agentMeta.osPlatform).toBe(page1WindowParams.platform);
+
+    await agent.click(agent.document.querySelector('a'));
+
+    const page2WindowParams = await getParams();
+    for (const key of propsToGet) {
+      expect(page2WindowParams[key]).toBe(page1WindowParams[key]);
+    }
+
+    const page2StartParams = (await agent.getJsValue('startPageVars')).value;
+    for (const key of propsToGet) {
+      expect(page2StartParams[key]).toBe(page1WindowParams[key]);
+    }
+
+    await agent.click(agent.document.querySelector('a'));
+    const page3WindowParams = await getParams();
+    for (const key of propsToGet) {
+      expect(page3WindowParams[key]).toBe(page1WindowParams[key]);
+    }
+
+    await agent.goBack();
+    const backParams = await getParams();
+    for (const key of propsToGet) {
+      expect(backParams[key]).toBe(page1WindowParams[key]);
+    }
+    for (const useragent of requestUserAgentStrings) {
+      expect(useragent).toBe(agentMeta.userAgentString);
+    }
+  });
+
+  it('should add user agent and platform to dedicated workers', async () => {
+    const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+
+    const requestUserAgentStrings: string[] = [];
+
+    koaServer.get('/workers-test', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html lang="en">
+<script>new Worker("worker.js").postMessage('');</script>
+</html>`;
+    });
+
+    koaServer.get('/worker.js', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.set('content-type', 'application/javascript');
+      ctx.body = `onmessage = () => {
+
+  const { ${propsToGet.join(',')} } = navigator;
+  fetch('/worker-xhr', {
+   method: 'POST',
+   body: JSON.stringify({ ${propsToGet.join(',')} })
+  });
+}`;
+    });
+
+    const xhr = new Promise<object>(resolve => {
+      koaServer.post('/worker-xhr', async ctx => {
+        requestUserAgentStrings.push(ctx.get('user-agent'));
+        const body = JSON.parse((await Helpers.readableToBuffer(ctx.req)).toString());
+        resolve(body);
+        ctx.body = 'Ok';
+      });
+    });
+
+    await agent.goto(`${koaServer.baseUrl}/workers-test`);
+    const params = await xhr;
+
+    for (const useragent of requestUserAgentStrings) {
+      expect(useragent).toBe(agentMeta.userAgentString);
+    }
+
+    for (const prop of propsToGet) {
+      const windowValue = (await agent.getJsValue(`navigator.${prop}`)).value;
+      expect(params[prop]).toStrictEqual(windowValue);
+    }
+  });
+
+  it('should add user agent and platform to service workers', async () => {
+    const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+
+    const requestUserAgentStrings: string[] = [];
+
+    koaServer.get('/sw-test', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.body = `<html lang="en">
+<h1>Service Worker Test</h1>
+<script>
+    navigator.serviceWorker.register('./service-worker.js');
+    navigator.serviceWorker.ready.then((reg) => {
+      if (reg.active) {
+        reg.active.postMessage("send");
+      }
+    });
+    navigator.serviceWorker.addEventListener("message", (event) => {
+      fetch('/service-xhr', {
+        method: 'POST',
+        body: event.data
+      });
+   });
+</script>
+</html>`;
+    });
+
+    koaServer.get('/service-worker.js', ctx => {
+      requestUserAgentStrings.push(ctx.get('user-agent'));
+      ctx.set('content-type', 'application/javascript');
+      ctx.body = `
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', async event => {
+  if (event.data !== 'send') return;
+  self.skipWaiting();
+  self.clients.claim();
+  const clients = await self.clients.matchAll();
+
+  const { ${propsToGet.join(',')} } = navigator;
+  const data = JSON.stringify({ ${propsToGet.join(',')} });
+
+  clients.forEach(client => client.postMessage(data));
+});`;
+    });
+
+    const xhr = new Promise<object>(resolve => {
+      koaServer.post('/service-xhr', async ctx => {
+        requestUserAgentStrings.push(ctx.get('user-agent'));
+        const body = JSON.parse((await Helpers.readableToBuffer(ctx.req)).toString());
+        resolve(body);
+        ctx.body = 'Ok';
+      });
+    });
+
+    /////// TEST BEGIN /////
+
+    await agent.goto(`${koaServer.baseUrl}/sw-test`);
+    const params = await xhr;
+
+    for (const useragent of requestUserAgentStrings) {
+      expect(useragent).toBe(agentMeta.userAgentString);
+    }
+
+    for (const prop of propsToGet) {
+      const windowValue = (await agent.getJsValue(`navigator.${prop}`)).value;
+      expect(params[prop]).toStrictEqual(windowValue);
+    }
+  });
+});

--- a/mitm/handlers/HttpUpgradeHandler.ts
+++ b/mitm/handlers/HttpUpgradeHandler.ts
@@ -1,6 +1,6 @@
 import net from 'net';
 import http from 'http';
-import Log from '@secret-agent/commons/Logger';
+import Log, { hasBeenLoggedSymbol } from '@secret-agent/commons/Logger';
 import MitmRequestContext from '../lib/MitmRequestContext';
 import CookieHandler from './CookieHandler';
 import BaseHttpHandler from './BaseHttpHandler';
@@ -42,8 +42,8 @@ export default class HttpUpgradeHandler extends BaseHttpHandler {
 
     session.emit('http-error', { request: MitmRequestContext.toEmittedResource(context), error });
 
-    if (!(error as any)?.isLogged) {
-      log.error(`MitmWebSocket.${errorType}`, {
+    if (!error[hasBeenLoggedSymbol]) {
+      log.info(`MitmWebSocketUpgrade.${errorType}`, {
         sessionId,
         error,
         url,

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -412,7 +412,7 @@ export interface IRequestSessionResponseEvent extends IRequestSessionRequestEven
   body: Buffer;
   redirectedToUrl?: string;
   executionMillis: number;
-  browserServedFromCache?: 'service-worker' | 'disk' | 'prefetch' | 'unspecified';
+  browserServedFromCache?: IHttpResourceLoadDetails['browserServedFromCache'];
   browserLoadFailure?: string;
   browserBlockedReason?: string;
   browserCanceled?: boolean;

--- a/mitm/lib/MitmRequestContext.ts
+++ b/mitm/lib/MitmRequestContext.ts
@@ -159,6 +159,8 @@ export default class MitmRequestContext {
       headers: ctx.responseHeaders,
       trailers: ctx.responseTrailers,
       timestamp: ctx.responseTime?.toISOString(),
+      browserServedFromCache: ctx.browserServedFromCache,
+      browserLoadFailure: ctx.browserLoadFailure,
       remoteAddress: ctx.remoteAddress,
     } as IResourceResponse;
 
@@ -181,8 +183,6 @@ export default class MitmRequestContext {
       executionMillis: (ctx.responseTime ?? new Date()).getTime() - ctx.requestTime.getTime(),
       isHttp2Push: ctx.isHttp2Push,
       browserBlockedReason: ctx.browserBlockedReason,
-      browserServedFromCache: ctx.browserServedFromCache,
-      browserLoadFailure: ctx.browserLoadFailure,
       browserCanceled: ctx.browserCanceled,
     };
   }

--- a/puppet-chrome/lib/NetworkManager.ts
+++ b/puppet-chrome/lib/NetworkManager.ts
@@ -273,7 +273,7 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
     const { requestId } = event;
     const resource = this.requestsById.get(requestId);
     if (resource) {
-      resource.browserServedFromCache = 'unspecified';
+      resource.browserServedFromCache = 'memory';
       this.emitLoaded(requestId);
     }
   }

--- a/puppet-interfaces/IPuppetPage.ts
+++ b/puppet-interfaces/IPuppetPage.ts
@@ -32,6 +32,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
     page: IPuppetPage,
     openParams: { url: string; windowName: string },
   ) => Promise<void>;
+  workerInitializeFn?: (worker: IPuppetWorker) => Promise<void>;
 
   getIndexedDbDatabaseNames(): Promise<{ frameId: string; origin: string; databases: string[] }[]>;
   setJavaScriptEnabled(enabled: boolean): Promise<void>;

--- a/puppet-interfaces/IPuppetWorker.ts
+++ b/puppet-interfaces/IPuppetWorker.ts
@@ -3,9 +3,9 @@ import ITypedEventEmitter from '@secret-agent/core-interfaces/ITypedEventEmitter
 export interface IPuppetWorker extends ITypedEventEmitter<IPuppetWorkerEvents> {
   id: string;
   url: string;
-  type: string;
+  type: 'service_worker' | 'worker';
   isReady: Promise<Error | null>;
-  evaluate<T>(expression: string): Promise<T>;
+  evaluate<T>(expression: string, isInitializationScript?: boolean): Promise<T>;
 }
 
 export interface IPuppetWorkerEvents {

--- a/puppet/test/Worker.test.ts
+++ b/puppet/test/Worker.test.ts
@@ -49,10 +49,13 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
       const worker = page.workers[0];
       expect(worker.url).toContain('worker.js');
 
-      await worker.isReady;
-
+      // don't have a way to determine if the worker is loaded yet
+      for (let i = 0; i < 10; i += 1) {
+        const isReady = await worker.evaluate<boolean>('!!self.workerFunction');
+        if (isReady) break;
+        await new Promise(setImmediate);
+      }
       expect(await worker.evaluate(`self.workerFunction()`)).toBe('worker function result');
-
       await page.goto(server.emptyPage);
       expect(page.workers.length).toBe(0);
     });

--- a/replay/package.json
+++ b/replay/package.json
@@ -79,7 +79,7 @@
     "concurrently": "^5.2.0",
     "core-js": "^3.6.5",
     "cross-env": "^7.0.3",
-    "electron": "10.1.5",
+    "electron": "10.3.2",
     "electron-builder": "^22.9.1",
     "electron-icon-builder": "^1.0.2",
     "shx": "^0.3.3",

--- a/website/docs/Advanced/ResourceResponse.md
+++ b/website/docs/Advanced/ResourceResponse.md
@@ -6,6 +6,18 @@ Instances of this class are associated with a resource returned from `window.wai
 
 ## Properties
 
+### browserServedFromCache
+
+Will have a value if http response was served from a browser cache.
+
+#### **Returns** `Promise<null | 'service-worker' | 'disk' | 'prefetch' | 'memory'>`
+
+### browserLoadFailure
+
+Will have a value if an http error occurred loading this request.
+
+#### **Returns** `Promise<string | null>`
+
 ### headers
 
 Retrieve the actual headers returned to the client (order and casing is preserved)
@@ -33,6 +45,8 @@ IPv4/6 and port of remote socket. `192.168.172.2:5001`
 ### statusCode
 
 Http response status code.
+
+NOTE: this value might be null if no HTTP response occurred, or an error occurred.
 
 #### **Returns** `Promise<number>`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7559,10 +7559,10 @@ electron-to-chromium@^1.3.523:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.545.tgz#d9add694c78554b8c00bc6e6fc929d5ccd7d1b99"
   integrity sha512-+0R/i17u5E1cwF3g0W8Niq3UUKTUMyyT4kLkutZUHG8mDNvFsAckK3HIanzGVtixe3b6rknD8k7gHiR6nKFkgg==
 
-electron@10.1.5:
-  version "10.1.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-10.1.5.tgz#f2b161310f627063e73fbac44efcb35dece83a90"
-  integrity sha512-fys/KnEfJq05TtMij+lFvLuKkuVH030CHYx03iZrW5DNNLwjE6cW3pysJ420lB0FRSfPjTHBMu2eVCf5TG71zQ==
+electron@10.3.2:
+  version "10.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-10.3.2.tgz#4484a1ea235b60d3f3c319b88da0073941c32a9b"
+  integrity sha512-YiLQAAiS0dPCrkjgdACqMFnOp9dVKVSzuI/mQPzmmugJRNiXvJ4WTmR1M1W28y0sjUKF+UJ8xh0oYtvSJLxZMw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
This PR handles appropriately setting useragent and platform in workers. Also ensures on a newly navigated page, the platform and useragent match the emulator.

Misc Fixes
- Don't use colors in console if turned off in node env variables. Linked to #158 
- Update electron version (security warning)
- Cleanup variables sent to CoreServer during a connect. Was serializing anything, which could lead to loops if a connection was passed in. Linked to #159 
- Return information to client when responses bypass the Mitm and use browser caches #153 
- Fix some failing tests
- Fix toString leaving evidence of proxy #108 
