### PR TITLE
fix(puppet): fix chrome-88

### DIFF
--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -329,6 +329,13 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
       return onrejected(err);
     }
   }
+
+  public toJSON(): any {
+    // return empty so we can
+    return {
+      type: 'Agent',
+    };
+  }
 }
 
 // This class will lazily connect to core on first access of the tab properties

--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -177,6 +177,13 @@ export default class FrameEnvironment {
     const coreFrame = await getCoreFrameEnvironment(this);
     await coreFrame.waitForLocation(trigger, options);
   }
+
+  public toJSON(): any {
+    // return empty so we can
+    return {
+      type: 'FrameEnvironment',
+    };
+  }
 }
 
 export function getFrameState(object: any): IState {

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -215,6 +215,13 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     connection.closeTab(this);
     return coreTab.then(x => x.close());
   }
+
+  public toJSON(): any {
+    // return empty so we can
+    return {
+      type: 'Tab',
+    };
+  }
 }
 
 async function getOrCreateFrameEnvironment(

--- a/client/test/handler.test.ts
+++ b/client/test/handler.test.ts
@@ -50,7 +50,7 @@ describe('Handler', () => {
     const handler = new Handler(
       new Piper({
         maxConcurrency: concurrency,
-        browserEmulatorIds: ['chrome-83'],
+        browserEmulatorIds: ['chrome-latest'],
       }),
     );
     Helpers.needsClosing.push(handler);

--- a/commons/package.json
+++ b/commons/package.json
@@ -9,7 +9,7 @@
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@secret-agent/emulate-chrome-83": "1.4.1-alpha.2",
+    "@secret-agent/emulate-chrome-latest": "1.4.1-alpha.2",
     "@secret-agent/puppet": "1.4.1-alpha.2",
     "@types/better-sqlite3": "^5.4.1"
   }

--- a/commons/test/TypeSerializer.test.ts
+++ b/commons/test/TypeSerializer.test.ts
@@ -1,5 +1,5 @@
 import Puppet from '@secret-agent/puppet';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import TypeSerializer, { stringifiedTypeSerializerClass } from '../TypeSerializer';
 import { CanceledPromiseError } from '../interfaces/IPendingWaitEvent';
 import logger from '../Logger';
@@ -36,7 +36,7 @@ test('it should be able to serialize a complex object in nodejs', () => {
 });
 
 test('should be able to serialize and deserialize in a browser window', async () => {
-  const puppet = new Puppet(Chrome83.engine);
+  const puppet = new Puppet(ChromeLatest.engine);
   try {
     await puppet.start();
     const context = await puppet.newContext(

--- a/core/lib/BrowserEmulators.ts
+++ b/core/lib/BrowserEmulators.ts
@@ -2,8 +2,8 @@ import { UAParser } from 'ua-parser-js';
 import IBrowserEmulatorClass from '@secret-agent/core-interfaces/IBrowserEmulatorClass';
 import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import { pickRandom } from '@secret-agent/commons/utils';
+import IUserAgentMatchMeta from '@secret-agent/core-interfaces/IUserAgentMatchMeta';
 import GlobalPool from './GlobalPool';
-import IUserAgentMatchMeta from "../../core-interfaces/IUserAgentMatchMeta";
 
 export default class BrowserEmulators {
   public static defaultId = ChromeLatest.id;
@@ -75,11 +75,16 @@ export default class BrowserEmulators {
     }
   }
 
-  private static extractUserAgentMatchMetaFromUa(uaBrowser: UAParser.IBrowser, uaOs: UAParser.IOS): IUserAgentMatchMeta {
-    const [browserVersionMajor, browserVersionMinor] = uaBrowser.version.split('.').map(x => Number(x));
+  private static extractUserAgentMatchMetaFromUa(
+    uaBrowser: UAParser.IBrowser,
+    uaOs: UAParser.IOS,
+  ): IUserAgentMatchMeta {
+    const [browserVersionMajor, browserVersionMinor] = uaBrowser.version
+      .split('.')
+      .map(x => Number(x));
     const [osVersionMajor, osVersionMinor] = uaOs.version.split('.').map(x => Number(x));
     const browserName = (uaBrowser.name || '').toLowerCase();
-    const browserId = `${browserName}-${browserVersionMajor}-${browserVersionMinor}`
+    const browserId = `${browserName}-${browserVersionMajor}-${browserVersionMinor}`;
     const osName = (uaOs.name || '').toLowerCase();
 
     let osId = [osName.replace(' ', '-'), osVersionMajor, osVersionMinor].filter(x => x).join('-');
@@ -89,13 +94,13 @@ export default class BrowserEmulators {
       browser: {
         id: browserId,
         name: browserName,
-        version: { major: browserVersionMajor, minor: browserVersionMinor }
+        version: { major: browserVersionMajor, minor: browserVersionMinor },
       },
       operatingSystem: {
         id: osId,
         name: osName,
-        version: { major: osVersionMajor, minor: osVersionMinor }
-      }
+        version: { major: osVersionMajor, minor: osVersionMinor },
+      },
     };
   }
 

--- a/core/lib/CommandRecorder.ts
+++ b/core/lib/CommandRecorder.ts
@@ -1,6 +1,6 @@
 import { IBoundLog } from '@secret-agent/core-interfaces/ILog';
 import Log from '@secret-agent/commons/Logger';
-import ICommandMeta from '../../core-interfaces/ICommandMeta';
+import ICommandMeta from '@secret-agent/core-interfaces/ICommandMeta';
 import Tab from './Tab';
 
 const { log } = Log(module);

--- a/core/lib/DomRecorder.ts
+++ b/core/lib/DomRecorder.ts
@@ -54,7 +54,7 @@ export default class DomRecorder {
     const command = `window.commandId=${commandId}`;
     await Promise.all(
       this.puppetPage.frames.map(x =>
-        x.evaluate(command, true, false).catch(() => {
+        x.evaluate(command, true, { shouldAwaitExpression: false }).catch(() => {
           // can fail when frames aren't ready. don't worry about it
         }),
       ),

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -22,6 +22,7 @@ import IWaitForOptions from '@secret-agent/core-interfaces/IWaitForOptions';
 import IFrameMeta from '@secret-agent/core-interfaces/IFrameMeta';
 import { ILoadEvent } from '@secret-agent/core-interfaces/ILoadEvent';
 import TypeSerializer from '@secret-agent/commons/TypeSerializer';
+import injectedSourceUrl from '@secret-agent/core-interfaces/injectedSourceUrl';
 import SessionState from './SessionState';
 import TabNavigationObserver from './FrameNavigationsObserver';
 import Session from './Session';
@@ -31,7 +32,6 @@ import CommandRecorder from './CommandRecorder';
 import FrameNavigations from './FrameNavigations';
 import { Serializable } from '../interfaces/ISerializable';
 import InjectedScriptError from './InjectedScriptError';
-import injectedSourceUrl from '../../core-interfaces/injectedSourceUrl';
 import { JsPath } from './JsPath';
 import InjectedScripts from './InjectedScripts';
 

--- a/core/lib/Viewports.ts
+++ b/core/lib/Viewports.ts
@@ -1,5 +1,5 @@
 import IViewport from '@secret-agent/core-interfaces/IViewport';
-import IWindowFraming from '../../core-interfaces/IWindowFraming';
+import IWindowFraming from '@secret-agent/core-interfaces/IWindowFraming';
 
 const defaultWindowFraming = {
   screenGapLeft: 0,
@@ -8,7 +8,7 @@ const defaultWindowFraming = {
   screenGapBottom: 0,
   frameBorderWidth: 0,
   frameBorderHeight: 0,
-}
+};
 
 export default class Viewports {
   static getDefault(windowFraming: IWindowFraming, base: IWindowFraming) {

--- a/core/test/mitm.test.ts
+++ b/core/test/mitm.test.ts
@@ -1,5 +1,5 @@
 import { Helpers } from '@secret-agent/testing';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import MitmRequestContext from '@secret-agent/mitm/lib/MitmRequestContext';
 import { createPromise } from '@secret-agent/commons/utils';
 import { LocationStatus } from '@secret-agent/core-interfaces/Location';
@@ -17,7 +17,7 @@ const mocks = {
 let koa: ITestKoaServer;
 beforeAll(async () => {
   koa = await Helpers.runKoaServer(true);
-  await GlobalPool.start([Chrome83.id]);
+  await GlobalPool.start([ChromeLatest.id]);
 });
 
 beforeEach(async () => {

--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -358,14 +358,15 @@ setTimeout(function() {
       },
     ]);
 
-    const spy = jest.spyOn<any, any>(FrameNavigationsObserver.prototype, 'onNavigation');
+    const spy = jest.spyOn<any, any>(FrameNavigationsObserver.prototype, 'resolvePendingStatus');
 
     // clear data before this run
     const popupTab = await tab.waitForNewTab();
     await popupTab.waitForLoad(LocationStatus.PaintingStable);
 
     // should not have triggered a navigation change
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain('PaintingStable');
   });
 
   it('handles a new tab that redirects', async () => {
@@ -408,8 +409,7 @@ setTimeout(() => {
     // clear data before this run
     const popupTab = await tab.waitForNewTab();
 
-    await popupTab.waitForLoad(LocationStatus.DomContentLoaded);
-    await popupTab.waitForLocation(LocationTrigger.change);
+    await new Promise(resolve => setTimeout(resolve, 200));
     await popupTab.waitForLoad(LocationStatus.PaintingStable);
 
     tab.sessionState.db.flush();
@@ -429,7 +429,7 @@ setTimeout(() => {
       `${koaServer.baseUrl}/popup-redirect3`,
       `${koaServer.baseUrl}/popup-redirect3`,
     ]);
-    expect(history[0].stateChanges.has('ContentPaint')).toBe(true);
+
     expect(history[1].stateChanges.has(LocationStatus.HttpRedirected)).toBe(true);
     expect(history[2].stateChanges.has(LocationStatus.HttpRedirected)).toBe(true);
     expect(history[3].stateChanges.has('ContentPaint')).toBe(true);

--- a/emulate-browsers/chrome-latest/index.ts
+++ b/emulate-browsers/chrome-latest/index.ts
@@ -1,3 +1,3 @@
-import ChromeLatest from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-88';
 
 export default ChromeLatest;

--- a/emulate-browsers/chrome-latest/install.ts
+++ b/emulate-browsers/chrome-latest/install.ts
@@ -1,1 +1,1 @@
-import '@secret-agent/emulate-chrome-83/install';
+import '@secret-agent/emulate-chrome-88/install';

--- a/emulate-browsers/chrome-latest/package.json
+++ b/emulate-browsers/chrome-latest/package.json
@@ -4,6 +4,6 @@
   "description": "BrowserEmulator for latest version of Chrome",
   "main": "index.js",
   "dependencies": {
-    "@secret-agent/emulate-chrome-83": "1.4.1-alpha.2"
+    "@secret-agent/emulate-chrome-88": "1.4.1-alpha.2"
   }
 }

--- a/full-client/test/tab.test.ts
+++ b/full-client/test/tab.test.ts
@@ -97,6 +97,8 @@ describe('Multi-tab scenarios', () => {
     await agent.waitForPaintingStable();
     expect(await agent.tabs).toHaveLength(1);
     expect(await agent.url).toBe(`${koaServer.baseUrl}/page1`);
+
+    const startCommandId = await agent.lastCommandId;
     await agent.click(agent.document.querySelector('a'));
 
     const tab1 = agent.activeTab;
@@ -110,6 +112,7 @@ describe('Multi-tab scenarios', () => {
       `${koaServer.baseUrl}/logo.png`,
       `${koaServer.baseUrl}/logo.png?page=page1`,
     ]);
+    await agent.waitForNewTab({ sinceCommandId: startCommandId });
 
     const tabs = await agent.tabs;
     expect(tabs).toHaveLength(2);

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -129,7 +129,7 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameEvents>
     // sometimes we get a new anchor link that already has an initiated frame. If that's the case, newDocumentScripts won't trigger.
     // NOTE: we DON'T want this to trigger for internal pages (':', 'about:blank')
     if (this.main.url?.startsWith('http')) {
-      await this.main.evaluate(script, installInIsolatedScope);
+      await this.main.evaluate(script, installInIsolatedScope, { retriesWaitingForLoad: 1 });
     }
   }
 

--- a/puppet-interfaces/IPuppetFrame.ts
+++ b/puppet-interfaces/IPuppetFrame.ts
@@ -17,7 +17,7 @@ export interface IPuppetFrame extends ITypedEventEmitter<IPuppetFrameEvents> {
   evaluate<T>(
     expression: string,
     isolateFromWebPageEnvironment?: boolean,
-    shouldAwaitExpression?: boolean,
+    options?: { shouldAwaitExpression?: boolean; retriesWaitingForLoad?: number },
   ): Promise<T>;
   evaluateOnIsolatedFrameElement<T>(expression: string): Promise<T>;
   toJSON(): object;

--- a/puppet/package.json
+++ b/puppet/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@secret-agent/emulate-chrome-80": "1.4.1-alpha.2",
-    "@secret-agent/emulate-chrome-83": "1.4.1-alpha.2",
+    "@secret-agent/emulate-chrome-latest": "1.4.1-alpha.2",
     "@secret-agent/testing": "1.4.1-alpha.2",
     "ws": "^7.3.1"
   }

--- a/puppet/test/BrowserContext.test.ts
+++ b/puppet/test/BrowserContext.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import { URL } from 'url';
 import Log from '@secret-agent/commons/Logger';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
@@ -11,7 +11,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'BrowserContext for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Frames.test.ts
+++ b/puppet/test/Frames.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import { Page } from '@secret-agent/puppet-chrome/lib/Page';
 import Log from '@secret-agent/commons/Logger';
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
@@ -12,7 +12,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Frames for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Keyboard.test.ts
+++ b/puppet/test/Keyboard.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import { IKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import Log from '@secret-agent/commons/Logger';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
@@ -13,7 +13,7 @@ const { log } = Log(module);
 
 const MAC = process.platform === 'darwin';
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Frames for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Mouse.test.ts
+++ b/puppet/test/Mouse.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import { IKeyboardKey } from '@secret-agent/core-interfaces/IKeyboardLayoutUS';
 import Log from '@secret-agent/commons/Logger';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
@@ -11,7 +11,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Frames for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Page.navigate.test.ts
+++ b/puppet/test/Page.navigate.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import Log from '@secret-agent/commons/Logger';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
 import IBrowserEngine from '@secret-agent/core-interfaces/IBrowserEngine';
@@ -10,7 +10,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Page.navigate for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Page.popups.test.ts
+++ b/puppet/test/Page.popups.test.ts
@@ -1,17 +1,17 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import Log from '@secret-agent/commons/Logger';
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
 import IBrowserEngine from '@secret-agent/core-interfaces/IBrowserEngine';
 import { TestServer } from './server';
 import Puppet from '../index';
-import { createTestPage, ITestPage } from './TestPage';
+import { capturePuppetContextLogs, createTestPage, ITestPage } from './TestPage';
 import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Page.popups for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;
@@ -33,6 +33,7 @@ describe.each([[Chrome80.engine], [Chrome83.engine]])(
         },
         log,
       );
+      capturePuppetContextLogs(context, `${browserEngine.fullVersion}-Page.popups-test`);
       context.on('page', event => {
         needsClosing.push(event.page);
       });

--- a/puppet/test/Page.test.ts
+++ b/puppet/test/Page.test.ts
@@ -1,6 +1,6 @@
 import ConsoleMessage from '@secret-agent/puppet-chrome/lib/ConsoleMessage';
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import Log from '@secret-agent/commons/Logger';
 import { IPuppetPage } from '@secret-agent/puppet-interfaces/IPuppetPage';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
@@ -12,7 +12,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Pages for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/Worker.test.ts
+++ b/puppet/test/Worker.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import Log from '@secret-agent/commons/Logger';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
 import IBrowserEngine from '@secret-agent/core-interfaces/IBrowserEngine';
@@ -10,7 +10,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Worker tests for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/puppet/test/launchProcess.test.ts
+++ b/puppet/test/launchProcess.test.ts
@@ -1,5 +1,5 @@
 import Chrome80 from '@secret-agent/emulate-chrome-80';
-import Chrome83 from '@secret-agent/emulate-chrome-83';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import Log from '@secret-agent/commons/Logger';
 import IBrowserEngine from '@secret-agent/core-interfaces/IBrowserEngine';
 import Puppet from '../index';
@@ -7,7 +7,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'launchProcess for %s@%s',
   (browserEngine: IBrowserEngine) => {
     const defaultBrowserOptions = browserEngine;

--- a/puppet/test/load.test.ts
+++ b/puppet/test/load.test.ts
@@ -1,6 +1,6 @@
-import Chrome80 from '@secret-agent/emulate-chrome-80';
 import Log from '@secret-agent/commons/Logger';
-import Chrome83 from '@secret-agent/emulate-chrome-83/index';
+import Chrome80 from '@secret-agent/emulate-chrome-80';
+import ChromeLatest from '@secret-agent/emulate-chrome-latest';
 import IPuppetContext from '@secret-agent/puppet-interfaces/IPuppetContext';
 import IBrowserEngine from '@secret-agent/core-interfaces/IBrowserEngine';
 import { TestServer } from './server';
@@ -10,7 +10,7 @@ import defaultEmulation from './_defaultEmulation';
 
 const { log } = Log(module);
 
-describe.each([[Chrome80.engine], [Chrome83.engine]])(
+describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
   'Load test for %s@%s',
   (browserEngine: IBrowserEngine) => {
     let server: TestServer;

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -54,7 +54,7 @@ const { Agent } = require('secret-agent');
 - options `object` Accepts any of the following:
   - connectionToCore `options | ConnectionToCore`. An object containing `IConnectionToCoreOptions` used to connect, or an already created `ConnectionToCore` instance. Defaults to automatically booting up and connecting to a local `Core`.
   - name `string`. This is used to generate a unique sessionName.
-  - browserEmulatorId `string` defaults to `chrome-83`. Emulates a specific browser engine version.
+  - browserEmulatorId `string` defaults to `chrome-latest`. Emulates a specific browser engine version.
   - humanEmulatorId `string`. Drives human-like mouse/keyboard movements.
   - timezoneId `string`. Overrides the host timezone. A list of valid ids are available at [unicode.org](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/zone_tzid.html)
   - locale `string`. Overrides the host languages settings (eg, en-US). Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules.

--- a/website/docs/BasicInterfaces/Handler.md
+++ b/website/docs/BasicInterfaces/Handler.md
@@ -70,7 +70,7 @@ const { Handler } = require('secret-agent');
   const handler = new Handler(remote1, {
     host: '172.234.22.2:1586',
     maxConcurrency: 5,
-    browserEmulatorIds: ['chrome-83'],
+    browserEmulatorIds: ['chrome-latest'],
   });
 
   const agent = await handler.createAgent();
@@ -138,7 +138,7 @@ NOTE: when using this method, you must call [`agent.close()`](/docs/basic-interf
 
 - options `object`. Accepts any of the following:
   - name `string`. This is used to generate a unique sessionName.
-  - browserEmulatorId `string` defaults to `chrome-83`. Emulates a specific browser engine version.
+  - browserEmulatorId `string` defaults to `chrome-latest`. Emulates a specific browser engine version.
   - humanEmulatorId `string`. Drives human-like mouse/keyboard movements.
   - timezoneId `string`. Overrides the host timezone. A list of valid ids are available at [unicode.org](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/zone_tzid.html)
   - locale `string`. Overrides the host languages settings (eg, en-US). Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules.

--- a/yarn.lock
+++ b/yarn.lock
@@ -18087,12 +18087,7 @@ typography@^0.16.19:
     object-assign "^4.1.0"
     typography-normalize "^0.16.19"
 
-ua-parser-js@^0.7.18:
-  version "0.7.24"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
-  integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
-
-ua-parser-js@^0.7.22:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.22:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
@@ -18824,7 +18819,14 @@ w3c-hr-time@^1.0.2:
   dependencies:
     browser-process-hrtime "^1.0.0"
 
-w3c-xmlserializer@^2.0.0, "w3c-xmlserializer@https://github.com/ulixee/w3c-xmlserializer.git":
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  dependencies:
+    xml-name-validator "^3.0.0"
+
+"w3c-xmlserializer@https://github.com/ulixee/w3c-xmlserializer.git":
   version "2.0.0"
   resolved "https://github.com/ulixee/w3c-xmlserializer.git#74efc6b7211319a6a14a2c12d86028ca60f4f559"
   dependencies:


### PR DESCRIPTION
Fixes Chrome 88. It seems like Chrome 88 pauses the debugger on new tabs, and won't allow it through until you run Runtime.runDebuggerIfWaiting. This means our current strategy of giving emulators access to puppet to perform initialization will hang. I think we need to adjust so that a page simply provides "scripts" to be run on each tab.