### PR TITLE
feat(interact): peg nodeid for interactions

### DIFF
--- a/core-interfaces/IElementRect.ts
+++ b/core-interfaces/IElementRect.ts
@@ -6,4 +6,5 @@ export default interface IElementRect {
   height: number;
   width: number;
   tag: string;
+  isVisible?: boolean;
 }

--- a/core-interfaces/IInteractionsHelper.ts
+++ b/core-interfaces/IInteractionsHelper.ts
@@ -8,7 +8,7 @@ import { IBoundLog } from './ILog';
 export default interface IInteractionsHelper {
   lookupBoundingRect(
     mousePosition: IMousePosition,
-  ): Promise<IRect & { elementTag?: string; nodeId?: number }>;
+  ): Promise<IRect & { elementTag?: string; nodeId?: number; isNodeVisible?: boolean }>;
   createMouseupTrigger(nodeId: number): Promise<{ didTrigger: () => Promise<IMouseUpResult> }>;
   createMouseoverTrigger(nodeId: number): Promise<{ didTrigger: () => Promise<boolean> }>;
   mousePosition: IPoint;

--- a/core/lib/CommandFormatter.ts
+++ b/core/lib/CommandFormatter.ts
@@ -136,7 +136,7 @@ export default class CommandFormatter {
 }
 
 export function formatJsPath(path: any) {
-  const jsPath = path
+  const jsPath = (path ?? [])
     .map((x, i) => {
       if (i === 0 && typeof x === 'number') {
         return '<previouslySelectedNode>';


### PR DESCRIPTION
When running interactions, if you pass in a query selector, we run it multiple times _within_ a single interaction. This can have strange effects if, for instance, nodes swap order, as it does in many cases where modals pop up. So you can end up trying to move and click on different nodes in the same interaction. 

This PR "pegs" the nodeid for the course of a single interaction.

In addition, if an element cannot be clicked on, a bit more information is presented about what could be going on.