### PR TITLE
Improve FrameNavigation tracking

### DIFF
--- a/core-interfaces/INavigation.ts
+++ b/core-interfaces/INavigation.ts
@@ -5,6 +5,7 @@ export default interface INavigation {
   frameId: string;
   resourceId: IResolvablePromise<number>;
   browserRequestId: string;
+  loaderId: string;
   navigationError?: Error;
   startCommandId: number;
   requestedUrl: string;

--- a/core-interfaces/ITypedEventEmitter.ts
+++ b/core-interfaces/ITypedEventEmitter.ts
@@ -3,7 +3,6 @@ export default interface ITypedEventEmitter<T> {
     eventType: K,
     listenerFn?: (this: this, event?: T[K]) => boolean,
     timeoutMillis?: number,
-    includeUnhandledEvents?: boolean,
   ): Promise<T[K]>;
 
   on<K extends keyof T & (string | symbol)>(

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -333,7 +333,7 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
 
       const incomingStatus = pageStateToLoadStatus[event];
 
-      this.navigations.onLoadStateChanged(incomingStatus, url, new Date(timestamp));
+      this.navigations.onLoadStateChanged(incomingStatus, url, null, new Date(timestamp));
     }
   }
 
@@ -412,7 +412,7 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
     else if (lowerEventName === 'domcontentloaded') status = LoadStatus.DomContentLoaded;
 
     if (status) {
-      this.navigations.onLoadStateChanged(status, event.frame.url);
+      this.navigations.onLoadStateChanged(status, event.frame.url, event.loaderId);
     }
   }
 
@@ -421,7 +421,12 @@ b) Use the UserProfile feature to set cookies for 1 or more domains before they'
     if (navigatedInDocument) {
       this.logger.info('Page.navigatedWithinDocument', event);
       // set load state back to all loaded
-      this.navigations.onNavigationRequested('inPage', frame.url, this.tab.lastCommandId);
+      this.navigations.onNavigationRequested(
+        'inPage',
+        frame.url,
+        this.tab.lastCommandId,
+        event.loaderId,
+      );
     }
     this.sessionState.updateFrameSecurityOrigin(this.tab.id, frame);
   }

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -348,7 +348,10 @@ export default class Session extends TypedEventEmitter<{
     page: IPuppetPage,
     openParams: { url: string; windowName: string } | null,
   ) {
-    const tab = Tab.create(this, page, parentTab, openParams);
+    const tab = Tab.create(this, page, parentTab, {
+      ...openParams,
+      loaderId: page.mainFrame.isDefaultUrl ? null : page.mainFrame.activeLoaderId,
+    });
     this.sessionState.captureTab(tab.id, page.id, page.devtoolsSessionId, parentTab.id);
     this.registerTab(tab, page);
 

--- a/core/models/FrameNavigationsTable.ts
+++ b/core/models/FrameNavigationsTable.ts
@@ -16,6 +16,7 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
         ['requestedUrl', 'TEXT'],
         ['finalUrl', 'TEXT'],
         ['navigationReason', 'TEXT'],
+        ['loaderId', 'TEXT'],
         ['initiatedTime', 'INTEGER'],
         ['httpRequestedTime', 'INTEGER'],
         ['httpRespondedTime', 'INTEGER'],
@@ -41,6 +42,7 @@ export default class FrameNavigationsTable extends SqliteTable<IFrameNavigationR
       navigation.requestedUrl,
       navigation.finalUrl,
       navigation.navigationReason,
+      navigation.loaderId,
       navigation.initiatedTime.getTime(),
       navigation.stateChanges.get(LoadStatus.HttpRequested)?.getTime(),
       navigation.stateChanges.get(LoadStatus.HttpResponded)?.getTime(),
@@ -64,6 +66,7 @@ export interface IFrameNavigationRecord {
   frameId: string;
   requestedUrl: string;
   finalUrl?: string;
+  loaderId: string;
   startCommandId: number;
   navigationReason: string;
   initiatedTime: Date;

--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -413,13 +413,15 @@ perfObserver.observe({ type: 'largest-contentful-paint', buffered: true });
     // clear data before this run
     const popupTab = await tab.waitForNewTab();
     await popupTab.waitForLoad(LocationStatus.PaintingStable);
+    const commandId = popupTab.lastCommandId;
     // if we're on serious delay, need to wait for change
     if ((await popupTab.getLocationHref()) === `${koaServer.baseUrl}/popup`) {
-      await popupTab.waitForLocation('change');
+      await popupTab.waitForLocation('change', { sinceCommandId: commandId });
     }
 
     tab.sessionState.db.flush();
     expect(await popupTab.getLocationHref()).toBe(`${koaServer.baseUrl}/popup-redirect3`);
+    await popupTab.waitForLoad(LocationStatus.PaintingStable);
 
     const history = popupTab.navigations.history;
     expect(history).toHaveLength(4);

--- a/emulate-browsers/base/test/chrome.test.ts
+++ b/emulate-browsers/base/test/chrome.test.ts
@@ -35,7 +35,7 @@ test('it should mimic a chrome object', async () => {
   await page.addNewDocumentScript(script, false);
   await Promise.all([
     page.navigate(httpServer.url),
-    page.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
+    page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
   ]);
 
   const structure = JSON.parse(
@@ -66,7 +66,7 @@ test('it should update loadtimes and csi values', async () => {
   );
   await Promise.all([
     page.navigate(httpServer.url),
-    page.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
+    page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
   ]);
 
   const loadTimes = JSON.parse(

--- a/emulate-browsers/base/test/plugins.test.ts
+++ b/emulate-browsers/base/test/plugins.test.ts
@@ -102,7 +102,7 @@ test('it should override plugins in a browser window', async () => {
   );
   await Promise.all([
     page.navigate(httpServer.url),
-    page.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
+    page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
   ]);
 
   const hasPlugins = await page.mainFrame.evaluate(

--- a/emulate-browsers/base/test/utils.test.ts
+++ b/emulate-browsers/base/test/utils.test.ts
@@ -95,7 +95,7 @@ test('should override a function and clean error stacks', async () => {
   );
   await Promise.all([
     page.navigate(httpServer.url),
-    page.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
+    page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'DOMContentLoaded'),
   ]);
 
   const worksOnce = await page.evaluate(

--- a/puppet-chrome/lib/Page.ts
+++ b/puppet-chrome/lib/Page.ts
@@ -110,19 +110,15 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
 
     this.setEventsToLog([
       'frame-created',
-      'frame-navigated',
-      'frame-lifecycle',
-      'frame-requested-navigation',
       'websocket-frame',
       'websocket-handshake',
       'navigation-response',
       'worker',
     ]);
 
-    for (const event of ['frame-created', 'frame-navigated', 'frame-lifecycle'] as const) {
-      this.framesManager.on(event, this.emit.bind(this, event));
-    }
-    for (const event of [
+    this.framesManager.addEventEmitter(this, ['frame-created']);
+
+    this.networkManager.addEventEmitter(this, [
       'navigation-response',
       'websocket-frame',
       'websocket-handshake',
@@ -130,9 +126,7 @@ export class Page extends TypedEventEmitter<IPuppetPageEvents> implements IPuppe
       'resource-was-requested',
       'resource-loaded',
       'resource-failed',
-    ] as const) {
-      this.networkManager.on(event, this.emit.bind(this, event));
-    }
+    ]);
 
     this.cdpSession.once('disconnected', this.emit.bind(this, 'close'));
 

--- a/puppet-interfaces/IPuppetFrame.ts
+++ b/puppet-interfaces/IPuppetFrame.ts
@@ -6,10 +6,12 @@ export interface IPuppetFrame extends ITypedEventEmitter<IPuppetFrameEvents> {
   parentId?: string;
   name?: string;
   url: string;
+  activeLoaderId: string;
   navigationReason?: string;
   disposition?: string;
   securityOrigin: string;
   isLoaded: boolean;
+  isDefaultUrl: boolean;
   isAttached(): boolean;
   waitForLoad(): Promise<void>;
   waitForLoader(loaderId?: string): Promise<Error | undefined>;
@@ -29,14 +31,15 @@ export interface ILifecycleEvents {
   init?: Date;
 }
 
-export interface IPuppetFrameEvents {
-  'frame-created': { frame: IPuppetFrame };
-  'frame-lifecycle': { frame: IPuppetFrame; name: string };
-  'frame-navigated': { frame: IPuppetFrame; navigatedInDocument?: boolean };
-  'frame-requested-navigation': { frame: IPuppetFrame; url: string; reason: NavigationReason };
+export interface IPuppetFrameManagerEvents {
+  'frame-created': { frame: IPuppetFrame; loaderId: string };
 }
-
-export interface IPuppetFrameInternalEvents {
-  'default-context-created': { executionContextId: number };
-  'isolated-context-created': { executionContextId: number };
+export interface IPuppetFrameEvents {
+  'frame-lifecycle': { frame: IPuppetFrame; name: string; loaderId: string };
+  'frame-navigated': { frame: IPuppetFrame; navigatedInDocument?: boolean; loaderId?: string };
+  'frame-requested-navigation': {
+    frame: IPuppetFrame;
+    url: string;
+    reason: NavigationReason;
+  };
 }

--- a/puppet-interfaces/IPuppetNetworkEvents.ts
+++ b/puppet-interfaces/IPuppetNetworkEvents.ts
@@ -7,6 +7,7 @@ export interface IPuppetNetworkEvents {
     status: number;
     location?: string;
     url?: string;
+    loaderId: string;
   };
   'websocket-frame': {
     browserRequestId: string;
@@ -22,16 +23,19 @@ export interface IPuppetNetworkEvents {
     redirectedFromUrl: string;
     isDocumentNavigation: boolean;
     frameId: string;
+    loaderId?: string;
   };
   'resource-was-requested': {
     resource: IHttpResourceLoadDetails;
     redirectedFromUrl: string;
     isDocumentNavigation: boolean;
     frameId: string;
+    loaderId?: string;
   };
   'resource-loaded': {
     resource: IHttpResourceLoadDetails;
     frameId?: string;
+    loaderId?: string;
   };
   'resource-failed': {
     resource: IHttpResourceLoadDetails;

--- a/puppet-interfaces/IPuppetPage.ts
+++ b/puppet-interfaces/IPuppetPage.ts
@@ -1,7 +1,7 @@
 import IRegisteredEventListener from '@secret-agent/core-interfaces/IRegisteredEventListener';
 import ITypedEventEmitter from '@secret-agent/core-interfaces/ITypedEventEmitter';
 import IRect from '@secret-agent/core-interfaces/IRect';
-import { IPuppetFrame, IPuppetFrameEvents } from './IPuppetFrame';
+import { IPuppetFrame, IPuppetFrameManagerEvents } from './IPuppetFrame';
 import { IPuppetKeyboard, IPuppetMouse } from './IPuppetInput';
 import { IPuppetNetworkEvents } from './IPuppetNetworkEvents';
 import { IPuppetWorker } from './IPuppetWorker';
@@ -45,7 +45,7 @@ export interface IPuppetPage extends ITypedEventEmitter<IPuppetPageEvents> {
   ): Promise<IRegisteredEventListener>;
 }
 
-export interface IPuppetPageEvents extends IPuppetFrameEvents, IPuppetNetworkEvents {
+export interface IPuppetPageEvents extends IPuppetFrameManagerEvents, IPuppetNetworkEvents {
   close: undefined;
   worker: { worker: IPuppetWorker };
   crashed: { error: Error; fatal?: boolean };

--- a/puppet/test/Page.navigate.test.ts
+++ b/puppet/test/Page.navigate.test.ts
@@ -89,7 +89,10 @@ describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
           res.statusCode = 204;
           res.end();
         });
-        const wait = page.waitOn('frame-lifecycle', event => event.name === 'DOMContentLoaded');
+        const wait = page.mainFrame.waitOn(
+          'frame-lifecycle',
+          event => event.name === 'DOMContentLoaded',
+        );
         await page.goto(`${server.baseUrl}/frames/one-frame.html`);
         await expect(wait).resolves.toBeTruthy();
       });
@@ -118,7 +121,7 @@ describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
             false,
           );
         })()`);
-        const waitForLoad = page.waitOn(
+        const waitForLoad = page.mainFrame.waitOn(
           'frame-lifecycle',
           event => event.name === 'DOMContentLoaded',
         );

--- a/puppet/test/Page.popups.test.ts
+++ b/puppet/test/Page.popups.test.ts
@@ -123,7 +123,7 @@ describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
             await newPage.click('a');
             popup = await popupNavigate;
 
-            await popup.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'load', 5e3, true);
+            await popup.mainFrame.waitForLoad();
             expect(popup.mainFrame.url).toBe(server.emptyPage);
           } finally {
             await popup?.close();

--- a/puppet/test/Page.test.ts
+++ b/puppet/test/Page.test.ts
@@ -295,9 +295,7 @@ describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
         const frame = page.frames[1];
         const loaded = page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === 'load');
         await new Promise<void>(resolve => {
-          page.on('frame-navigated', f => {
-            if (f.frame.id === frame.id) resolve();
-          });
+          frame.on('frame-navigated', () => resolve());
         });
         await frame.evaluate(`window.stop()`);
         await expect(navigationPromise).resolves.toBe(undefined);

--- a/puppet/test/TestPage.ts
+++ b/puppet/test/TestPage.ts
@@ -77,9 +77,13 @@ export async function detachFrame(page: IPuppetPage, frameId: string) {
       })('${frameId}')`);
 }
 
-export async function goto(page: IPuppetPage, url: string, waitOnLifecycle = 'load') {
+export async function goto(
+  page: IPuppetPage,
+  url: string,
+  waitOnLifecycle: 'load' | 'DOMContentLoaded' = 'load',
+) {
   const nav = page.navigate(url);
-  const lifecycle = page.waitOn('frame-lifecycle', event => event.name === waitOnLifecycle);
+  const lifecycle = page.mainFrame.waitOn('frame-lifecycle', ev => ev.name === waitOnLifecycle);
   await Promise.all([lifecycle, nav, page.mainFrame.waitOn('frame-navigated')]);
 }
 

--- a/puppet/test/load.test.ts
+++ b/puppet/test/load.test.ts
@@ -60,7 +60,7 @@ describe.each([[Chrome80.engine], [ChromeLatest.engine]])(
           page = createTestPage(await context.newPage());
           await page.goto(server.url('link.html'));
 
-          const navigate = page.waitOn('frame-navigated');
+          const navigate = page.mainFrame.waitOn('frame-navigated');
           await page.click('a');
           await navigate;
           expect(page.mainFrame.url).toBe(`${server.crossProcessBaseUrl}/empty.html`);


### PR DESCRIPTION
We had some github actions failing under load under Chrome 88 because of the way things have changed with new tabs. Trying to fix it, I realized we were taking all frame "navigation" changes as if they will always come in perfect order. This could cause issues sometimes where we would mis-match the redirect urls or current navigation that was actually an event updating a previous navigation.

In this PR, I've moved to tracking navigations by the "loader id" assigned in chrome.