### PR TITLE
Wait for all dispatches settled

### DIFF
--- a/client/connections/DisconnectedFromCoreError.ts
+++ b/client/connections/DisconnectedFromCoreError.ts
@@ -4,5 +4,6 @@ export default class DisconnectedFromCoreError extends CanceledPromiseError {
   public code = 'DisconnectedFromCore';
   constructor(readonly coreHost: string) {
     super(`This Agent has been disconnected from Core (coreHost: ${coreHost})`);
+    this.name = 'DisconnectedFromCore';
   }
 }

--- a/client/lib/CoreCommandQueue.ts
+++ b/client/lib/CoreCommandQueue.ts
@@ -1,30 +1,18 @@
-import { createPromise } from '@secret-agent/commons/utils';
 import ISessionMeta from '@secret-agent/core-interfaces/ISessionMeta';
-import Log from '@secret-agent/commons/Logger';
-import Resolvable from '@secret-agent/commons/Resolvable';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
+import Queue from '@secret-agent/commons/Queue';
 import ConnectionToCore from '../connections/ConnectionToCore';
 
-const { log } = Log(module);
-
 export default class CoreCommandQueue {
-  public type: 'queue' | 'heap' = 'queue';
-  public items: IItem[] = [];
   public lastCommandId = 0;
-  private isProcessing = false;
 
-  private abortPromise = new Resolvable<CanceledPromiseError>();
-
+  private readonly internalQueue: Queue;
   private readonly sessionMarker: string = '';
 
   constructor(
     private readonly meta: (ISessionMeta & { sessionName: string }) | null,
     private readonly connection: ConnectionToCore,
-    parentCommandQueue?: CoreCommandQueue,
   ) {
-    if (parentCommandQueue) {
-      this.type = parentCommandQueue.type;
-    }
     if (meta) {
       const markers = [
         ''.padEnd(50, '-'),
@@ -34,73 +22,33 @@ export default class CoreCommandQueue {
       ].join('\n');
       this.sessionMarker = `\n\n${markers}`;
     }
+    this.internalQueue = new Queue('CORE COMMANDS');
+    this.internalQueue.concurrency = 1;
   }
 
   public run<T>(command: string, ...args: any[]): Promise<T> {
-    const { resolve, reject, promise } = createPromise<T>();
-    this.items.push({
-      resolve,
-      reject,
-      command,
-      meta: this.meta,
-      args,
-      stack: new Error().stack.replace('Error:', ''),
+    return this.internalQueue.run<T>(this.runRequest.bind(this, command, args)).catch(error => {
+      error.stack += `${this.sessionMarker}`;
+      throw error;
     });
-    this.processQueue().catch(error =>
-      log.error('CommandRunError', { error, sessionId: this.meta?.sessionId }),
-    );
-    return promise;
   }
 
   public clearPending(cancelError: CanceledPromiseError): void {
-    this.items.length = 0;
-    this.abortPromise.resolve(cancelError);
+    this.internalQueue.stop(cancelError);
   }
 
-  // PRIVATE
+  private async runRequest<T>(command: string, args: any[]): Promise<T> {
+    const response = await this.connection.sendRequest({
+      meta: this.meta,
+      command,
+      args,
+    });
 
-  private async processQueue(): Promise<void> {
-    if (this.isProcessing) return;
-    this.isProcessing = true;
-    try {
-      while (this.items.length) {
-        const item: IItem = this.items.shift();
-        try {
-          const response = await Promise.race([
-            this.connection.sendRequest({
-              meta: item.meta,
-              command: item.command,
-              args: item.args,
-            }),
-            this.abortPromise.promise,
-          ]);
-          if (response instanceof CanceledPromiseError) throw response;
-
-          let data = null;
-          if (response) {
-            this.lastCommandId = response.commandId;
-            data = response.data;
-          }
-          item.resolve(data);
-        } catch (error) {
-          error.stack += `\n${'------CORE COMMANDS'.padEnd(50, '-')}${item.stack}${
-            this.sessionMarker
-          }`;
-          item.reject(error);
-        }
-        await new Promise(setImmediate);
-      }
-    } finally {
-      this.isProcessing = false;
+    let data: T = null;
+    if (response) {
+      this.lastCommandId = response.commandId;
+      data = response.data;
     }
+    return data;
   }
-}
-
-interface IItem {
-  resolve: (value: any) => void;
-  reject: (reason?: any) => void;
-  command: string;
-  meta: ISessionMeta | null;
-  args: any[];
-  stack: string;
 }

--- a/client/lib/CoreSessions.ts
+++ b/client/lib/CoreSessions.ts
@@ -16,8 +16,12 @@ export default class CoreSessions {
     this.sessionTimeoutMillis = sessionTimeoutMillis;
   }
 
-  public async waitForAvailable(callbackFn: () => Promise<any>): Promise<void> {
-    await this.queue.run(async () => await callbackFn(), this.sessionTimeoutMillis);
+  public waitForAvailable(callbackFn: () => Promise<any>): Promise<void> {
+    return this.queue.run(callbackFn, this.sessionTimeoutMillis);
+  }
+
+  public hasAvailability(): boolean {
+    return this.queue.canRunMoreConcurrently();
   }
 
   public get(sessionId: string): CoreSession | null {

--- a/client/lib/CoreTab.ts
+++ b/client/lib/CoreTab.ts
@@ -40,7 +40,7 @@ export default class CoreTab implements IJsPathEventTarget {
       sessionName,
     };
     this.connection = connection;
-    this.commandQueue = new CoreCommandQueue(meta, connection, connection.commandQueue);
+    this.commandQueue = new CoreCommandQueue(meta, connection);
     this.eventHeap = new CoreEventHeap(this.meta, connection);
 
     if (!this.eventHeap.hasEventInterceptors('resource')) {

--- a/client/lib/Handler.ts
+++ b/client/lib/Handler.ts
@@ -7,6 +7,9 @@ import Agent from './Agent';
 import ConnectionToCore from '../connections/ConnectionToCore';
 import ConnectionFactory from '../connections/ConnectionFactory';
 
+type SettledDispatchesBySessionId = { [sessionId: string]: { args: any; error?: Error } };
+type PendingDispatch = { resolution: Promise<Error | void>; sessionId?: string; args: any };
+
 const { log } = Log(module);
 
 export default class Handler {
@@ -23,7 +26,7 @@ export default class Handler {
   }
 
   private readonly connections: ConnectionToCore[] = [];
-  private readonly dispatches: Promise<Error | void>[] = [];
+  private readonly dispatches: PendingDispatch[] = [];
 
   constructor(...connectionOptions: (IConnectionToCoreOptions | ConnectionToCore)[]) {
     if (!connectionOptions.length) {
@@ -70,17 +73,19 @@ export default class Handler {
     };
     const connection = pickRandom(this.connections);
 
-    // NOTE: keep await to ensure dispatch stays in stack trace
-    const promise = connection
+    const dispatched: PendingDispatch = { args, resolution: null };
+    dispatched.resolution = connection
       .useAgent(options, async agent => {
         try {
-          return await runFn(agent, args);
+          dispatched.sessionId = await agent.sessionId;
+          await runFn(agent, args);
         } finally {
           await agent.close();
         }
       })
       .catch((err: Error) => err);
-    this.dispatches.push(promise);
+
+    this.dispatches.push(dispatched);
   }
 
   public async createAgent(createAgentOptions: IAgentCreateOptions = {}): Promise<Agent> {
@@ -115,12 +120,32 @@ export default class Handler {
     this.dispatches.length = 0;
     await Promise.all(
       dispatches.map(async dispatch => {
-        const err = await dispatch;
+        const err = await dispatch.resolution;
         if (err) throw err;
       }),
     );
     // keep going if there are new things queued
     if (this.dispatches.length) return this.waitForAllDispatches();
+  }
+
+  public async waitForAllDispatchesSettled(): Promise<SettledDispatchesBySessionId> {
+    const result: SettledDispatchesBySessionId = {};
+
+    do {
+      const dispatches = [...this.dispatches];
+      // clear out dispatches everytime you check it
+      this.dispatches.length = 0;
+
+      await Promise.all(dispatches.map(x => x.resolution));
+      for (const { sessionId, resolution, args } of dispatches) {
+        const error = <Error>await resolution;
+        result[sessionId] = { args, error };
+      }
+
+      await new Promise(setImmediate);
+    } while (this.dispatches.length);
+
+    return result;
   }
 
   public async close(error?: Error): Promise<void> {

--- a/commons/Queue.ts
+++ b/commons/Queue.ts
@@ -1,14 +1,16 @@
 import IResolvablePromise from '@secret-agent/core-interfaces/IResolvablePromise';
 import { createPromise } from './utils';
 import { CanceledPromiseError } from './interfaces/IPendingWaitEvent';
+import Resolvable from './Resolvable';
 
-type Callback<T> = (value?: any) => Promise<T>;
+type AsyncCallback<T> = (value?: any) => Promise<T>;
 
 export default class Queue {
   public concurrency = 1;
   public idletimeMillis = 500;
   public idlePromise = createPromise();
 
+  private readonly abortPromise = new Resolvable<CanceledPromiseError>();
   private idleTimout: NodeJS.Timeout;
   private activeCount = 0;
 
@@ -16,7 +18,7 @@ export default class Queue {
 
   constructor(readonly stacktraceMarker = 'QUEUE') {}
 
-  public run<T>(cb: Callback<T>, timeoutMillis?: number): Promise<T> {
+  public run<T>(cb: AsyncCallback<T>, timeoutMillis?: number): Promise<T> {
     const promise = createPromise<T>(timeoutMillis);
 
     this.queue.push({
@@ -24,23 +26,30 @@ export default class Queue {
       cb,
       startStack: new Error('').stack.split('\n').slice(1).join('\n'),
     });
-    setImmediate(() => this.next());
+
+    this.next().catch(() => null);
     return promise.promise;
   }
 
-  public stop(error?: Error): void {
+  public stop(error?: CanceledPromiseError): void {
+    const canceledError = error ?? new CanceledPromiseError('Canceling Queue Item');
+    this.abortPromise.resolve(canceledError);
     while (this.queue.length) {
       const next = this.queue.shift();
       if (!next) continue;
 
-      this.reject(next, error ?? new CanceledPromiseError('Canceling Queue Item'));
+      this.reject(next, canceledError);
     }
+  }
+
+  public canRunMoreConcurrently(): boolean {
+    return this.activeCount < this.concurrency;
   }
 
   private async next(): Promise<void> {
     clearTimeout(this.idleTimout);
 
-    if (this.activeCount >= this.concurrency) return;
+    if (!this.canRunMoreConcurrently()) return;
 
     const next = this.queue.shift();
     if (!next) {
@@ -58,7 +67,8 @@ export default class Queue {
 
     this.activeCount += 1;
     try {
-      const res = await next.cb();
+      const res = await Promise.race([next.cb(), this.abortPromise.promise]);
+      if (res instanceof CanceledPromiseError) throw res;
       next.promise.resolve(res);
     } catch (error) {
       this.reject(next, error);
@@ -79,6 +89,6 @@ export default class Queue {
 
 interface IQueueEntry {
   promise: IResolvablePromise;
-  cb: Callback<any>;
+  cb: AsyncCallback<any>;
   startStack: string;
 }

--- a/commons/Queue.ts
+++ b/commons/Queue.ts
@@ -68,7 +68,8 @@ export default class Queue {
     this.activeCount += 1;
     try {
       const res = await Promise.race([next.cb(), this.abortPromise.promise]);
-      if (res instanceof CanceledPromiseError) throw res;
+      if (this.abortPromise.isResolved) throw await this.abortPromise.promise;
+
       next.promise.resolve(res);
     } catch (error) {
       this.reject(next, error);

--- a/core/lib/CoreProcess.ts
+++ b/core/lib/CoreProcess.ts
@@ -25,6 +25,8 @@ export default class CoreProcess {
       });
       // now that it's set, if Core shuts down, clear out the host promise
       this.child.once('exit', () => {
+        this.child.removeAllListeners('message');
+        this.child.removeAllListeners('error');
         this.coreHostPromise = null;
         this.child = null;
       });
@@ -34,11 +36,9 @@ export default class CoreProcess {
 
   public static kill(signal?: NodeJS.Signals) {
     const child = this.child;
-    this.child = null;
-
-    if (child && !child.killed) {
-      const closed = new Promise<void>(resolve => child.once('exit', resolve));
-      child.kill(signal);
+    if (child) {
+      const closed = new Promise<void>(resolve => child.once('exit', () => setImmediate(resolve)));
+      if (!child.killed) child.kill(signal);
       return closed;
     }
   }

--- a/core/server/ConnectionToClient.ts
+++ b/core/server/ConnectionToClient.ts
@@ -94,6 +94,7 @@ export default class ConnectionToClient extends TypedEventEmitter<{
         });
       }
       data = this.serializeError(error);
+      data.isDisconnecting = this.isClosing || session?.isClosing;
     }
 
     const commandId = session?.sessionState?.lastCommand?.id;

--- a/core/server/index.ts
+++ b/core/server/index.ts
@@ -103,11 +103,13 @@ export default class CoreServer {
         try {
           await wsSend(ws, json);
         } catch (error) {
-          log.error('Error sending message', {
-            error,
-            payload,
-            sessionId: null,
-          });
+          if (connection.isClosing === false) {
+            log.error('Error sending message', {
+              error,
+              payload,
+              sessionId: null,
+            });
+          }
           if (isOpen(ws)) {
             ws.close(CLOSE_UNEXPECTED_ERROR, JSON.stringify({ message: error.message }));
           }

--- a/full-client/test/handler.test.ts
+++ b/full-client/test/handler.test.ts
@@ -260,6 +260,7 @@ describe('connectionToCore', () => {
     await waitForGoto.promise;
     socket.destroy();
     await expect(handler.waitForAllDispatches()).rejects.toThrowError(DisconnectedFromCoreError);
+    await new Promise(setImmediate);
     expect(dispatchError).toBeTruthy();
     expect(dispatchError).toBeInstanceOf(DisconnectedFromCoreError);
     expect((dispatchError as DisconnectedFromCoreError).coreHost).toBe(coreHost);

--- a/full-client/test/handler.test.ts
+++ b/full-client/test/handler.test.ts
@@ -191,7 +191,7 @@ describe('waitForAllDispatchesSettled', () => {
 describe('connectionToCore', () => {
   it('handles disconnects from killed core server', async () => {
     const coreHost = await CoreProcess.spawn({});
-    Helpers.onClose(() => CoreProcess.kill());
+    Helpers.onClose(() => CoreProcess.kill('SIGINT'));
     const connection = new RemoteConnectionToCore({
       maxConcurrency: 2,
       host: coreHost,
@@ -202,24 +202,27 @@ describe('connectionToCore', () => {
     Helpers.needsClosing.push(handler);
 
     const waitForGoto = createPromise();
-    let dispatchError: Error = null;
+    const dispatchErrorPromise = createPromise<Error>();
     handler.dispatchAgent(async agent => {
       try {
         await agent.goto(koaServer.baseUrl);
         const promise = agent.waitForMillis(10e3);
+        await new Promise(resolve => setTimeout(resolve, 50));
         waitForGoto.resolve();
         await promise;
       } catch (error) {
-        dispatchError = error;
+        dispatchErrorPromise.resolve(error);
         throw error;
       }
     });
     await waitForGoto.promise;
     await CoreProcess.kill('SIGINT');
-    await expect(handler.waitForAllDispatches()).rejects.toThrowError(DisconnectedFromCoreError);
-    expect(dispatchError).toBeTruthy();
+    await new Promise(setImmediate);
+    await expect(dispatchErrorPromise).resolves.toBeTruthy();
+    const dispatchError = await dispatchErrorPromise;
     expect(dispatchError).toBeInstanceOf(DisconnectedFromCoreError);
     expect((dispatchError as DisconnectedFromCoreError).coreHost).toBe(coreHost);
+    await expect(handler.waitForAllDispatches()).rejects.toThrowError(DisconnectedFromCoreError);
   });
 
   it('handles core server ending websocket (econnreset)', async () => {
@@ -264,28 +267,40 @@ describe('connectionToCore', () => {
 
   it('can close without waiting for dispatches', async () => {
     const spawnedCoreHost = await CoreProcess.spawn({});
-    Helpers.onClose(() => CoreProcess.kill());
+    Helpers.onClose(() => CoreProcess.kill('SIGINT'));
     const coreHost = await Core.server.address;
 
-    const handler = new Handler({ host: coreHost }, { host: spawnedCoreHost });
+    const localConn = new RemoteConnectionToCore({ host: coreHost, maxConcurrency: 2 });
+    const spawnedConn = new RemoteConnectionToCore({ host: spawnedCoreHost, maxConcurrency: 2 });
+    await localConn.connect();
+    await spawnedConn.connect();
+    const handler = new Handler(localConn, spawnedConn);
     Helpers.needsClosing.push(handler);
+
+    let spawnedConnections = 0;
+    let localConnections = 0;
 
     const waits: Promise<any>[] = [];
     const waitForAgent = async (agent: Agent, waitForGoto: IResolvablePromise<any>) => {
       await agent.goto(koaServer.baseUrl);
+      const host = await agent.coreHost;
+      if (host === spawnedCoreHost) spawnedConnections += 1;
+      else localConnections += 1;
 
       // don't wait
       const promise = agent.waitForMillis(10e3);
       waitForGoto.resolve();
-      await promise;
+      await expect(promise).rejects.toThrowError('Disconnected');
     };
-    for (let i = 0; i < 10; i += 1) {
+    for (let i = 0; i < 4; i += 1) {
       const waitForGoto = createPromise();
       waits.push(waitForGoto.promise);
       handler.dispatchAgent(waitForAgent, waitForGoto);
     }
 
     await Promise.all(waits);
+    expect(spawnedConnections).toBe(2);
+    expect(localConnections).toBe(2);
 
     // kill off one of the cores
     await CoreProcess.kill('SIGINT');
@@ -308,7 +323,7 @@ describe('connectionToCore', () => {
     expect(await handler.coreHosts).toHaveLength(1);
 
     const spawnedCoreHost = await CoreProcess.spawn({});
-    Helpers.onClose(() => CoreProcess.kill());
+    Helpers.onClose(() => CoreProcess.kill('SIGINT'));
     await expect(handler.addConnectionToCore({ host: spawnedCoreHost })).resolves.toBeUndefined();
 
     expect(await handler.coreHosts).toHaveLength(2);

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -120,7 +120,12 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
       }
     }
 
-    await resource.isRequestedInBrowser.promise;
+    const stack = resource.isRequestedInBrowser.stack;
+    const result = await resource.isRequestedInBrowser.promise;
+    if (result instanceof Error) {
+      result.stack += `\n${'------PENDING-CHROME_RESOURCE'.padEnd(50, '-')}\n${stack}`;
+      throw result;
+    }
 
     const idx = this.resourcesRequestedByBrowser.indexOf(resource);
     if (idx >= 0) this.resourcesRequestedByBrowser.splice(idx, 1);
@@ -185,7 +190,7 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
       );
     if (match) {
       match.resourceType = event.resource.resourceType;
-      match.isRequestedInBrowser.reject(event.loadError);
+      match.isRequestedInBrowser.resolve(event.loadError);
     } else {
       log.warn('BrowserViewOfResourceLoad::Failed', {
         sessionId: this.sessionId,
@@ -240,7 +245,7 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
     const logid = this.logger.stats('MitmRequestSession.Closing');
     this.isClosing = true;
     for (const pending of this.resourcesRequestedByBrowser) {
-      pending.isRequestedInBrowser.reject(
+      pending.isRequestedInBrowser.resolve(
         new CanceledPromiseError('Canceling: Mitm Request Session Closing'),
       );
     }
@@ -449,7 +454,7 @@ interface IResourcePendingBrowserLoad {
   method: string;
   origin: string;
   referer: string;
-  isRequestedInBrowser: IResolvablePromise<IResourcePendingBrowserLoad>;
+  isRequestedInBrowser: IResolvablePromise<IResourcePendingBrowserLoad | Error>;
   tabId?: string;
   browserRequestId?: string;
   resourceType?: ResourceType;

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -222,7 +222,7 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
       try {
         return await this.dns.lookupIp(host);
       } catch (error) {
-        log.error('DnsLookup.Error', {
+        log.info('DnsLookup.Error', {
           sessionId: this.sessionId,
           error,
         });

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,4 @@
-lerna version --conventional-commits --no-push --exact --force-publish
+lerna version prerelease --conventional-commits --no-push --exact --force-publish
 yarn build:dist
 cd build-dist/
 npx lerna publish from-package

--- a/website/docs/BasicInterfaces/Handler.md
+++ b/website/docs/BasicInterfaces/Handler.md
@@ -213,6 +213,17 @@ const { Handler } = require('secret-agent');
 
 ### handler.waitForAllDispatches*()* {#wait-for-all-dispatches}
 
-Waits for all agents which have been created using `dispatchAgent` to complete. If any errors are thrown by Agents, they will be thrown upon awaiting this method.
+Waits for all agents which have been created using `dispatchAgent` to complete. If any errors are thrown by Agents, the first exception will be thrown upon awaiting this method.
 
 #### **Returns**: `Promise`
+
+### handler.waitForAllDispatchesSettled*()* {#wait-for-all-dispatches-settled}
+
+Waits for all agents which have been created using `dispatchAgent` to complete or throw an error. This method will always wait for all dispatches to finish, regardless of errors thrown. This is different from `waitForAllDispatches`, which will throw on any dispatch errors.
+
+#### **Returns**: `Promise<DispatchResults>`
+
+- DispatchResults { [sessionId: string]: { args?: any, error?: Error } }
+  - sessionId `string key`. The session id assigned to the dispatched Agent.
+  - args `any`. Any arguments passed to the dispatched Agent.
+  - error `Error?`. An error if one has been thrown during dispatch.


### PR DESCRIPTION
This PR has a main feature to go alongside Handler.waitForAllDispatches, called waitForAllDispatchesSettled. It differs from waitForAllDispatches in that it will run through ALL dispatches and return the results of each at the end, instead of short-circuiting at the first thrown error. This feature is based on some of the ways waitForAllDispatches is being used in MissionImpossible, as well as in #165 #172 examples from @A-PostHuman.

As part of this PR, some of the inner workings of CoreCommandQueue and CoreConnections got cleaned up to consistently return errors - whichever part of the process you're in. We still had some timing problems if a connection was not yet in-flight at the time of disconnect.

Two bug fixes are added to this PR:
1. Dns errors were bubbling up because of our deferred promises rejecting without active handlers 
2. MitmSessionCloses were likewise bubbling up when there was no handler on an http2 push that got canceled during shutdown.