### PR TITLE
feat(emulate): wait 3 seconds after load

### DIFF
--- a/core/lib/FrameNavigationsObserver.ts
+++ b/core/lib/FrameNavigationsObserver.ts
@@ -130,7 +130,7 @@ export default class FrameNavigationsObserver {
     const top = this.navigations.top;
     if (!top) return { isStable: false };
 
-    // need to wait for both load + painting stable, or wait 3 seconds after painting stable
+    // need to wait for both load + painting stable, or wait 3 seconds after either one
     const loadDate = top.stateChanges.get('Load');
     const contentPaintedDate = top.stateChanges.get('ContentPaint');
     if (!!loadDate && !!contentPaintedDate) return { isStable: true };
@@ -138,11 +138,8 @@ export default class FrameNavigationsObserver {
     // NOTE: LargestContentfulPaint, which currently drives PaintingStable will NOT trigger if the page
     // doesn't have any "contentful" items that are eligible (image, headers, divs, paragraphs that fill the page)
 
-    // if not stable yet, don't count as resolved
-    if (!contentPaintedDate) return { isStable: false };
-
     // have contentPaintedDate date, but no load
-    const timeUntilReadyMs = moment().diff(contentPaintedDate, 'milliseconds');
+    const timeUntilReadyMs = moment().diff(contentPaintedDate ?? loadDate, 'milliseconds');
     return {
       isStable: timeUntilReadyMs >= 3e3,
       timeUntilReadyMs: Math.min(3e3, 3e3 - timeUntilReadyMs),

--- a/core/models/FrameNavigationsTable.ts
+++ b/core/models/FrameNavigationsTable.ts
@@ -12,7 +12,7 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
       'FrameNavigations',
       [
         ['id', 'INTEGER', 'NOT NULL PRIMARY KEY'],
-        ['frameId', 'INTEGER'],
+        ['frameId', 'TEXT'],
         ['startCommandId', 'INTEGER'],
         ['requestedUrl', 'TEXT'],
         ['finalUrl', 'TEXT'],
@@ -62,7 +62,7 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
 
 export interface IFrameNavigationRecord {
   id: number;
-  frameId: number;
+  frameId: string;
   requestedUrl: string;
   finalUrl?: string;
   startCommandId: number;

--- a/emulate-browsers/base/test/iframe.test.ts
+++ b/emulate-browsers/base/test/iframe.test.ts
@@ -61,8 +61,8 @@ test('should not break iframe functions', async () => {
     const body = document.querySelector('body');
     const iframe = document.createElement('iframe');
     iframe.srcdoc = 'foobar';
-    iframe.contentWindow.mySuperFunction = () => returnValue;
     body.appendChild(iframe);
+    iframe.contentWindow.mySuperFunction = () => returnValue;
   })("${testFuncReturnValue}")`);
 
   const realReturn = await page.evaluate(


### PR DESCRIPTION
We have some sites in MI that never trigger waitForPaintingStable. They do get the load event. In the top 100 sites, load and content stable occur within 1ms of each other for most sites, within 24ms worst case. This fallback clause will cover these within a large margin of error.