### PR TITLE
Timeout bugs

### DIFF
--- a/commons/SourceMapSupport.ts
+++ b/commons/SourceMapSupport.ts
@@ -1,6 +1,6 @@
-import * as SourceMapSupport from 'source-map-support';
+import { install } from 'source-map-support';
 
 if (!Error[Symbol.for('source-map-support')]) {
   Error[Symbol.for('source-map-support')] = true;
-  SourceMapSupport.install({ uncaughtShimInstalled: false });
+  install({ handleUncaughtExceptions: false });
 }

--- a/core/dbs/SessionDb.ts
+++ b/core/dbs/SessionDb.ts
@@ -143,7 +143,16 @@ export default class SessionDb {
   }
 
   public flush() {
-    if (this.batchInsert) this.batchInsert.immediate();
+    if (this.batchInsert) {
+      try {
+        this.batchInsert.immediate();
+      } catch (error) {
+        if (String(error).match(/attempt to write a readonly database/)) {
+          clearInterval(this.saveInterval);
+        }
+        throw error;
+      }
+    }
   }
 
   public unsubscribeToChanges() {

--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -227,7 +227,9 @@ export default class SessionState {
     if (!navigations) return;
 
     const isNavigationToCurrentUrl =
-      resource.url === navigations.currentUrl && resourceEvent.request.method !== 'OPTIONS';
+      (resource.url === navigations.currentUrl ||
+        resource.request.url === navigations.currentUrl) &&
+      resourceEvent.request.method !== 'OPTIONS';
 
     if (
       isNavigationToCurrentUrl ||
@@ -250,7 +252,10 @@ export default class SessionState {
     if (isResponse) {
       const navigations = this.navigationsByTabId[tabId];
       const isNavigationToCurrentUrl =
-        resource.url === navigations.currentUrl && resourceEvent.request.method !== 'OPTIONS';
+        (resource.url === navigations.currentUrl ||
+          resource.request.url === navigations.currentUrl) &&
+        resourceEvent.request.method !== 'OPTIONS';
+
       if (
         isNavigationToCurrentUrl ||
         resourceResponseEvent.browserRequestId === navigations.top?.browserRequestId

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -662,14 +662,17 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
     ) {
       this.navigations.onHttpResponded(
         event.resource.browserRequestId,
-        event.resource.url?.href,
+        event.resource.responseUrl ?? event.resource.url?.href,
         event.frameId ?? this.mainFrameId,
       );
     }
 
-    const resources = this.sessionState.getBrowserRequestResources(event.resource.browserRequestId);
+    const resourcesWithBrowserRequestId = this.sessionState.getBrowserRequestResources(
+      event.resource.browserRequestId,
+    );
 
-    if (!resources?.length) {
+    // if we get a cached response, it might never hit mitm, so record now
+    if (event.resource.browserServedFromCache && !resourcesWithBrowserRequestId?.length) {
       const ctx = MitmRequestContext.createFromLoadedResource(event.resource);
       this.sessionState.captureResource(this.id, MitmRequestContext.toEmittedResource(ctx), true);
     }

--- a/core/lib/TabNavigations.ts
+++ b/core/lib/TabNavigations.ts
@@ -95,7 +95,10 @@ export default class TabNavigations extends TypedEventEmitter<TabNavigationEvent
   ): void {
     if (url === 'about:blank') return;
     // if this is a redirect, capture in top
-    if (redirectedFromUrl && this.top?.requestedUrl === redirectedFromUrl) {
+    if (
+      redirectedFromUrl &&
+      (this.top?.requestedUrl === redirectedFromUrl || this.top?.finalUrl === redirectedFromUrl)
+    ) {
       this.changeNavigationState(this.top, LocationStatus.HttpRedirected, url);
     }
     // if we already have this status at top level, this is a new nav

--- a/core/lib/TabNavigationsObserver.ts
+++ b/core/lib/TabNavigationsObserver.ts
@@ -118,7 +118,7 @@ export default class TabNavigationsObserver {
   public cancelWaiting(cancelMessage: string): void {
     clearTimeout(this.waitingForLoadTimeout);
     for (const promise of [this.waitingForResource, this.waitingForPromise]) {
-      if (!promise || !promise.isResolved) continue;
+      if (!promise || promise.isResolved) continue;
 
       const canceled = new CanceledPromiseError(cancelMessage);
       canceled.stack += `\n${'------LOCATION'.padEnd(50, '-')}\n${promise.stack}`;
@@ -221,7 +221,7 @@ export default class TabNavigationsObserver {
     if (this.waitingForPromise) this.cancelWaiting('New location trigger created');
 
     this.waitingForStatus = status;
-    this.waitingForPromise = createPromise<void>(timeoutMs ?? 30e3);
+    this.waitingForPromise = createPromise<void>(timeoutMs ?? 60e3);
     return this.waitingForPromise.promise;
   }
 

--- a/core/package.json
+++ b/core/package.json
@@ -9,6 +9,7 @@
     },
     "./start": "./start.js",
     "./lib/*": "./lib/*.js",
+    "./dbs/*": "./dbs/*.js",
     "./lib/CoreProcess": "./lib/CoreProcess.js",
     "./server": "./server/index.js"
   },

--- a/mitm/handlers/BaseHttpHandler.ts
+++ b/mitm/handlers/BaseHttpHandler.ts
@@ -63,6 +63,16 @@ export default abstract class BaseHttpHandler {
         'error',
         this.onError.bind(this, 'ProxyToServer.RequestError'),
       );
+      const stream = <http2.Http2Stream>this.context.proxyToServerRequest;
+      stream.on('streamClosed', code =>
+        this.onError(
+          'ProxyToH2Server.StreamClosedError',
+          new Error(`Stream closed with code ${code}`),
+        ),
+      );
+      if (stream.session && stream.session.listenerCount('error') === 0) {
+        stream.session?.on('error', this.onError.bind(this, 'ProxyToServer.SessionError'));
+      }
 
       return this.context.proxyToServerRequest;
     } catch (err) {

--- a/mitm/handlers/HttpUpgradeHandler.ts
+++ b/mitm/handlers/HttpUpgradeHandler.ts
@@ -71,8 +71,12 @@ export default class HttpUpgradeHandler extends BaseHttpHandler {
     proxyToServerMitmSocket.on('close', () => {
       this.context.setState(ResourceState.End);
       // don't try to write again
-      clientSocket.destroy();
-      serverSocket.destroy();
+      try {
+        clientSocket.destroy();
+        serverSocket.destroy();
+      } catch (err) {
+        // no-operation
+      }
     });
 
     // copy response message (have to write to raw socket)
@@ -89,7 +93,11 @@ export default class HttpUpgradeHandler extends BaseHttpHandler {
 
     if (!serverSocket.readable || !serverSocket.writable) {
       this.context.setState(ResourceState.PrematurelyClosed);
-      return serverSocket.destroy();
+      try {
+        return serverSocket.destroy();
+      } catch (error) {
+        // don't log if error
+      }
     }
     serverSocket.on('error', this.onError.bind(this, 'ServerToProxy.UpgradeSocketError'));
 

--- a/mitm/lib/MitmProxy.ts
+++ b/mitm/lib/MitmProxy.ts
@@ -86,7 +86,7 @@ export default class MitmProxy {
     this.db.close();
     while (this.serverConnects.length) {
       const connect = this.serverConnects.shift();
-      connect.destroy();
+      destroyConnection(connect);
     }
     delete this.secureContexts;
 
@@ -223,9 +223,9 @@ export default class MitmProxy {
       }
     });
 
-    proxyConnection.on('end', () => socket.destroy());
-    proxyConnection.on('close', () => socket.destroy());
-    socket.on('close', () => proxyConnection.destroy());
+    proxyConnection.on('end', () => destroyConnection(socket));
+    proxyConnection.on('close', () => destroyConnection(socket));
+    socket.on('close', () => destroyConnection(proxyConnection));
     socket.on('end', this.removeSocketConnect.bind(this, socket));
 
     await connectedPromise;
@@ -315,6 +315,14 @@ export default class MitmProxy {
   private static isTlsByte(buffer: Buffer): boolean {
     // check for clienthello byte
     return buffer[0] === 0x16;
+  }
+}
+
+function destroyConnection(socket: net.Socket): void {
+  try {
+    socket.destroy();
+  } catch (e) {
+    // nothing to do
   }
 }
 

--- a/puppet-chrome/lib/NetworkManager.ts
+++ b/puppet-chrome/lib/NetworkManager.ts
@@ -306,7 +306,7 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
         this.requestsById.delete(id);
         this.emit('resource-loaded', { resource, frameId });
       }
-    }, 500);
+    }, 500).unref();
   }
 
   /////// WEBSOCKET EVENT HANDLERS /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Mitm could throw unhandled errors during write if the stream got closed
- Tab DomContentLoaded can take a really long time if you loop and re-load in the same tab a lot of times. Extended the timeout to 60 seconds