### PR TITLE
fix(puppet): remove disable-gpu flag

### DIFF
--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -84,11 +84,7 @@ export default class Puppet {
     }
 
     try {
-      const { proxyPort } = args;
-      const launchArgs = launcher.getLaunchArgs({
-        showBrowser: !!this.engine.isHeaded,
-        proxyPort,
-      });
+      const launchArgs = launcher.getLaunchArgs(args);
 
       // exists, but can't launch, try to launch
       await validateHostRequirements(this.engine);
@@ -133,6 +129,10 @@ ${remedyMessage}`);
   }
 }
 
-interface ILaunchArgs {
+export interface ILaunchArgs {
   proxyPort?: number;
+  showBrowser?: boolean;
+  disableDevtools?: boolean;
+  disableGpu?: boolean;
+  noChromeSandbox?: boolean;
 }


### PR DESCRIPTION
The current flags we have turned on for GPU are disabling gpu and gpu compositing on Macs, Windows and Linux. I think we originally turned the flags on this way to that a docker/machine with no gpu would run the same way as a development machine. The problem is some sites (like https://github.com) with a lot of webgl are incredibly slow when you do that.

I'm proposing (not 100% sure on this) that we should NOT disable gpu by default. NOTE that disable gpu was a workaround for old chromium issues that made gpu not work in headless on win/mac/linux even when there was hardware present (https://crbug.com/737678 and https://crbug.com/729961). Those are resolved at this point, so it's really just about working with no gpu. 

There's also a potential issue with Linux headless using acceleration (https://github.com/chromium/chromium/commit/19671359ae25aa1e30bde90f8ff92453eeaac2ba). I am torn on if we should use this setting on linux, or just allow this to be added on by users if needed. You can add flags by running
```Chrome83.engine.extraLaunchArgs.push('--use-gl=egl').```

NOTE that Puppeteer and Playwright have both removed disable-gpu and use-gl flags at this point.

@calebjclark any thoughts? Should we add a condition to add use-gl=egl to linux? My only concern is it appears to disable using a software solution and force a hardware one, so it potentially creates new issues on machines without gpus.