### PR TITLE
fix: os version should fallback to major if no minor exists

### DIFF
--- a/emulate-browsers/base/lib/VersionUtils.ts
+++ b/emulate-browsers/base/lib/VersionUtils.ts
@@ -1,3 +1,29 @@
+export function findClosestVersionMatch(versionToMatch: string, versions: string[]) {
+  if (versions.length === 1 && versions[0] === 'ALL') return 'ALL';
+
+  // there is no guarantee we have an exact match, so let's get the closest
+  const versionTree = convertVersionsToTree(versions);
+  const [major, minor] = versionToMatch.split('-').map(x => Number(x));
+
+  const majors = Object.keys(versionTree).map(x => Number(x));
+  const majorMatch = getClosestNumberMatch(major, majors);
+  let versionMatch = `${majorMatch}`;
+
+  if (minor) {
+    const minors = Object.keys(versionTree[majorMatch]).map(x => Number(x));
+    const minorMatch = getClosestNumberMatch(minor, minors);
+    if (minorMatch !== undefined) versionMatch += `-${minorMatch}`;
+  } else if (!versions.includes(versionMatch)) {
+    const minors = Object.keys(versionTree[majorMatch]).map(x => Number(x));
+    if (minors.length) {
+      const minorMatch = major > majorMatch ? Math.max(...minors) : Math.min(...minors);
+      versionMatch += `-${minorMatch}`;
+    }
+  }
+
+  return versions.includes(versionMatch) ? versionMatch : null;
+}
+
 export function getClosestNumberMatch(numToMatch: number, nums: number[]) {
   const sortedNums = nums.sort();
   let closest = sortedNums[0];
@@ -18,6 +44,7 @@ export function convertVersionsToTree(versions: string[]): IVersionTree {
   return versions.reduce((tree: any, version: string) => {
     const [major, minor, build] = version.split(/\.|-/);
     tree[major] = tree[major] || {};
+    if(minor === undefined) return tree;
     tree[major][minor] = tree[major][minor] || [];
     if (build) tree[major][minor].push(build);
     return tree;

--- a/emulate-browsers/base/test/VersionUtils.test.ts
+++ b/emulate-browsers/base/test/VersionUtils.test.ts
@@ -1,0 +1,6 @@
+import { findClosestVersionMatch } from '../lib/VersionUtils';
+
+test('it should findClosestVersionMatch even if minor is not matched', async () => {
+  const versionMatch = findClosestVersionMatch('11-2', ['11']);
+  expect(versionMatch).toBe('11');
+}, 60e3);


### PR DESCRIPTION
This fixes #166. The emulator data is tagged to version 11, but the OS version was 11.2. It should fallback to 11 if no 11.2 exists.