### PR TITLE
fix(emulate): mask widevine checks

### DIFF
--- a/core-interfaces/IBrowserEngine.ts
+++ b/core-interfaces/IBrowserEngine.ts
@@ -4,6 +4,7 @@ export default interface IBrowserEngine {
   executablePath: string;
   executablePathEnvVar: string;
   extraLaunchArgs?: string[];
+  isHeaded?: boolean;
 }
 
 export type IBrowserEngineConfig = Pick<

--- a/core/index.ts
+++ b/core/index.ts
@@ -151,13 +151,13 @@ export default class Core {
   });
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  process.on('uncaughtExceptionMonitor', async (error: Error) => {
-    await Core.logUnhandledError(error, true);
+process.on('uncaughtExceptionMonitor', async (error: Error) => {
+  await Core.logUnhandledError(error, true);
+  if (process.env.NODE_ENV !== 'test') {
     await Core.shutdown();
-  });
+  }
+});
 
-  process.on('unhandledRejection', async (error: Error) => {
-    await Core.logUnhandledError(error, false);
-  });
-}
+process.on('unhandledRejection', async (error: Error) => {
+  await Core.logUnhandledError(error, false);
+});

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -106,10 +106,8 @@ export default class GlobalPool {
     const puppet = new Puppet(engine);
     this.puppets.push(puppet);
 
-    const showBrowser = Boolean(JSON.parse(process.env.SHOW_BROWSER ?? 'false'));
     const browserOrError = await puppet.start({
       proxyPort: this.mitmServer.port,
-      showBrowser,
     });
     if (browserOrError instanceof Error) throw browserOrError;
     return puppet;

--- a/emulate-browsers/base/index.ts
+++ b/emulate-browsers/base/index.ts
@@ -25,6 +25,10 @@ function getEngine(
     executablePathEnvVar,
   ).toJSON();
 
+  engineFetcher.isHeaded = Boolean(
+    JSON.parse(process.env.SA_SHOW_BROWSER ?? process.env.SHOW_BROWSER ?? 'false'),
+  );
+
   log.stats('Browser.getEngine', {
     sessionId: null,
     engineFetcher,

--- a/emulate-browsers/chrome-80/index.ts
+++ b/emulate-browsers/chrome-80/index.ts
@@ -130,6 +130,7 @@ export default class Chrome80 {
     domOverrides.add('navigator', {
       userAgentString: this.userAgentString,
       platform: this.osPlatform,
+      headless: Chrome80.engine.isHeaded !== true,
     });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {

--- a/emulate-browsers/chrome-81/index.ts
+++ b/emulate-browsers/chrome-81/index.ts
@@ -130,6 +130,7 @@ export default class Chrome81 {
     domOverrides.add('navigator', {
       userAgentString: this.userAgentString,
       platform: this.osPlatform,
+      headless: Chrome81.engine.isHeaded !== true,
     });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {

--- a/emulate-browsers/chrome-83/index.ts
+++ b/emulate-browsers/chrome-83/index.ts
@@ -130,6 +130,7 @@ export default class Chrome83 {
     domOverrides.add('navigator', {
       userAgentString: this.userAgentString,
       platform: this.osPlatform,
+      headless: Chrome83.engine.isHeaded !== true,
     });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {

--- a/emulate-browsers/safari-13/index.ts
+++ b/emulate-browsers/safari-13/index.ts
@@ -178,6 +178,7 @@ export default class Safari13 {
     domOverrides.add('navigator', {
       userAgentString: this.userAgentString,
       platform: this.osPlatform,
+      headless: Safari13.engine.isHeaded !== true,
     });
 
     domOverrides.add('MediaDevices.prototype.enumerateDevices', {

--- a/puppet-chrome/index.ts
+++ b/puppet-chrome/index.ts
@@ -96,7 +96,6 @@ const defaultArgs = [
   '--disable-breakpad', // Disable crashdump collection (reporting is already disabled in Chromium)
   '--disable-client-side-phishing-detection', //  Disables client-side phishing detection.
   '--disable-domain-reliability', // Disables Domain Reliability Monitoring, which tracks whether the browser has difficulty contacting Google-owned sites and uploads reports to Google.
-  '--disable-component-update', // Don't update the browser 'components' listed at chrome://components/
   '--disable-component-extensions-with-background-pages', // Disable some built-in extensions that aren't affected by --disable-extensions
   '--disable-default-apps', // Disable installation of default apps on first run
   '--disable-dev-shm-usage', // https://github.com/GoogleChrome/puppeteer/issues/1834
@@ -115,6 +114,8 @@ const defaultArgs = [
   '--use-gl=osmesa',
 
   '--incognito',
+
+  '--use-fake-device-for-media-stream',
 
   '--no-default-browser-check', //  Disable the default browser check, do not prompt to set it as such
   '--metrics-recording-only', // Disable reporting to UMA, but allows for collection

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -35,11 +35,7 @@ export default class Puppet {
     puppBrowserCounter += 1;
   }
 
-  public start(
-    args: ILaunchArgs = {
-      showBrowser: false,
-    },
-  ): Promise<IPuppetBrowser | Error> {
+  public start(args: ILaunchArgs = {}): Promise<IPuppetBrowser | Error> {
     if (this.browserOrError) {
       return this.browserOrError;
     }
@@ -88,8 +84,11 @@ export default class Puppet {
     }
 
     try {
-      const { proxyPort, showBrowser } = args;
-      const launchArgs = launcher.getLaunchArgs({ showBrowser, proxyPort });
+      const { proxyPort } = args;
+      const launchArgs = launcher.getLaunchArgs({
+        showBrowser: !!this.engine.isHeaded,
+        proxyPort,
+      });
 
       // exists, but can't launch, try to launch
       await validateHostRequirements(this.engine);
@@ -136,5 +135,4 @@ ${remedyMessage}`);
 
 interface ILaunchArgs {
   proxyPort?: number;
-  showBrowser?: boolean;
 }


### PR DESCRIPTION
This PR helps avoid widevine checks from uncovering SecretAgent by:
1) If headless, polyfiling requests to widevine (NOTE: this will not actually play widevine content)
2) If non-headless, allow regular widevine operation (fixed by removing "disable-update-components" in chrome, which flagged off widevine.

As part of this PR, control of whether a browser is headless is moved closer to the BrowserEmulators control. Right now, they all use the same env variable, but we could easily change that to be unique per browser engine.

NOTE: this PR adds to the emulator scripts, but has to actually add a variable to the navigator script, so will need to be updated in the "template" in slab.