### PR TITLE
Re-Hover, Null Elements

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@secret-agent/commons": "1.4.1-alpha.1",
     "@secret-agent/core-interfaces": "1.4.1-alpha.1",
     "@secret-agent/replay": "1.4.1-alpha.1",
-    "awaited-dom": "^1.1.10",
+    "awaited-dom": "^1.1.11",
     "uuid": "^8.3.2",
     "ws": "^7.4.2"
   },

--- a/core-interfaces/package.json
+++ b/core-interfaces/package.json
@@ -4,7 +4,7 @@
   "description": "Core interfaces used by SecretAgent",
   "dependencies": {
     "@secret-agent/puppet-interfaces": "1.4.1-alpha.1",
-    "awaited-dom": "^1.1.10"
+    "awaited-dom": "^1.1.11"
   },
   "devDependencies": {
     "devtools-protocol": "^0.0.799653"

--- a/core/lib/CommandFormatter.ts
+++ b/core/lib/CommandFormatter.ts
@@ -1,5 +1,5 @@
 import ICommandMeta from '@secret-agent/core-interfaces/ICommandMeta';
-import { IInteractionGroup, IInteractionGroups } from '@secret-agent/core-interfaces/IInteractions';
+import { IInteractionGroup } from '@secret-agent/core-interfaces/IInteractions';
 import { getKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import getAttachedStateFnName from '@secret-agent/core-interfaces/getAttachedStateFnName';
 import ICommandWithResult from '../interfaces/ICommandWithResult';

--- a/core/lib/CommandFormatter.ts
+++ b/core/lib/CommandFormatter.ts
@@ -1,5 +1,5 @@
 import ICommandMeta from '@secret-agent/core-interfaces/ICommandMeta';
-import { IInteractionGroup } from '@secret-agent/core-interfaces/IInteractions';
+import { IInteractionGroup, IInteractionGroups } from '@secret-agent/core-interfaces/IInteractions';
 import { getKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import getAttachedStateFnName from '@secret-agent/core-interfaces/getAttachedStateFnName';
 import ICommandWithResult from '../interfaces/ICommandWithResult';
@@ -124,6 +124,21 @@ export default class CommandFormatter {
             ? `${step[0]}(${step.slice(1).map(x => JSON.stringify(x))})`
             : step;
         }
+      }
+    }
+
+    if (!command.resultNodeIds && command.name === 'execJsPath') {
+      const [jsPath] = JSON.parse(command.args);
+      if (typeof jsPath[0] === 'number') command.resultNodeIds = [jsPath[0]];
+    }
+
+    if (!command.resultNodeIds && command.name === 'interact') {
+      const args = JSON.parse(command.args);
+      const mouseInteraction = args.find((x: IInteractionGroup) => {
+        return x.length && x[0].mousePosition && x[0].mousePosition.length === 1;
+      });
+      if (mouseInteraction) {
+        command.resultNodeIds = mouseInteraction.mousePosition;
       }
     }
 

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "@secret-agent/mitm": "1.4.1-alpha.1",
     "@secret-agent/puppet": "1.4.1-alpha.1",
     "@secret-agent/puppet-interfaces": "1.4.1-alpha.1",
-    "awaited-dom": "^1.1.10",
+    "awaited-dom": "^1.1.11",
     "better-sqlite3": "^7.1.4",
     "moment": "^2.24.1",
     "uuid": "^8.3.2",

--- a/core/test/interact.test.ts
+++ b/core/test/interact.test.ts
@@ -194,9 +194,9 @@ describe.each([['ghost'], ['basic'], ['skipper']])(
       // @ts-ignore
       const interactor = tab.mainFrameEnvironment.interactor;
       // @ts-ignore
-      const originalFn = interactor.getPositionXY.bind(interactor);
-      const mouseMoveSpy = jest.spyOn<any, any>(interactor, 'getPositionXY');
-      mouseMoveSpy.mockImplementationOnce(async mousePosition => {
+      const originalFn = interactor.lookupBoundingRect.bind(interactor);
+      const lookupSpy = jest.spyOn(interactor, 'lookupBoundingRect');
+      lookupSpy.mockImplementationOnce(async mousePosition => {
         const data = await originalFn(mousePosition);
         data.y -= 500;
         return data;
@@ -209,7 +209,7 @@ describe.each([['ghost'], ['basic'], ['skipper']])(
           mousePosition: ['window', 'document', ['querySelector', '#button-1']],
         },
       ]);
-      expect(mouseMoveSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(lookupSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
       const lastClicked = await tab.getJsValue('lastClicked');
       expect(lastClicked.value).toBe('clickedit');
     });

--- a/full-client/package.json
+++ b/full-client/package.json
@@ -17,7 +17,7 @@
     "@secret-agent/emulate-chrome-80": "1.4.1-alpha.1",
     "@secret-agent/mitm": "1.4.1-alpha.1",
     "@secret-agent/testing": "1.4.1-alpha.1",
-    "awaited-dom": "^1.1.10",
+    "awaited-dom": "^1.1.11",
     "fpcollect": "^1.0.4",
     "fpscanner": "^0.1.5",
     "ws": "^7.3.1"

--- a/full-client/test/document.test.ts
+++ b/full-client/test/document.test.ts
@@ -185,6 +185,13 @@ describe('basic Document tests', () => {
     expect(await heading2.textContent).toBe('Also me');
   });
 
+  it("returns null for elements that don't exist", async () => {
+    const agent = await openBrowser(`/`);
+    const { document } = agent;
+    const element = await document.querySelector('#this-element-aint-there');
+    expect(element).toBe(null);
+  });
+
   it('can determine if an element is visible', async () => {
     koaServer.get('/isVisible', ctx => {
       ctx.body = `

--- a/full-client/test/interact.test.ts
+++ b/full-client/test/interact.test.ts
@@ -2,7 +2,7 @@ import { Helpers } from '@secret-agent/testing';
 import { KeyboardKeys } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import { Command } from '@secret-agent/client/interfaces/IInteractions';
 import { ITestKoaServer } from '@secret-agent/testing/helpers';
-import { Handler } from '../index';
+import { Handler, LocationStatus } from '../index';
 
 let koaServer: ITestKoaServer;
 let handler: Handler;
@@ -146,6 +146,27 @@ describe('basic Interact tests', () => {
     );
 
     expect(await textarea.value).toBe('T');
+    await agent.close();
+  });
+
+  it('should be able to click on the same element twice', async () => {
+    koaServer.get('/twice', ctx => {
+      ctx.body = `
+        <body>
+          <div id="spot">Twice spot</div>
+        </body>
+      `;
+    });
+    const agent = await handler.createAgent({
+      humanEmulatorId: 'basic',
+    });
+    Helpers.needsClosing.push(agent);
+    await agent.goto(`${koaServer.baseUrl}/twice`);
+    await agent.activeTab.waitForLoad(LocationStatus.DomContentLoaded);
+    const logo = agent.document.querySelector('#spot');
+    await expect(agent.interact({ click: logo })).resolves.toBeUndefined();
+    await agent.waitForMillis(100);
+    await expect(agent.interact({ click: logo })).resolves.toBeUndefined();
     await agent.close();
   });
 });

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@microflash/gridsome-plugin-feed": "^1.2.1",
     "@types/json2md": "^1.5.0",
     "@types/lodash.kebabcase": "^4.1.6",
-    "awaited-dom": "^1.1.10",
+    "awaited-dom": "^1.1.11",
     "babel-runtime": "^6.26.0",
     "decamelize": "^4.0.0",
     "docsearch.js": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,10 +4428,10 @@ autoprefixer@^9.4.7, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awaited-dom@^1.1.10:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.1.10.tgz#2895769c7b50a832780c7dda26a5674167c35665"
-  integrity sha512-GmrTDjCj1YPONNRbiboMuXZ9ms5jLv80rhqz4IakMytkQhbG54VK0zCl6hwTp8WwhP+aZgCiYdn1DJsbkutZ6w==
+awaited-dom@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.1.11.tgz#b551319dc20c4e0723d432d5fbb1996b46dd643c"
+  integrity sha512-BA7NGrICmqhYXfLN5/D9SsoWgDhrSB2bvdsP6efHiHNDG67zmWr019Xjt6cB43i1b6RzdlkQ7BRIfyeGWzd9wg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
- Fix re-hovering over a location that is already hovered.
- Update Awaiteddom to return null if a node doesn't exist
- Show non-interacted nodes in replay that are used in execJsPath

Closes #209 