### PR TITLE
Network Issues

### DIFF
--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -597,7 +597,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
 
     session.mitmRequestSession.browserRequestMatcher.onBrowserRequestedResource(resource, this.id);
 
-    if (isDocumentNavigation) {
+    if (isDocumentNavigation && !event.resource.browserCanceled) {
       navigations.onHttpRequested(url, lastCommandId, redirectedFromUrl, browserRequestId);
     }
   }

--- a/mitm-socket/lib/connect.go
+++ b/mitm-socket/lib/connect.go
@@ -35,6 +35,7 @@ func main() {
 	domainSocketPiper := &DomainSocketPiper{
 		Path:  socketPath,
 		debug: connectArgs.Debug,
+		keepAlive: connectArgs.KeepAlive,
 	}
 
 	if debug {
@@ -89,4 +90,5 @@ type ConnectArgs struct {
 	TcpTtl             int
 	TcpWindowSize      int
 	Debug              bool
+	KeepAlive          bool
 }

--- a/mitm/lib/MitmRequestContext.ts
+++ b/mitm/lib/MitmRequestContext.ts
@@ -52,14 +52,24 @@ export default class MitmRequestContext {
     const expectedProtocol = `${protocol}${isSSL ? 's' : ''}:`;
 
     let url: URL;
-    if (clientToProxyRequest.url.match(/[http|ws]s?:\/\//)) {
+    if (
+      clientToProxyRequest.url.startsWith('http://') ||
+      clientToProxyRequest.url.startsWith('https://') ||
+      clientToProxyRequest.url.startsWith('ws://') ||
+      clientToProxyRequest.url.startsWith('wss://')
+    ) {
       url = new URL(clientToProxyRequest.url);
     } else {
       let providedHost = (clientToProxyRequest.headers.host ??
         clientToProxyRequest.headers[':authority'] ??
         '') as string;
       if (providedHost.endsWith('/')) providedHost = providedHost.slice(0, -1);
-      if (providedHost.startsWith('http') || providedHost.startsWith('ws')) {
+      if (
+        providedHost.startsWith('http://') ||
+        providedHost.startsWith('https://') ||
+        providedHost.startsWith('ws://') ||
+        providedHost.startsWith('wss://')
+      ) {
         providedHost = providedHost.split('://').slice(1).join('://');
       }
       // build urls in two steps because URL constructor will bomb on valid WHATWG urls with path

--- a/puppet-chrome/lib/NetworkManager.ts
+++ b/puppet-chrome/lib/NetworkManager.ts
@@ -398,12 +398,13 @@ export class NetworkManager extends TypedEventEmitter<IPuppetNetworkEvents> {
 
     const resource = this.requestsById.get(requestId);
     if (resource) {
-      if (!this.requestPublishingById.get(requestId)?.isPublished) {
-        this.doEmitResourceRequested(requestId);
-      }
       if (canceled) resource.browserCanceled = true;
       if (blockedReason) resource.browserBlockedReason = blockedReason;
       if (errorText) resource.browserLoadFailure = errorText;
+
+      if (!this.requestPublishingById.get(requestId)?.isPublished) {
+        this.doEmitResourceRequested(requestId);
+      }
       this.emit('resource-failed', {
         resource,
       });


### PR DESCRIPTION
This PR fixes a few network errors:
1. URLs starting with "ws" (like wsj.com) were being treated as if they were starting with ws://, ie websockets.
2. Some sites send redirect and end over http. The golang sockets were not correctly reading these
3. The golang socket library was not properly disconnecting with a 0 byte EOF
4. Sites that redirect to a protocol (ie, whatsapp://chat) were failing to ever trigger paintingStable