### PR TITLE
feat(core): throw fetch error if no origin

### DIFF
--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -189,7 +189,13 @@ export default class FrameEnvironment {
     return await new JsPath(this, jsPath).exec(propertiesToExtract);
   }
 
-  public createRequest(input: string | number, init?: IRequestInit): Promise<IAttachedState> {
+  public async createRequest(input: string | number, init?: IRequestInit): Promise<IAttachedState> {
+    if (!this.navigations.top && !this.url) {
+      throw new Error(
+        'You need to use a "goto" before attempting to fetch. The in-browser fetch needs an origin to function properly.',
+      );
+    }
+    await this.navigationsObserver.waitForReady();
     return this.runIsolatedFn(
       `${InjectedScripts.Fetcher}.createRequest`,
       input,
@@ -198,7 +204,13 @@ export default class FrameEnvironment {
     );
   }
 
-  public fetch(input: string | number, init?: IRequestInit): Promise<IAttachedState> {
+  public async fetch(input: string | number, init?: IRequestInit): Promise<IAttachedState> {
+    if (!this.navigations.top && !this.url) {
+      throw new Error(
+        'You need to use a "goto" before attempting to fetch. The in-browser fetch needs an origin to function properly.',
+      );
+    }
+    await this.navigationsObserver.waitForReady();
     return this.runIsolatedFn(
       `${InjectedScripts.Fetcher}.fetch`,
       input,

--- a/full-client/test/fetch.test.ts
+++ b/full-client/test/fetch.test.ts
@@ -13,11 +13,21 @@ afterAll(Helpers.afterAll);
 afterEach(Helpers.afterEach);
 
 describe('Fetch tests', () => {
+  it('should be able to fetch from top level', async () => {
+    const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
+
+    await expect(agent.fetch('https://dataliberationfoundation.org')).rejects.toThrowError(
+      'need to use a "goto"',
+    );
+  });
+
   it('should be able to run a fetch from the browser', async () => {
     koaServer.get('/fetch', ctx => {
       ctx.body = { got: 'it' };
     });
     const agent = await handler.createAgent();
+    Helpers.needsClosing.push(agent);
 
     await agent.goto(`${koaServer.baseUrl}/`);
     await agent.waitForPaintingStable();

--- a/website/docs/BasicInterfaces/FrameEnvironment.md
+++ b/website/docs/BasicInterfaces/FrameEnvironment.md
@@ -95,15 +95,23 @@ Perform a native "fetch" request in the current frame environment.
 #### **Returns**: [`Promise<Response>`](/docs/awaited-dom/response)
 
 ```js
-const url = 'https://dataliberationfoundation.org';
-const response = await agent.fetch(url);
+const origin = 'https://dataliberationfoundation.org/';
+const getUrl = 'https://dataliberationfoundation.org/mission';
+
+await agent.goto(origin);
+const mainFrame = agent.mainFrameEnvironment;
+const response = await mainFrame.fetch(getUrl);
 ```
 
 Http Post example with a body:
 
 ```js
-const url = 'https://dataliberationfoundation.org/nopost';
-const response = await agent.fetch(url, {
+const origin = 'https://dataliberationfoundation.org/';
+const postUrl = 'https://dataliberationfoundation.org/nopost';
+
+await agent.goto(origin);
+const mainFrame = agent.mainFrameEnvironment;
+const response = await mainFrame.fetch(postUrl, {
   method: 'post',
   headers: {
     Authorization: 'Basic ZWx1c3VhcmlvOnlsYWNsYXZl',
@@ -113,6 +121,7 @@ const response = await agent.fetch(url, {
   }),
 });
 ```
+
 
 ### frameEnvironment.getFrameEnvironment*(frameElement)* {#find-frame}
 

--- a/website/docs/BasicInterfaces/Tab.md
+++ b/website/docs/BasicInterfaces/Tab.md
@@ -93,7 +93,7 @@ Closes the current tab only (will close the whole Agent instance if there are no
 Perform a native "fetch" request in the [mainFrameEnvironment](#main-frame-environment) context.
 
 NOTE: You can work around Cross Origin Request (CORS) issues or change your request "origin" by running fetch
-from each [FrameEnvironment](/docs/basic-interfaces/frame-environment#fetch).
+from a different [FrameEnvironment](/docs/basic-interfaces/frame-environment#fetch).
 
 #### **Arguments**:
 
@@ -107,15 +107,21 @@ Alias for [tab.mainFrameEnvironment.fetch](/docs/basic-interfaces/frame-environm
 #### **Returns**: [`Promise<Response>`](/docs/awaited-dom/response)
 
 ```js
-const url = 'https://dataliberationfoundation.org';
-const response = await agent.fetch(url);
+const origin = 'https://dataliberationfoundation.org/';
+const getUrl = 'https://dataliberationfoundation.org/mission';
+
+await agent.goto(origin);
+const response = await agent.fetch(getUrl);
 ```
 
 Http Post example with a body:
 
 ```js
-const url = 'https://dataliberationfoundation.org/nopost';
-const response = await agent.fetch(url, {
+const origin = 'https://dataliberationfoundation.org/';
+const postUrl = 'https://dataliberationfoundation.org/nopost';
+
+await agent.goto(origin);
+const response = await agent.fetch(postUrl, {
   method: 'post',
   headers: {
     Authorization: 'Basic ZWx1c3VhcmlvOnlsYWNsYXZl',


### PR DESCRIPTION
If a fetch is run on a page with no "goto", it currently fails. This PR throws an error if a url hasn't been loaded for a frame, and tweaks the documentation.