### PR TITLE
Mitm bug, install deps message issue

### DIFF
--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -181,7 +181,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
     return this.isDisconnecting === false && this.coreSessions.hasAvailability();
   }
 
-  public async createSession(options: ICreateSessionOptions): Promise<CoreSession | Error> {
+  public async createSession(options: ICreateSessionOptions): Promise<CoreSession> {
     try {
       const sessionMeta = await this.commandQueue.run<ISessionMeta>('Session.create', options);
       const session = new CoreSession({ ...sessionMeta, sessionName: options.sessionName }, this);
@@ -189,7 +189,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
       return session;
     } catch (error) {
       if (error instanceof DisconnectedFromCoreError && this.isDisconnecting) return null;
-      return error;
+      throw error;
     }
   }
 

--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -181,7 +181,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
     return this.isDisconnecting === false && this.coreSessions.hasAvailability();
   }
 
-  public async createSession(options: ICreateSessionOptions): Promise<CoreSession> {
+  public async createSession(options: ICreateSessionOptions): Promise<CoreSession | Error> {
     try {
       const sessionMeta = await this.commandQueue.run<ISessionMeta>('Session.create', options);
       const session = new CoreSession({ ...sessionMeta, sessionName: options.sessionName }, this);
@@ -189,7 +189,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
       return session;
     } catch (error) {
       if (error instanceof DisconnectedFromCoreError && this.isDisconnecting) return null;
-      throw error;
+      return error;
     }
   }
 
@@ -307,8 +307,8 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
       this.pendingRequestsById.delete(id);
       this.rejectPendingRequest(entry, new DisconnectedFromCoreError(host));
     }
-    this.coreSessions.stop(new DisconnectedFromCoreError(host));
     this.commandQueue.stop(new DisconnectedFromCoreError(host));
+    this.coreSessions.stop(new DisconnectedFromCoreError(host));
   }
 
   private createPendingResult(): IResolvablePromiseWithId {

--- a/client/connections/RemoteConnectionToCore.ts
+++ b/client/connections/RemoteConnectionToCore.ts
@@ -64,7 +64,7 @@ export default class RemoteConnectionToCore extends ConnectionToCore {
         webSocket.once('close', this.internalDisconnect);
         webSocket.once('error', this.internalDisconnect);
         webSocket.on('message', message => {
-          const payload = TypeSerializer.parse(message.toString());
+          const payload = TypeSerializer.parse(message.toString(), 'REMOTE CORE');
           this.onMessage(payload);
         });
       } catch (error) {

--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -406,7 +406,7 @@ class SessionConnection {
     );
     this._connection = connection;
 
-    this._coreSession = connection.createSession(options);
+    this._coreSession = connection.createSession(options).catch(err => err);
 
     const defaultShowReplay = Boolean(JSON.parse(process.env.SA_SHOW_REPLAY ?? 'true'));
 

--- a/client/lib/CoreSession.ts
+++ b/client/lib/CoreSession.ts
@@ -88,9 +88,12 @@ export default class CoreSession implements IJsPathEventTarget {
   }
 
   public async close(): Promise<void> {
-    await this.commandQueue.run('Session.close');
-    process.nextTick(() => this.connection.closeSession(this));
-    loggerSessionIdNames.delete(this.sessionId);
+    try {
+      await this.commandQueue.run('Session.close');
+    } finally {
+      process.nextTick(() => this.connection.closeSession(this));
+      loggerSessionIdNames.delete(this.sessionId);
+    }
   }
 
   public async addEventListener(

--- a/client/lib/Handler.ts
+++ b/client/lib/Handler.ts
@@ -189,7 +189,7 @@ export default class Handler {
     if (this.isClosing) return;
     this.isClosing = true;
     // eslint-disable-next-line promise/no-promise-in-callback
-    await Promise.all(this.connections.map(x => x.disconnect(error)));
+    await Promise.all(this.connections.map(x => x.disconnect(error).catch(() => null)));
   }
 
   private getAvailableConnections(): ConnectionToCore[] {
@@ -204,6 +204,8 @@ export default class Handler {
   }
 
   private registerUnhandledExceptionHandlers(): void {
+    if (process.env.NODE_ENV === 'test') return;
+
     process.on('uncaughtExceptionMonitor', this.close.bind(this));
     process.on('unhandledRejection', this.logUnhandledError.bind(this));
   }

--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -154,7 +154,7 @@ class LogEvents {
   }
 }
 
-export { LogEvents, loggerSessionIdNames, hasBeenLoggedSymbol };
+export { Log, LogEvents, loggerSessionIdNames, hasBeenLoggedSymbol };
 
 export function injectLogger(builder: (module: NodeModule) => ILogBuilder): void {
   logCreator = builder;

--- a/commons/ShutdownHandler.ts
+++ b/commons/ShutdownHandler.ts
@@ -1,9 +1,9 @@
-import Log from './Logger';
+import logger from './Logger';
 import { CanceledPromiseError } from './interfaces/IPendingWaitEvent';
 
 type ShutdownSignal = NodeJS.Signals | 'exit';
 
-const { log } = Log(module);
+const { log } = logger(module);
 
 export default class ShutdownHandler {
   public static exitOnSignal = true;

--- a/commons/TypeSerializer.ts
+++ b/commons/TypeSerializer.ts
@@ -2,7 +2,7 @@ export default class TypeSerializer {
   public static errorTypes = new Map<string, { new (message?: string): Error }>();
   private static isNodejs = typeof process !== 'undefined' && process.release.name === 'node';
 
-  public static parse(stringified: string): any {
+  public static parse(stringified: string, stackMarker = 'SERIALIZER'): any {
     return JSON.parse(stringified, (key, entry) => {
       if (!entry || !entry.type) return entry;
 
@@ -41,10 +41,13 @@ export default class TypeSerializer {
           }
         }
 
+        const startStack = new Error('').stack.split(/\r?\n/).slice(1).join('\n');
         const e = new Constructor(message);
         e.name = name;
-        if (stack) e.stack = stack;
         Object.assign(e, data);
+        if (stack) {
+          e.stack = `${stack}\n${`------${stackMarker}`.padEnd(50, '-')}\n${startStack}`;
+        }
         return e;
       }
 

--- a/commons/test/TypeSerializer.test.ts
+++ b/commons/test/TypeSerializer.test.ts
@@ -2,9 +2,9 @@ import Puppet from '@secret-agent/puppet';
 import Chrome83 from '@secret-agent/emulate-chrome-83';
 import TypeSerializer, { stringifiedTypeSerializerClass } from '../TypeSerializer';
 import { CanceledPromiseError } from '../interfaces/IPendingWaitEvent';
-import Log from '../Logger';
+import logger from '../Logger';
 
-const { log } = Log(module);
+const { log } = logger(module);
 
 let testObject: any;
 beforeAll(() => {

--- a/core/index.ts
+++ b/core/index.ts
@@ -151,13 +151,12 @@ export default class Core {
   });
 });
 
-process.on('uncaughtExceptionMonitor', async (error: Error) => {
-  await Core.logUnhandledError(error, true);
-  if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV !== 'test') {
+  process.on('uncaughtExceptionMonitor', async (error: Error) => {
+    await Core.logUnhandledError(error, true);
     await Core.shutdown();
-  }
-});
-
-process.on('unhandledRejection', async (error: Error) => {
-  await Core.logUnhandledError(error, false);
-});
+  });
+  process.on('unhandledRejection', async (error: Error) => {
+    await Core.logUnhandledError(error, false);
+  });
+}

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -403,7 +403,9 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
       return this.runFn(fnName, serializedFn, retries - 1);
     }
 
-    const result = unparsedResult ? TypeSerializer.parse(unparsedResult as string) : unparsedResult;
+    const result = unparsedResult
+      ? TypeSerializer.parse(unparsedResult as string, 'BROWSER')
+      : unparsedResult;
     if (result?.error) {
       this.logger.error(fnName, { result });
       throw new InjectedScriptError(result.error, result.pathState);

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -80,7 +80,7 @@ export default class GlobalPool {
     const closePromises: Promise<any>[] = [];
     while (this.puppets.length) {
       const puppetBrowser = this.puppets.shift();
-      closePromises.push(puppetBrowser.close());
+      closePromises.push(puppetBrowser.close().catch(err => err));
     }
     if (this.mitmServer) {
       closePromises.push(this.mitmServer.close());

--- a/core/models/ResourcesTable.ts
+++ b/core/models/ResourcesTable.ts
@@ -39,6 +39,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
         ['usedArtificialCache', 'INTEGER'],
         ['didUserScriptBlockResource', 'INTEGER'],
         ['requestOriginalHeaders', 'TEXT'],
+        ['responseOriginalHeaders', 'TEXT'],
         ['httpError', 'TEXT'],
         ['browserServedFromCache', 'TEXT'],
         ['browserLoadFailure', 'TEXT'],
@@ -57,6 +58,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
       socketId: number;
       redirectedToUrl?: string;
       originalHeaders: IResourceHeaders;
+      responseOriginalHeaders?: IResourceHeaders;
       clientAlpn: string;
       dnsResolvedIp?: string;
       wasCached?: boolean;
@@ -114,6 +116,7 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
       extras.wasCached ? 1 : 0,
       extras.didBlockResource ? 1 : 0,
       JSON.stringify(extras.originalHeaders ?? {}),
+      JSON.stringify(extras.responseOriginalHeaders ?? {}),
       errorString,
       meta.response?.browserServedFromCache,
       meta.response?.browserLoadFailure,
@@ -174,6 +177,7 @@ export interface IResourcesRecord {
   didUserScriptBlockResource: boolean;
   isHttp2Push: boolean;
   requestOriginalHeaders: string;
+  responseOriginalHeaders: string;
   httpError: string;
 
   browserServedFromCache?: 'service-worker' | 'disk' | 'prefetch' | 'memory';

--- a/core/package.json
+++ b/core/package.json
@@ -7,8 +7,7 @@
       "import": "./index.mjs",
       "require": "./index.cjs"
     },
-    "./start": "./start.js",
-    "./server": "./server/index.js"
+    "./start": "./start.js"
   },
   "dependencies": {
     "@secret-agent/commons": "1.4.1-alpha.0",
@@ -22,7 +21,7 @@
     "@secret-agent/puppet": "1.4.1-alpha.0",
     "@secret-agent/puppet-interfaces": "1.4.1-alpha.0",
     "awaited-dom": "^1.1.10",
-    "better-sqlite3": "^7.1.2",
+    "better-sqlite3": "^7.1.4",
     "moment": "^2.24.1",
     "uuid": "^8.3.2",
     "ws": "^7.4.2"
@@ -33,7 +32,7 @@
     "@secret-agent/emulate-safari-13": "1.4.1-alpha.0",
     "@secret-agent/puppet-chrome": "1.4.1-alpha.0",
     "@secret-agent/testing": "1.4.1-alpha.0",
-    "@types/better-sqlite3": "^5.4.0",
+    "@types/better-sqlite3": "^5.4.1",
     "@types/json-socket": "^0.1.17",
     "http-proxy-agent": "^4.0.1",
     "vue": "^2.6.12"

--- a/core/server/index.ts
+++ b/core/server/index.ts
@@ -91,7 +91,7 @@ export default class CoreServer {
     if (request.url === '/') {
       const connection = Core.addConnection();
       ws.on('message', message => {
-        const payload = TypeSerializer.parse(message.toString());
+        const payload = TypeSerializer.parse(message.toString(), 'CLIENT');
         return connection.handleRequest(payload);
       });
 

--- a/mitm-socket/index.ts
+++ b/mitm-socket/index.ts
@@ -33,14 +33,15 @@ export default class MitmSocket extends TypedEventEmitter<{
   public dialTime: Date;
   public connectTime: Date;
   public closeTime: Date;
+
+  public isConnected = false;
   public isReused = false;
+  public isClosing = false;
 
   public get pid(): number | undefined {
     return this.child?.pid;
   }
 
-  private isClosing = false;
-  private isConnected = false;
   private child: ChildProcess;
   private connectError?: string;
   private readonly callStack: string;
@@ -223,7 +224,9 @@ export default class MitmSocket extends TypedEventEmitter<{
           host: this.connectOpts?.host,
           clientHello: this.connectOpts?.clientHelloId,
         });
-      } else if (message) {
+      } else if (message.startsWith('[DomainSocketPiper.Closed]')) {
+        this.close();
+      } else {
         this.logger.info('SocketHandler.onData', {
           message,
           host: this.connectOpts?.host,

--- a/mitm-socket/index.ts
+++ b/mitm-socket/index.ts
@@ -33,6 +33,7 @@ export default class MitmSocket extends TypedEventEmitter<{
   public dialTime: Date;
   public connectTime: Date;
   public closeTime: Date;
+  public isReused = false;
 
   public get pid(): number | undefined {
     return this.child?.pid;

--- a/mitm-socket/lib/connect.go
+++ b/mitm-socket/lib/connect.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -33,8 +34,8 @@ func main() {
 	debug := connectArgs.Debug
 
 	domainSocketPiper := &DomainSocketPiper{
-		Path:  socketPath,
-		debug: connectArgs.Debug,
+		Path:      socketPath,
+		debug:     connectArgs.Debug,
 		keepAlive: connectArgs.KeepAlive,
 	}
 
@@ -46,6 +47,11 @@ func main() {
 
 	addr := fmt.Sprintf("%s:%s", connectArgs.Host, connectArgs.Port)
 	dialConn, err := Dial(addr, connectArgs)
+
+	tcpConn := dialConn.(*net.TCPConn)
+	if connectArgs.KeepAlive {
+		tcpConn.SetKeepAlive(true)
+	}
 
 	if err != nil {
 		log.Fatalf("Dial (proxy/remote) Error: %+v\n", err)

--- a/mitm-socket/lib/connect.go
+++ b/mitm-socket/lib/connect.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -47,11 +46,6 @@ func main() {
 
 	addr := fmt.Sprintf("%s:%s", connectArgs.Host, connectArgs.Port)
 	dialConn, err := Dial(addr, connectArgs)
-
-	tcpConn := dialConn.(*net.TCPConn)
-	if connectArgs.KeepAlive {
-		tcpConn.SetKeepAlive(true)
-	}
 
 	if err != nil {
 		log.Fatalf("Dial (proxy/remote) Error: %+v\n", err)

--- a/mitm-socket/lib/dialer.go
+++ b/mitm-socket/lib/dialer.go
@@ -32,5 +32,11 @@ func Dial(addr string, connectArgs ConnectArgs) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	tcpConn, ok := dialConn.(*net.TCPConn)
+	if ok && connectArgs.KeepAlive {
+		tcpConn.SetKeepAlive(true)
+	}
+
 	return dialConn, nil
 }

--- a/mitm-socket/lib/domain_socket_piper.go
+++ b/mitm-socket/lib/domain_socket_piper.go
@@ -49,7 +49,7 @@ func (piper *DomainSocketPiper) Pipe(remoteConn net.Conn, sigc chan os.Signal) {
 		}
 	}
 
-	copyUntilTimeout := func(dst io.Writer, src net.Conn, notifyChan chan error, counter *uint32) {
+	copy := func(dst io.Writer, src net.Conn, notifyChan chan error, counter *uint32) {
 		var readErr error
 		var writeErr error
 		var n int
@@ -83,7 +83,7 @@ func (piper *DomainSocketPiper) Pipe(remoteConn net.Conn, sigc chan os.Signal) {
                         }
                         return
                     }
-                    time.Sleep(1 * time.Second)
+				    time.Sleep(200 * time.Millisecond)
                 }
 			} else if n == 0 {
 				time.Sleep(200 * time.Millisecond)
@@ -92,8 +92,8 @@ func (piper *DomainSocketPiper) Pipe(remoteConn net.Conn, sigc chan os.Signal) {
 	}
 
 	// Pipe data
-	go copyUntilTimeout(remoteConn, piper.client, localNotify, &piper.completeCounter)
-	go copyUntilTimeout(piper.client, remoteConn, remoteNotify, &piper.completeCounter)
+	go copy(remoteConn, piper.client, localNotify, &piper.completeCounter)
+	go copy(piper.client, remoteConn, remoteNotify, &piper.completeCounter)
 
 	// Read until one of these errors occur
 	var err error

--- a/mitm-socket/lib/domain_socket_piper.go
+++ b/mitm-socket/lib/domain_socket_piper.go
@@ -78,9 +78,9 @@ func (piper *DomainSocketPiper) Pipe(remoteConn net.Conn, sigc chan os.Signal) {
 				if readErr == io.EOF {
 				    if n == 0 {
                         atomic.AddUint32(&piper.completeCounter, 1)
-                        if piper.debug {
-                            fmt.Println("DomainSocket -> 0 Byte EOF")
-                        }
+
+                        fmt.Println("[DomainSocketPiper.Closed] -> 0 Byte EOF")
+
                         return
                     }
 				    time.Sleep(200 * time.Millisecond)

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -84,7 +84,7 @@ export default class HeadersHandler {
         continue;
       }
       // if going h2->h1->h2, strip http1 headers before responding to client
-      if (ctx.isServerHttp2 === false && ctx.isClientHttp2) {
+      if (ctx.isClientHttp2) {
         if (stripHttp1HeadersForH2.includes(canonizedKey.toLowerCase())) {
           continue;
         }

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -262,6 +262,7 @@ export interface IRequestSessionResponseEvent extends IRequestSessionRequestEven
   wasCached: boolean;
   dnsResolvedIp?: string;
   resourceType: ResourceType;
+  responseOriginalHeaders?: IResourceHeaders;
   body: Buffer;
   redirectedToUrl?: string;
   executionMillis: number;

--- a/mitm/lib/MitmProxy.ts
+++ b/mitm/lib/MitmProxy.ts
@@ -57,7 +57,7 @@ export default class MitmProxy {
 
     this.db = new NetworkDb(options.sslCaDir);
     this.ca = new CertificateAuthority(this.db);
-    this.httpServer = http.createServer();
+    this.httpServer = http.createServer({ insecureHTTPParser: true });
     this.httpServer.on('connect', this.onHttpConnect.bind(this));
     this.httpServer.on('clientError', this.onClientError.bind(this, false));
     this.httpServer.on('request', this.onHttpRequest.bind(this, false));

--- a/mitm/lib/MitmRequestAgent.ts
+++ b/mitm/lib/MitmRequestAgent.ts
@@ -56,7 +56,8 @@ export default class MitmRequestAgent {
       port: url.port || (ctx.isSSL ? 443 : 80),
       headers: ctx.requestHeaders,
       rejectUnauthorized: allowUnverifiedCertificates === false,
-    };
+      insecureHTTPParser: true, // if we don't include this setting, invalid characters in http requests will blow up responses
+    } as any;
 
     await this.assignSocket(ctx, requestSettings);
 

--- a/mitm/lib/MitmRequestContext.ts
+++ b/mitm/lib/MitmRequestContext.ts
@@ -198,6 +198,7 @@ export default class MitmRequestContext {
       localAddress: ctx.localAddress,
       dnsResolvedIp: ctx.dnsResolvedIp,
       originalHeaders: ctx.requestOriginalHeaders,
+      responseOriginalHeaders: ctx.responseOriginalHeaders,
       socketId: ctx.proxyToServerMitmSocket?.id,
       clientAlpn: ctx.clientAlpn,
       serverAlpn: ctx.proxyToServerMitmSocket?.alpn,

--- a/mitm/package.json
+++ b/mitm/package.json
@@ -7,7 +7,7 @@
     "@secret-agent/commons": "1.4.1-alpha.0",
     "@secret-agent/core-interfaces": "1.4.1-alpha.0",
     "@secret-agent/mitm-socket": "1.4.1-alpha.0",
-    "better-sqlite3": "^7.1.2",
+    "better-sqlite3": "^7.1.4",
     "devtools-protocol": "^0.0.799653",
     "dns-packet": "^5.2.1",
     "moment": "^2.24.1",

--- a/mitm/test/MitmRequestAgent.test.ts
+++ b/mitm/test/MitmRequestAgent.test.ts
@@ -3,7 +3,6 @@ import { getProxyAgent, runHttpsServer } from '@secret-agent/testing/helpers';
 import * as WebSocket from 'ws';
 import * as HttpProxyAgent from 'http-proxy-agent';
 import { IncomingHttpHeaders, IncomingMessage } from 'http';
-import * as net from 'net';
 import { URL } from 'url';
 import * as https from 'https';
 import MitmServer from '../lib/MitmProxy';
@@ -117,7 +116,7 @@ test('should create new connections as needed when no keepalive', async () => {
 
 test('should be able to handle a reused socket that closes on server', async () => {
   const server = await Helpers.runHttpsServer(async (req, res) => {
-    res.setHeader('Connection', 'keep-alive');
+    res.writeHead(200, { Connection: 'keep-alive' });
 
     res.end('Looks good');
   });

--- a/puppet/package.json
+++ b/puppet/package.json
@@ -11,7 +11,7 @@
     "@secret-agent/puppet-chrome": "1.4.1-alpha.0",
     "@secret-agent/puppet-interfaces": "1.4.1-alpha.0",
     "progress": "^2.0.3",
-    "tar": "^6.0.5"
+    "tar": "^6.1.0"
   },
   "devDependencies": {
     "@secret-agent/emulate-chrome-80": "1.4.1-alpha.0",

--- a/replay/package.dist.json
+++ b/replay/package.dist.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "dependencies": {
     "progress": "^2.0.3",
-    "tar": "^6.0.5",
+    "tar": "^6.1.0",
     "compare-versions": "^3.6.0",
     "proper-lockfile": "^4.1.1"
   }

--- a/replay/package.json
+++ b/replay/package.json
@@ -73,7 +73,7 @@
     "progress": "^2.0.3",
     "proper-lockfile": "^4.1.1",
     "source-map-support": "^0.5.19",
-    "tar": "^6.0.5",
+    "tar": "^6.1.0",
     "uuid": "^8.3.2",
     "ws": "^7.4.2"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -41,7 +41,7 @@
     "noderdom-detached": "git://github.com/ulixee/noderdom-detached.git#dist",
     "pug": "^3.0.2",
     "sass-loader": "^8.0.0",
-    "sharp": "^0.23.2",
+    "sharp": "^0.25.4",
     "ts-loader": "^6.2.1",
     "typescript": "~4.1.2",
     "vue-svg-loader": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,7 +2788,7 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/better-sqlite3@^5.4.0", "@types/better-sqlite3@^5.4.1":
+"@types/better-sqlite3@^5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-5.4.1.tgz#d45600bc19f8f41397263d037ca9b0d05df85e58"
   integrity sha512-8hje3Rhsg/9veTkALfCwiWn7VMrP1QDwHhBSgerttYPABEvrHsMQnU9dlqoM6QX3x4uw3Y06dDVz8uDQo1J4Ng==
@@ -4639,14 +4639,14 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.0.tgz#09c40d92e936c64777aa385c4e9b904f8147eaf0"
   integrity sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==
 
-better-sqlite3@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.2.tgz#95565757a834093f1ecae0d4457f60820ed5dd2a"
-  integrity sha512-8FWYnJ6Bx94MBX03J5Ka7sTRlvXXMEm4FW2Op7nM8ErQZeyALYLmSlbMBnfr4cMpS0tj0aYZv0a+26G2YJuIjg==
+better-sqlite3@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.4.tgz#19ba6aa10b92f81410944f498d9f63b000f0b9c1"
+  integrity sha512-9BvUSm8/xSyxZbnWpcRAwEZsfTK0196qi4592N5WoVMM3dAH9g0E3/colX0dxhGVSLcVfkiBUoCEBkFz8uvySw==
   dependencies:
     bindings "^1.5.0"
-    prebuild-install "^5.3.3"
-    tar "^6.0.5"
+    prebuild-install "^6.0.1"
+    tar "^6.1.0"
 
 bfj@^6.1.1:
   version "6.1.2"
@@ -5515,7 +5515,7 @@ chokidar@^3.3.0, chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.3:
+chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -12889,7 +12889,7 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.9.0"
 
-minizlib@^2.1.0, minizlib@^2.1.1:
+minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -13071,7 +13071,7 @@ mz@^2.4.0, mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.13.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -14820,10 +14820,31 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27, postcss@^7.0.3
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prebuild-install@^5.3.3, prebuild-install@^5.3.4:
+prebuild-install@^5.3.4:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
   integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
+prebuild-install@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.1.tgz#5902172f7a40eb67305b96c2a695db32636ee26d"
+  integrity sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^2.0.3"
@@ -16411,22 +16432,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@^0.23.2:
-  version "0.23.4"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.23.4.tgz#ca36067cb6ff7067fa6c77b01651cb9a890f8eb3"
-  integrity sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==
-  dependencies:
-    color "^3.1.2"
-    detect-libc "^1.0.3"
-    nan "^2.14.0"
-    npmlog "^4.1.2"
-    prebuild-install "^5.3.3"
-    semver "^6.3.0"
-    simple-get "^3.1.0"
-    tar "^5.0.5"
-    tunnel-agent "^0.6.0"
-
-sharp@^0.25.2:
+sharp@^0.25.2, sharp@^0.25.4:
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.25.4.tgz#1a8e542144a07ab7e9316ab89de80182b827c363"
   integrity sha512-umSzJJ1oBwIOfwFFt/fJ7JgCva9FvrEU2cbbm7u/3hSDZhXvkME8WE5qpaJqLIe2Har5msF5UG4CzYlEg5o3BQ==
@@ -16511,7 +16517,7 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3, simple-get@^3.1.0:
+simple-get@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
   integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
@@ -17462,19 +17468,7 @@ tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tar@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-5.0.5.tgz#03fcdb7105bc8ea3ce6c86642b9c942495b04f93"
-  integrity sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==
-  dependencies:
-    chownr "^1.1.3"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.0"
-    mkdirp "^0.5.0"
-    yallist "^4.0.0"
-
-tar@^6.0.2, tar@^6.0.5:
+tar@^6.0.2, tar@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
   integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==


### PR DESCRIPTION
2 bug fixes
1. The message to run the 'install dependencies' script broke from showing the original message in core. Writing a unit test for this led to me to an unhandled rejection issue.
2. When the mitm re-uses http1 connections, they can disconnect before they get reused, but the socket doesn't know. This fix tests out the socket before reusing it (by attempting to send the http request and seeing if an econnreset happens)