### PR TITLE
fix(puppet): handle crashed windows

### DIFF
--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -348,7 +348,6 @@ export default class SessionState {
   }
 
   public captureError(tabId: number, frameId: string, source: string, error: Error): void {
-    this.logger.info('Window.error', { source, error });
     this.db.pageLogs.insert(tabId, frameId, source, error.stack || String(error), new Date());
   }
 

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -701,10 +701,11 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     this.frameEnvironmentsById.set(frame.id, frame);
   }
 
-  /////// LOGGGING EVENTS //////////////////////////////////////////////////////////////////////////
+  /////// LOGGING EVENTS ///////////////////////////////////////////////////////////////////////////
 
   private onPageError(event: IPuppetPageEvents['page-error']): void {
     const { error, frameId } = event;
+    this.logger.info('Window.pageError', { error, frameId });
     this.sessionState.captureError(this.id, frameId, `events.page-error`, error);
   }
 
@@ -715,6 +716,10 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
 
   private onTargetCrashed(event: IPuppetPageEvents['crashed']): void {
     const error = event.error;
+
+    const errorLevel = event.fatal ? 'error' : 'info';
+    this.logger[errorLevel]('BrowserEngine.Tab.crashed', { error });
+
     this.sessionState.captureError(this.id, this.mainFrameId, `events.error`, error);
   }
 

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -95,11 +95,11 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameEvents>
     return this.isReady;
   }
 
-  public close() {
+  public close(error?: Error) {
     eventUtils.removeEventListeners(this.registeredEvents);
     this.cancelPendingEvents('FramesManager closed');
     for (const frame of this.framesById.values()) {
-      frame.cancelPendingEvents('FramesManager closed');
+      frame.close(error);
     }
   }
 

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -280,9 +280,17 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
     return this.closePromise.promise;
   }
 
-  didClose(): void {
+  onTargetKilled(errorCode: number): void {
+    this.emit('crashed', {
+      error: new Error(`Page crashed - killed by Chrome with code ${errorCode}`),
+      fatal: true,
+    });
+    this.didClose();
+  }
+
+  didClose(closeError?: Error): void {
     this.isClosed = true;
-    this.framesManager.close();
+    this.framesManager.close(closeError);
     this.networkManager.close();
     eventUtils.removeEventListeners(this.registeredEvents);
     this.cancelPendingEvents('Page closed', ['close']);

--- a/puppet-interfaces/IPuppetPage.ts
+++ b/puppet-interfaces/IPuppetPage.ts
@@ -48,7 +48,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
 export interface IPuppetPageEvents extends IPuppetFrameEvents, IPuppetNetworkEvents {
   close: undefined;
   worker: { worker: IPuppetWorker };
-  crashed: { error: Error };
+  crashed: { error: Error; fatal?: boolean };
   console: { frameId: string; type: string; message: string; location: string };
   'page-error': { frameId: string; error: Error };
 }


### PR DESCRIPTION
We were simply ignoring if a page crashed and no further commands were working. This PR makes sure we actually throw errors when we can't run things anymore.
