### PR TITLE
chore(core): type serializer

### DIFF
--- a/commons/SessionClosedOrMissingError.ts
+++ b/commons/SessionClosedOrMissingError.ts
@@ -1,4 +1,5 @@
 import { CanceledPromiseError } from './interfaces/IPendingWaitEvent';
+import { registerSerializableErrorType } from './TypeSerializer';
 
 export default class SessionClosedOrMissingError extends CanceledPromiseError {
   constructor(message: string) {
@@ -6,3 +7,5 @@ export default class SessionClosedOrMissingError extends CanceledPromiseError {
     this.name = 'SessionClosedOrMissingError';
   }
 }
+
+registerSerializableErrorType(SessionClosedOrMissingError);

--- a/commons/TypeSerializer.ts
+++ b/commons/TypeSerializer.ts
@@ -1,65 +1,148 @@
-import * as Typeson from 'typeson';
-import * as TypesonRegistry from 'typeson-registry/dist/presets/builtin';
-import * as Fs from 'fs';
-import { CanceledPromiseError } from './interfaces/IPendingWaitEvent';
-
-const buffer = {
-  buffer: {
-    test(x) {
-      return x !== null && x instanceof Buffer;
-    },
-    replace(n) {
-      return n?.toJSON().data;
-    },
-    revive(s) {
-      return Buffer.from(s);
-    },
-  },
-};
-
-const errorHandler = {
-  error: {
-    test(x) {
-      return x instanceof Error || Typeson.toStringTag(x) === 'Error';
-    },
-    replace({ name, message, stack, ...data }) {
-      return { name, message, stack, ...data };
-    },
-    revive({ name, message, stack, ...data }) {
-      let Constructor = Error;
-      if (global[name]) {
-        Constructor = global[name];
-      }
-      if (name === 'CanceledPromiseError') Constructor = CanceledPromiseError as any;
-
-      const e = new Constructor(message);
-      e.name = name;
-      if (stack) e.stack = stack;
-      Object.assign(e, data);
-      return e;
-    },
-  },
-};
-
-const TSON = new Typeson().register(TypesonRegistry).register(buffer).register(errorHandler);
-
-const domScript = `${Fs.readFileSync(require.resolve('typeson/dist/typeson.min.js'), 'utf8')};
-${Fs.readFileSync(require.resolve('typeson-registry/dist/presets/builtin.js'), 'utf8').replace(
-  /\/\/# sourceMappingURL=.+\.map/g,
-  '',
-)};
-
-const TSON = new Typeson().register(Typeson.presets.builtin);
-`;
-
 export default class TypeSerializer {
-  static domScript = domScript;
+  public static errorTypes = new Map<string, { new (message?: string): Error }>();
+  private static isNodejs = typeof process !== 'undefined' && process.release.name === 'node';
 
-  static stringify(object: any): string {
-    return TSON.stringify(object);
+  public static parse(stringified: string): any {
+    return JSON.parse(stringified, (key, entry) => {
+      if (!entry || !entry.type) return entry;
+
+      const { value, type } = entry;
+
+      if (type === 'BigInt') return BigInt(value);
+      if (type === 'NaN') return Number.NaN;
+      if (type === 'Infinity') return Number.POSITIVE_INFINITY;
+      if (type === '-Infinity') return Number.NEGATIVE_INFINITY;
+      if (type === 'DateIso') return new Date(value);
+      if (type === 'Buffer64' || type === 'ArrayBuffer64') {
+        if (this.isNodejs) {
+          return Buffer.from(value, 'base64');
+        }
+
+        const decoded = globalThis.atob(value);
+        // @ts-ignore
+        const uint8Array = new TextEncoder().encode(decoded);
+        if (!entry.args) return uint8Array;
+
+        const { arrayType, byteOffset, byteLength } = entry.args;
+
+        return new globalThis[arrayType](uint8Array.buffer, byteOffset, byteLength);
+      }
+      if (type === 'RegExp') return new RegExp(value[0], value[1]);
+      if (type === 'Map') return new Map(value);
+      if (type === 'Set') return new Set(value);
+      if (type === 'Error') {
+        const { name, message, stack, ...data } = value;
+        let Constructor = this.errorTypes && this.errorTypes.get(name);
+        if (!Constructor) {
+          if (this.isNodejs) {
+            Constructor = global[name] || Error;
+          } else {
+            Constructor = globalThis[name] || Error;
+          }
+        }
+
+        const e = new Constructor(message);
+        e.name = name;
+        if (stack) e.stack = stack;
+        Object.assign(e, data);
+        return e;
+      }
+
+      return entry;
+    });
   }
 
-  static parse(stringified: string): any {
-    return TSON.parse(stringified);
+  public static stringify(object: any): string {
+    return JSON.stringify(object, (key, value) => {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const resultObject = {};
+        for (const [k, v] of Object.entries(value)) {
+          resultObject[k] = this.convertKeyValue(k, v);
+        }
+        return resultObject;
+      }
+      return this.convertKeyValue(key, value);
+    });
+  }
+
+  private static convertKeyValue(_: string, value: any): any {
+    if (Number.isNaN(value)) {
+      return { type: 'NaN' };
+    }
+
+    if (value === Number.POSITIVE_INFINITY) {
+      return { type: 'Infinity' };
+    }
+
+    if (value === Number.NEGATIVE_INFINITY) {
+      return { type: '-Infinity' };
+    }
+
+    if (value === null || value === undefined) return value;
+
+    const type = typeof value;
+    if (type === 'boolean' || type === 'string' || type === 'number') return value;
+    if (type === 'bigint') {
+      return { type: 'BigInt', value: value.toString() };
+    }
+
+    if (value instanceof Date) {
+      return { type: 'DateIso', value: value.toISOString() };
+    }
+
+    if (value instanceof RegExp) {
+      return { type: 'RegExp', value: [value.source, value.flags] };
+    }
+
+    if (value instanceof Error) {
+      const { name, message, stack, ...data } = value;
+      return { type: 'Error', value: { name, message, stack, ...data } };
+    }
+
+    if (value instanceof Map) {
+      return { type: 'Map', value: [...value.entries()] };
+    }
+
+    if (value instanceof Set) {
+      return { type: 'Set', value: [...value] };
+    }
+
+    if (this.isNodejs) {
+      if (value instanceof Buffer || Buffer.isBuffer(value)) {
+        return { type: 'Buffer64', value: value.toString('base64') };
+      }
+    } else {
+      if (ArrayBuffer.isView(value)) {
+        // @ts-ignore
+        const binary = new TextDecoder('utf8').decode(value.buffer);
+        return {
+          type: 'ArrayBuffer64',
+          value: globalThis.btoa(binary),
+          args: {
+            arrayType: value[Symbol.toStringTag],
+            byteOffset: value.byteOffset,
+            byteLength: value.byteLength,
+          },
+        };
+      }
+      if (value instanceof ArrayBuffer) {
+        // @ts-ignore
+        const binary = new TextDecoder('utf8').decode(value);
+        return {
+          type: 'ArrayBuffer64',
+          value: globalThis.btoa(binary),
+        };
+      }
+    }
+
+    return value;
   }
 }
+
+export function registerSerializableErrorType(errorConstructor: {
+  new (message?: string): Error;
+}): void {
+  TypeSerializer.errorTypes.set(errorConstructor.name, errorConstructor);
+}
+
+export const stringifiedTypeSerializerClass = TypeSerializer.toString();

--- a/commons/interfaces/IPendingWaitEvent.ts
+++ b/commons/interfaces/IPendingWaitEvent.ts
@@ -1,4 +1,5 @@
 import IResolvablePromise from '@secret-agent/core-interfaces/IResolvablePromise';
+import { registerSerializableErrorType } from '../TypeSerializer';
 
 export class CanceledPromiseError extends Error {
   constructor(message: string) {
@@ -13,3 +14,5 @@ export default interface IPendingWaitEvent {
   resolvable: IResolvablePromise;
   error: CanceledPromiseError;
 }
+
+registerSerializableErrorType(CanceledPromiseError);

--- a/commons/interfaces/TimeoutError.ts
+++ b/commons/interfaces/TimeoutError.ts
@@ -1,6 +1,10 @@
+import { registerSerializableErrorType } from '../TypeSerializer';
+
 export default class TimeoutError extends Error {
   constructor(message?: string) {
     super(message ?? 'Timeout waiting for promise');
     this.name = 'TimeoutError';
   }
 }
+
+registerSerializableErrorType(TimeoutError);

--- a/commons/package.json
+++ b/commons/package.json
@@ -6,11 +6,11 @@
   "dependencies": {
     "@secret-agent/core-interfaces": "1.4.0-alpha.1",
     "https-proxy-agent": "^5.0.0",
-    "source-map-support": "^0.5.19",
-    "typeson": "^5.18.2",
-    "typeson-registry": "^1.0.0-alpha.38"
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^5.4.1"
+    "@types/better-sqlite3": "^5.4.1",
+    "@secret-agent/emulate-chrome-83": "^1.4.0-alpha.1",
+    "@secret-agent/puppet": "^1.4.0-alpha.1"
   }
 }

--- a/commons/test/TypeSerializer.test.ts
+++ b/commons/test/TypeSerializer.test.ts
@@ -1,0 +1,64 @@
+import Puppet from '@secret-agent/puppet';
+import Chrome83 from '@secret-agent/emulate-chrome-83';
+import TypeSerializer, { stringifiedTypeSerializerClass } from '../TypeSerializer';
+import { CanceledPromiseError } from '../interfaces/IPendingWaitEvent';
+import Log from '../Logger';
+
+const { log } = Log(module);
+
+let testObject: any;
+beforeAll(() => {
+  testObject = {
+    name: 'original',
+    map: new Map<string, number>([
+      ['1', 1],
+      ['2', 2],
+    ]),
+    set: new Set([1, 2, 3, 4]),
+    regex: /test13234/gi,
+    date: new Date('2021-03-17T15:41:06.513Z'),
+    buffer: Buffer.from('This is a test buffer'),
+    error: new CanceledPromiseError('This is canceled'),
+  };
+
+  testObject.nestedObject = { ...testObject, name: 'nested' };
+  testObject.nestedArray = [
+    { ...testObject, name: 'item1' },
+    { ...testObject, name: 'item2' },
+  ];
+});
+
+test('it should be able to serialize a complex object in nodejs', () => {
+  const result = TypeSerializer.stringify(testObject);
+  expect(typeof result).toBe('string');
+  const decoded = TypeSerializer.parse(result);
+  expect(decoded).toEqual(testObject);
+});
+
+test('should be able to serialize and deserialize in a browser window', async () => {
+  const puppet = new Puppet(Chrome83.engine);
+  try {
+    await puppet.start();
+    const context = await puppet.newContext(
+      {
+        userAgent: 'Page tests',
+        proxyPassword: '',
+        viewport: { width: 1920, height: 800 } as any,
+      } as any,
+      log,
+    );
+    const page = await context.newPage();
+    await page.evaluate(`${stringifiedTypeSerializerClass}`);
+    const serialized = TypeSerializer.stringify(testObject);
+
+    const result = await page.evaluate<any>(`(function() {
+    const decodedInClient = TypeSerializer.parse(JSON.stringify(${serialized}));
+    return TypeSerializer.stringify(decodedInClient);
+})()`);
+    expect(typeof result).toBe('string');
+    const decoded = TypeSerializer.parse(result);
+    expect(decoded).toEqual(testObject);
+  } finally {
+    await puppet.close();
+  }
+});

--- a/core/lib/DomRecorder.ts
+++ b/core/lib/DomRecorder.ts
@@ -51,10 +51,10 @@ export default class DomRecorder {
   }
 
   public async setCommandIdForPage(commandId: number) {
-    const command = `window.commandId = ${commandId}`;
+    const command = `window.commandId=${commandId}`;
     await Promise.all(
       this.puppetPage.frames.map(x =>
-        x.evaluate(command, true).catch(() => {
+        x.evaluate(command, true, false).catch(() => {
           // can fail when frames aren't ready. don't worry about it
         }),
       ),

--- a/core/lib/FrameNavigationsObserver.ts
+++ b/core/lib/FrameNavigationsObserver.ts
@@ -95,7 +95,7 @@ export default class FrameNavigationsObserver {
 
     const promise = this.createStatusTriggeredPromise(status, options.timeoutMs);
 
-    this.onLoadStatusChange();
+    if (this.navigations.top) this.onLoadStatusChange();
     return promise;
   }
 

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
-import TypeSerializer from '@secret-agent/commons/TypeSerializer';
+import { stringifiedTypeSerializerClass } from '@secret-agent/commons/TypeSerializer';
 
 const pageScripts = {
   domStorage: fs.readFileSync(require.resolve(`../injected-scripts/domStorage.js`), 'utf8'),
@@ -11,7 +11,9 @@ const pageScripts = {
 
 const injectedScript = `(function installInjectedScripts() {
 const exports = {}; // workaround for ts adding an exports variable
-${TypeSerializer.domScript};
+${stringifiedTypeSerializerClass};
+
+const TSON = TypeSerializer;
 
 ${pageScripts.jsPath};
 ${pageScripts.Fetcher};

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -75,6 +75,7 @@ export default class Session extends TypedEventEmitter<{
     super();
     this.id = uuidv1();
     Session.byId[this.id] = this;
+    this.logger = log.createChild(module, { sessionId: this.id });
     this.awaitedEventListener = new AwaitedEventListener(this);
     this.browserEmulatorId = BrowserEmulators.getId(options.browserEmulatorId);
     const BrowserEmulator = BrowserEmulators.getClass(this.browserEmulatorId);

--- a/puppet-chrome/lib/Frame.ts
+++ b/puppet-chrome/lib/Frame.ts
@@ -96,6 +96,7 @@ export default class Frame
   public async evaluate<T>(
     expression: string,
     isolateFromWebPageEnvironment?: boolean,
+    shouldAwaitExpression = true,
   ): Promise<T> {
     const contextId = await this.waitForActiveContextId(isolateFromWebPageEnvironment);
     const result = await this.cdpSession.send(
@@ -104,7 +105,7 @@ export default class Frame
         expression,
         contextId,
         returnByValue: true,
-        awaitPromise: true,
+        awaitPromise: shouldAwaitExpression,
       },
       this,
     );

--- a/puppet-chrome/lib/Worker.ts
+++ b/puppet-chrome/lib/Worker.ts
@@ -90,7 +90,7 @@ export class Worker extends TypedEventEmitter<IPuppetWorkerEvents> implements IP
     const contextId = await this.executionContextId.promise;
     const result = await this.cdpSession.send('Runtime.evaluate', {
       expression,
-      awaitPromise: true,
+      awaitPromise: !isInitializationScript,
       contextId,
       returnByValue: true,
     });

--- a/puppet-interfaces/IPuppetFrame.ts
+++ b/puppet-interfaces/IPuppetFrame.ts
@@ -14,7 +14,11 @@ export interface IPuppetFrame extends ITypedEventEmitter<IPuppetFrameEvents> {
   waitForLoad(): Promise<void>;
   waitForLoader(loaderId?: string): Promise<Error | undefined>;
   canEvaluate(isolatedFromWebPageEnvironment: boolean): boolean;
-  evaluate<T>(expression: string, isolateFromWebPageEnvironment?: boolean): Promise<T>;
+  evaluate<T>(
+    expression: string,
+    isolateFromWebPageEnvironment?: boolean,
+    shouldAwaitExpression?: boolean,
+  ): Promise<T>;
   evaluateOnIsolatedFrameElement<T>(expression: string): Promise<T>;
   toJSON(): object;
 }

--- a/website/docs/Advanced/UserProfile.md
+++ b/website/docs/Advanced/UserProfile.md
@@ -11,7 +11,7 @@ UserProfiles enable you to capture the full browser state of a user after perfor
 
 This "state" is not instantiated, but retrieved from an Agent instance: [agent.exportUserProfile()](/docs/basic-interfaces/agent#export-profile).
 
-State is stored for all domains (origins) that are loaded into a window at the time of export. The exported state is JSON with additional type information for IndexedDB ([typeson](https://github.com/dfahlander/typeson).
+State is stored for all domains (origins) that are loaded into a window at the time of export. The exported state is JSON with additional type information for IndexedDB complex objects.
 
 When you restore a UserProfile, SecretAgent will restore the Cookies, Dom Storage and IndexedDB records for all domains that are included in the state.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4599,11 +4599,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-arraybuffer-es6@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
-  integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
-
 base64-js@^1.0.2, base64-js@^1.2.3, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -18075,25 +18070,6 @@ typescript@~4.1.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
-typeson-registry@^1.0.0-alpha.38:
-  version "1.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"
-  integrity sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==
-  dependencies:
-    base64-arraybuffer-es6 "^0.7.0"
-    typeson "^6.0.0"
-    whatwg-url "^8.4.0"
-
-typeson@^5.18.2:
-  version "5.18.2"
-  resolved "https://registry.yarnpkg.com/typeson/-/typeson-5.18.2.tgz#0d217fc0e11184a66aa7ca0076d9aa7707eb7bc2"
-  integrity sha512-Vetd+OGX05P4qHyHiSLdHZ5Z5GuQDrHHwSdjkqho9NSCYVSLSfRMjklD/unpHH8tXBR9Z/R05rwJSuMpMFrdsw==
-
-typeson@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/typeson/-/typeson-6.0.0.tgz#a1e8465028376565f9efed96fef6879a9a844c10"
-  integrity sha512-WFgL4bEdyyfH6VfzC39AcSfeGqTFycW8TvWQy/hbtN8ssbuXSrkSdW2OCt0bUmUZdmFR0wrszyr0CIhvvs4RQw==
-
 typography-normalize@^0.16.19:
   version "0.16.19"
   resolved "https://registry.yarnpkg.com/typography-normalize/-/typography-normalize-0.16.19.tgz#58e0cf12466870c5b27006daa051fe7307780660"
@@ -19127,7 +19103,7 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
-whatwg-url@^8.0.0, whatwg-url@^8.4.0:
+whatwg-url@^8.0.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.4.0.tgz#50fb9615b05469591d2b2bd6dfaed2942ed72837"
   integrity sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==


### PR DESCRIPTION
This PR adds a type serializer for JSON and replaces typeson. It's not as full featured, but doesn't require corejs and regenerator runtime as dependencies. It's also smaller to send over to the js side.