### PR TITLE
fix(emulator): polyfill setAppBadge/clearAppBadge

### DIFF
--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -107,11 +107,9 @@ export default class GlobalPool {
     this.puppets.push(puppet);
 
     const showBrowser = Boolean(JSON.parse(process.env.SHOW_BROWSER ?? 'false'));
-    const showBrowserLogs = Boolean(JSON.parse(process.env.DEBUG ?? 'false'));
     const browserOrError = await puppet.start({
       proxyPort: this.mitmServer.port,
       showBrowser,
-      pipeBrowserIo: showBrowserLogs,
     });
     if (browserOrError instanceof Error) throw browserOrError;
     return puppet;

--- a/emulate-browsers/base/injected-scripts/navigator.ts
+++ b/emulate-browsers/base/injected-scripts/navigator.ts
@@ -10,3 +10,31 @@ if (args.userAgentString && self.navigator?.userAgent !== args.userAgentString) 
 if (args.platform && self.navigator?.platform !== args.platform) {
   proxyGetter(self.navigator, 'platform', () => args.platform, true);
 }
+
+if ('setAppBadge' in self.navigator) {
+  proxyFunction(self.navigator, 'setAppBadge', (target, thisArg, argArray) => {
+    let error: TypeError;
+    if (argArray.length) {
+      const arg = argArray[0];
+      if (typeof arg === 'number') {
+        if (arg < 0 || arg > Number.MAX_SAFE_INTEGER) {
+          error = new TypeError(
+            `Failed to execute 'setAppBadge' on 'Navigator': Value is outside the 'unsigned long long' value range.`,
+          );
+        }
+      } else {
+        error = new TypeError(
+          `Failed to execute 'setAppBadge' on 'Navigator': Value is not of type 'unsigned long long'.`,
+        );
+      }
+    }
+    if (error) return Promise.reject(cleanErrorStack(error));
+    return Promise.resolve(undefined);
+  });
+}
+
+if ('clearAppBadge' in self.navigator) {
+  proxyFunction(self.navigator, 'clearAppBadge', (target, thisArg, argArray) => {
+    return Promise.resolve(undefined);
+  });
+}

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -38,7 +38,6 @@ export default class Puppet {
   public start(
     args: ILaunchArgs = {
       showBrowser: false,
-      pipeBrowserIo: false,
     },
   ): Promise<IPuppetBrowser | Error> {
     if (this.browserOrError) {
@@ -89,7 +88,7 @@ export default class Puppet {
     }
 
     try {
-      const { pipeBrowserIo, proxyPort, showBrowser } = args;
+      const { proxyPort, showBrowser } = args;
       const launchArgs = launcher.getLaunchArgs({ showBrowser, proxyPort });
 
       // exists, but can't launch, try to launch
@@ -98,7 +97,7 @@ export default class Puppet {
       if (this.engine.extraLaunchArgs?.length) {
         launchArgs.push(...this.engine.extraLaunchArgs);
       }
-      const launchedProcess = await launchProcess(executablePath, launchArgs, {}, pipeBrowserIo);
+      const launchedProcess = await launchProcess(executablePath, launchArgs, {});
       return launcher.createPuppet(launchedProcess, this.engine);
     } catch (err) {
       const launchError = launcher.translateLaunchError(err);
@@ -138,5 +137,4 @@ ${remedyMessage}`);
 interface ILaunchArgs {
   proxyPort?: number;
   showBrowser?: boolean;
-  pipeBrowserIo?: boolean;
 }

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -31,13 +31,8 @@ export default function launchProcess(
   executablePath: string,
   processArguments: string[],
   env: NodeJS.ProcessEnv,
-  pipeIo = true,
 ): Promise<ILaunchedProcess> {
   const stdio: StdioOptions = ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'];
-  if (!pipeIo) {
-    stdio[1] = 'ignore';
-    stdio[2] = 'ignore';
-  }
 
   log.info(`Puppet.LaunchProcess`, { sessionId: null, executablePath, processArguments });
   const launchedProcess = childProcess.spawn(executablePath, processArguments, {
@@ -63,17 +58,16 @@ export default function launchProcess(
   let exe = executablePath.split(Path.sep).pop().toLowerCase();
   exe = exe[0].toUpperCase() + exe.slice(1);
 
-  if (pipeIo) {
-    const stdout = readline.createInterface({ input: launchedProcess.stdout });
-    stdout.on('line', line => {
-      log.stats(`${exe}.stdout`, { message: line, sessionId: null });
-    });
+  const stdout = readline.createInterface({ input: launchedProcess.stdout });
+  stdout.on('line', line => {
+    log.stats(`${exe}.stdout`, { message: line, sessionId: null });
+  });
 
-    const stderr = readline.createInterface({ input: launchedProcess.stderr });
-    stderr.on('line', line => {
-      log.warn(`${exe}.stderr`, { message: line, sessionId: null });
-    });
-  }
+  const stderr = readline.createInterface({ input: launchedProcess.stderr });
+  stderr.on('line', line => {
+    log.warn(`${exe}.stderr`, { message: line, sessionId: null });
+  });
+
   let processKilled = false;
   launchedProcess.once('exit', (exitCode, signal) => {
     processKilled = true;


### PR DESCRIPTION
Calls to clearAppBadge and setAppBadge were crashing Puppet/Chrome. It's a known issue in headless, that appears to be resolved in chrome 89 (https://chromium.googlesource.com/chromium/src.git/+/c8a9fc64753d988e7ee59045a52aea14773fbe0d)


As part of this, I'm proposing we log Chrome stdout and stderr to the database by default, not with additional logging. It was hard to find our crash issue without it.