### PR TITLE
feat(client): coreHost & disconnecting errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,6 +188,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/ordered-imports': 'off',
+    '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/no-shadow': [
       'error',
       { ignoreTypeValueShadow: true, ignoreFunctionTypeParameterNameValueShadow: true },

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-          
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -27,9 +27,9 @@ jobs:
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn
+            ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
         run: yarn install --immutable --network-timeout 1000000

--- a/client/connections/DisconnectedFromCoreError.ts
+++ b/client/connections/DisconnectedFromCoreError.ts
@@ -1,0 +1,8 @@
+import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+
+export default class DisconnectedFromCoreError extends CanceledPromiseError {
+  public code = 'DisconnectedFromCore';
+  constructor(readonly coreHost: string) {
+    super(`This Agent has been disconnected from Core (coreHost: ${coreHost})`);
+  }
+}

--- a/client/lib/CoreSessions.ts
+++ b/client/lib/CoreSessions.ts
@@ -24,9 +24,9 @@ export default class CoreSessions {
     return this.sessionsById.get(sessionId);
   }
 
-  public close(): boolean {
+  public close(closeError: Error): boolean {
     const hasSessions = this.sessionsById.size > 0;
-    this.queue.stop();
+    this.queue.stop(closeError);
     this.sessionsById.clear();
     return hasSessions;
   }

--- a/commons/Queue.ts
+++ b/commons/Queue.ts
@@ -28,12 +28,12 @@ export default class Queue {
     return promise.promise;
   }
 
-  public stop(): void {
+  public stop(error?: Error): void {
     while (this.queue.length) {
       const next = this.queue.shift();
       if (!next) continue;
 
-      this.reject(next, new CanceledPromiseError('Canceling Queue Item'));
+      this.reject(next, error ?? new CanceledPromiseError('Canceling Queue Item'));
     }
   }
 

--- a/commons/SessionClosedOrMissingError.ts
+++ b/commons/SessionClosedOrMissingError.ts
@@ -1,0 +1,8 @@
+import { CanceledPromiseError } from './interfaces/IPendingWaitEvent';
+
+export default class SessionClosedOrMissingError extends CanceledPromiseError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionClosedOrMissingError';
+  }
+}

--- a/commons/interfaces/IPendingWaitEvent.ts
+++ b/commons/interfaces/IPendingWaitEvent.ts
@@ -1,6 +1,11 @@
 import IResolvablePromise from '@secret-agent/core-interfaces/IResolvablePromise';
 
-export class CanceledPromiseError extends Error {}
+export class CanceledPromiseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CanceledPromiseError';
+  }
+}
 
 export default interface IPendingWaitEvent {
   id: number;

--- a/commons/interfaces/TimeoutError.ts
+++ b/commons/interfaces/TimeoutError.ts
@@ -1,5 +1,6 @@
 export default class TimeoutError extends Error {
   constructor(message?: string) {
     super(message ?? 'Timeout waiting for promise');
+    this.name = 'TimeoutError';
   }
 }

--- a/core-interfaces/ICoreResponsePayload.ts
+++ b/core-interfaces/ICoreResponsePayload.ts
@@ -2,5 +2,4 @@ export default interface ICoreResponsePayload {
   responseId?: string;
   commandId?: number;
   data: any;
-  isError?: boolean;
 }

--- a/core/lib/DomEnvError.ts
+++ b/core/lib/DomEnvError.ts
@@ -5,6 +5,7 @@ export default class DomEnvError extends Error {
   constructor(message: string, pathState: { step: IPathStep; index: number }) {
     super(message);
     this.pathState = pathState;
+    this.name = 'DomEnvError';
   }
 
   public toJSON(): object {

--- a/core/server/ConnectionToClient.ts
+++ b/core/server/ConnectionToClient.ts
@@ -14,6 +14,7 @@ import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingW
 import PuppetLaunchError from '@secret-agent/puppet/lib/PuppetLaunchError';
 import { DependenciesMissingError } from '@secret-agent/puppet/lib/DependenciesMissingError';
 import IUserProfile from '@secret-agent/core-interfaces/IUserProfile';
+import SessionClosedOrMissingError from '@secret-agent/commons/SessionClosedOrMissingError';
 import Session from '../lib/Session';
 import Tab from '../lib/Tab';
 import GlobalPool from '../lib/GlobalPool';
@@ -71,7 +72,9 @@ export default class ConnectionToClient extends TypedEventEmitter<{
         // if not on this function, assume we're sending on to tab
         const tab = Session.getTab(meta);
         if (!tab) {
-          data = new CanceledPromiseError('Requested tab is not a part of session or closed.');
+          data = new SessionClosedOrMissingError(
+            `The requested command (${command}) references a tab that is no longer part of session or has been closed.`,
+          );
         } else if (typeof tab[command] !== 'function') {
           data = new Error(`Command not available on tab (${command} - ${typeof tab[command]})`);
         } else {

--- a/core/server/index.ts
+++ b/core/server/index.ts
@@ -95,9 +95,8 @@ export default class CoreServer {
         return connection.handleRequest(payload);
       });
 
-      ws.on('close', () => {
-        return connection.disconnect();
-      });
+      ws.once('close', () => connection.disconnect());
+      ws.once('error', error => connection.disconnect(error));
 
       connection.on('message', async payload => {
         const json = TypeSerializer.stringify(payload);

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -363,6 +363,7 @@ localStorage.setItem('cross', '1');
 
       await tab.goto(`${koaServer.baseUrl}/cross-storage`);
       await tab.waitForLoad('PaintingStable');
+      await tab.puppetPage.frames[1].waitForLoad();
       profile = await connection.exportUserProfile(meta);
       expect(profile.storage[koaServer.baseUrl]?.localStorage).toHaveLength(1);
       expect(profile.storage['http://dataliberationfoundation.org']?.localStorage).toHaveLength(1);

--- a/full-client/test/fetch.test.ts
+++ b/full-client/test/fetch.test.ts
@@ -58,7 +58,7 @@ describe('Fetch tests', () => {
   it('should be able to create a request object', async () => {
     let header1: string;
     koaServer.get('/request', ctx => {
-      header1 = ctx.headers.header1;
+      header1 = ctx.headers.header1 as string;
 
       ctx.body = { got: 'request' };
     });

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,4 @@
-lerna version --conventional-commits --no-push --exact
+lerna version --conventional-commits --no-push --exact --force-publish
 yarn build:dist
 cd build-dist/
 npx lerna publish from-package

--- a/puppet-chrome/lib/ProtocolError.ts
+++ b/puppet-chrome/lib/ProtocolError.ts
@@ -1,7 +1,11 @@
 export default class ProtocolError extends Error {
   public remoteError: { message: string; data: any; code?: number };
   public method: string;
-  constructor(stack: string, method: string, remoteError: { message: string; data: any; code?: number }) {
+  constructor(
+    stack: string,
+    method: string,
+    remoteError: { message: string; data: any; code?: number },
+  ) {
     let message = `${method}: ${remoteError.message}`;
     if ('data' in remoteError) {
       if (typeof remoteError.data === 'string') {
@@ -11,6 +15,7 @@ export default class ProtocolError extends Error {
       }
     }
     super(message);
+    this.name = 'ProtocolError';
     this.method = method;
     this.stack = stack;
     this.remoteError = remoteError;

--- a/puppet/lib/DependenciesMissingError.ts
+++ b/puppet/lib/DependenciesMissingError.ts
@@ -7,5 +7,6 @@ export class DependenciesMissingError extends Error {
     super(
       `Some of the dependencies needed to run ${engineName} are not on your system!\n\n${resolutionMessage}`,
     );
+    this.name = 'DependenciesMissingError';
   }
 }

--- a/puppet/lib/PuppetLaunchError.ts
+++ b/puppet/lib/PuppetLaunchError.ts
@@ -4,5 +4,6 @@ export default class PuppetLaunchError extends Error implements IPuppetLaunchErr
   constructor(message: string, stack: string, readonly isSandboxError: boolean) {
     super(message);
     this.stack = stack;
+    this.name = 'PuppetLaunchError';
   }
 }

--- a/website/blog/2020-12-29-why-handlers.md
+++ b/website/blog/2020-12-29-why-handlers.md
@@ -1,6 +1,6 @@
 ---
 title: 'Scaling SecretAgent Scrapes with Handlers'
-path: /handling-scale
+path: /blog/handling-scale
 date: 2020-12-29
 summary: "We needed a simpler approach to scaling out to multiple machines running SecretAgent and 1000s of waiting actions. So we added a new concept called Handlers."
 ---

--- a/website/blog/2021-02-19-chrome-stable.md
+++ b/website/blog/2021-02-19-chrome-stable.md
@@ -1,0 +1,30 @@
+---
+title: 'Moving from Chromium to Chrome'
+path: /blog/chromium-chrome
+date: 2021-02-19
+summary: "We're moving our underlying engine from Chromium to Chrome in the coming weeks."
+---
+
+We're moving our underlying engine from Chromium to Chrome in the coming weeks. 
+
+## Why?
+There are a few reasons we decided to go this direction:
+1. Chrome is the actual browser being used in the wild by consumers.
+2. Chrome has increasingly diverged from Chromium. In our DoubleAgent testing, we're seeing Chrome 85-89 steadily diverge features. This makes it harder and harder to emulate Chrome when using Chromium as the engine.
+3. Chrome has certain features that aren't in Chromium that will be nearly impossible to emulate (x-headers to Google sites, Widevine, etc). In theory, you could use DRM as a way to weed out Chromium users masking themselves as Chrome users.
+
+## Chrome Version-Specific Installers 
+This switch was somewhat challenging, primarily because the Chrome team doesn't openly publish versions of Chrome that stay on the version you want them on. Even on Ubuntu, if you install the .deb release, it will install an apt updater, and if you're not careful, your engine will swap out underneath you.
+
+Our first task was to go out and find stable Chrome installations for each version. We created a new project called [chrome-versions](https://github.com/ulixee/chrome-versions) that downloads, extracts, and stores versions of Chrome for Linux, Windows and Mac. 
+
+For each version, we stripped out the auto-update features and converted them to .tar archives that can be extracted side-by-side. They're then published on Github as release assets for each Chrome version (eg, https://github.com/ulixee/chrome-versions/releases/tag/88.0.4324.182)
+
+On Debian/Ubuntu, Chrome often needs packages to be installed. We re-bundled the .deb control file into a new installer that can be run after you extract the chrome executable - this makes setting up CI or docker very simple for 1 or more Chrome installations.
+
+## SecretAgent
+SecretAgent has been updated to use Chrome everywhere. Our emulators have "polyfills" auto-generated for how to resemble Chrome headed when running each version headless. The changes are significant enough from Chromium that you need to actually use Chrome underneath. 
+
+No changes should be visible in your scripts, but you might see some installation changes as you go to upgrade. We also experienced some changes in no-sandbox features when running on Docker. Your mileage here may vary. 
+
+This new release will have an updated Dockerfile and files under `tools/docker/*` showing how to get up and running on Docker-slim.

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -72,6 +72,12 @@ Returns a reference to the currently active tab.
 
 #### **Type**: [`Tab`](/docs/basic-interfaces/tab)
 
+### agent.coreHost {#core-host}
+
+The connectionToCore host address to which this Agent has connected. This is useful in scenarios where a Handler is round-robining connections between multiple hosts.
+
+#### **Type**: `Promise<string>`
+
 ### agent.document <div class="specs"><i>W3C</i></div> {#document}
 
 Returns a reference to the document that the active tab contains.

--- a/website/docs/BasicInterfaces/Handler.md
+++ b/website/docs/BasicInterfaces/Handler.md
@@ -79,6 +79,12 @@ const { Handler } = require('secret-agent');
 
 ## Properties
 
+### handler.coreHosts {#core-hosts}
+
+Readonly property returning the resolved list of coreHosts.
+
+#### **Returns**: `Promise<string[]>`
+
 ### handler.defaultAgentOptions {#default-agent-properties}
 
 Sets default properties to apply to any new Agent created. Accepts any of the configurations that can be provided to [`createAgent()`](#create-agent).
@@ -90,6 +96,31 @@ See the [Configuration](/docs/overview/configuration) page for more details on `
 #### **Type**: [`Tab`](/docs/basic-interfaces/tab)
 
 ## Methods
+
+### handler.addConnectionToCore*(options | connectionToCore)* {#add-connection}
+
+Adds a connection to the handler. This method will call connect on the underlying connection.
+
+Connection arguments are the same as the constructor arguments for a single connection.
+
+#### **Arguments**:
+
+Can be either:
+
+- options `object`. A set of settings that controls the creation of a [`connection`](/docs/advanced/connection-to-core#options) to a `SecretAgent Core`. (see [`constructor`](#constructor))
+- connectionToCore [`ConnectionToCore`](/docs/advanced/connection-to-core#options). A pre-initialized connection to a `SecretAgent Core`.
+
+#### **Returns**: `Promise<void>`
+
+### handler.closeConnectionToCore*(coreHost)* {#close-connection}
+
+Closes and disconnects a connection from core. Agents "in-process" will throw `DisconnectedFromCoreError` on active commands.
+
+#### **Arguments**:
+
+- coreHost `string`. The coreHost connection.
+
+#### **Returns**: `Promise<void>`
 
 ### handler.close*()* {#close}
 
@@ -131,9 +162,9 @@ const { Handler } = require('secret-agent');
   const agent2 = await handler.createAgent();
 
   setTimeout(() => agent2.close(), 100);
-  
+
   // will be available in 100 ms when agent2 closes
-  const agent3 = await handler.createAgent(); 
+  const agent3 = await handler.createAgent();
 })();
 ```
 
@@ -142,6 +173,8 @@ const { Handler } = require('secret-agent');
 This method allows you queue up functions that should be called as soon as a connection can allocate a new Agent. All configurations available to `createAgent` are available here.
 
 NOTE: you do not need to call close on an Agent when using this method. It will automatically be called when your callback returns.
+
+On Disconnecting: if a Core is shut-down or the handler closes a coreConnection while work is still in-progress, the agent commands will throw a `DisconnectedFromCoreError`.
 
 #### **Arguments**:
 

--- a/website/gridsome.config.js
+++ b/website/gridsome.config.js
@@ -78,5 +78,27 @@ module.exports = {
         },
       },
     },
+    {
+      use: '@microflash/gridsome-plugin-feed',
+      options: {
+        contentTypes: ['Post'],
+        feedOptions: {
+          title: 'SecretAgent Blog',
+          description: 'A blog about scraping, features and experiences developing SecretAgent',
+        },
+        rss: {
+          enabled: true,
+          output: '/feed.xml',
+        },
+        atom: {
+          enabled: true,
+          output: '/feed.atom',
+        },
+        json: {
+          enabled: true,
+          output: '/feed.json',
+        },
+      },
+    },
   ],
 };

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@gridsome/remark-prismjs": "^0.3.0",
     "@gridsome/vue-remark": "^0.2.1",
+    "@microflash/gridsome-plugin-feed": "^1.2.1",
     "@types/json2md": "^1.5.0",
     "@types/lodash.kebabcase": "^4.1.6",
     "awaited-dom": "^1.1.10",

--- a/website/src/pages/Blog.vue
+++ b/website/src/pages/Blog.vue
@@ -61,6 +61,9 @@ export default {
     margin-bottom: 10px;
     padding-bottom: 10px;
   }
+  article {
+    margin-bottom: 45px;
+  }
   .read-link {
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,6 +2537,14 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@microflash/gridsome-plugin-feed@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@microflash/gridsome-plugin-feed/-/gridsome-plugin-feed-1.2.1.tgz#b57b687f000d13adc5ca6ab1a1f1d77df0caf8b0"
+  integrity sha512-1/AM0igskl8pczLdjkYfHvzsBQgSoKUow2x7OfcXn3UJz0Cz79AEXs/yULKdMTcu5L2Ix/4qooa263tMsqiKdQ==
+  dependencies:
+    dayjs "^1.9.8"
+    feed "^4.2.1"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -6776,6 +6784,11 @@ dateformat@^3.0.0, dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.9.8:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
@@ -8506,6 +8519,13 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
+
+feed@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/feed/-/feed-4.2.2.tgz#865783ef6ed12579e2c44bbef3c9113bc4956a7e"
+  integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
+  dependencies:
+    xml-js "^1.6.11"
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -19354,6 +19374,13 @@ xhr@^2.0.1:
     is-function "^1.0.1"
     parse-headers "^2.0.0"
     xtend "^4.0.0"
+
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
+  dependencies:
+    sax "^1.2.4"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds the following features to handlers to manage connections coming and going.

- Agent.coreHost - retrieve the coreHost that an agent is connected to.
- Handler.addConnectionToCore(options | connectionObject) - connect to a new handler
- Handler.removeConnectionToCore(coreHost: string) - remove and disconnect connection to core
- Handler will throw DisconnectedFromCoreError if an agent shuts down/disconnects from a CoreConnection while still mid-operation.

closes #165, #163