### PR TITLE
fix(mitm): store resources if tab not found

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -283,10 +283,10 @@ export default class Session extends TypedEventEmitter<{
     const tabId = this.mitmRequestSession.browserRequestMatcher.requestIdToTabId.get(
       event.browserRequestId,
     );
-    const tab = this.tabs.find(x => x.id === tabId);
+    let tab = this.tabs.find(x => x.id === tabId);
     if (!tab && !tabId) {
-      this.logger.warn(`Mitm Response received without matching tab`, { event });
-      return;
+      // if we can't place it, just use the first active tab
+      tab = this.tabs.find(x => !x.isClosing) ?? this.tabs[0];
     }
 
     const resource = this.sessionState.captureResource(tab?.id ?? tabId, event, true);


### PR DESCRIPTION
If an http response is returned to the mitm and we don't match a tab (ie, Chrome requested the resource), we were throwing out the data. This PR broadcasts it on the first active tab by default instead.