### PR TITLE
Node pointer

### DIFF
--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -336,13 +336,6 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
       throw err;
     }
   }
-
-  public toJSON(): any {
-    // return empty so we can
-    return {
-      type: 'Agent',
-    };
-  }
 }
 
 // This class will lazily connect to core on first access of the tab properties

--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -15,10 +15,11 @@ import IWaitForElementOptions from '@secret-agent/interfaces/IWaitForElementOpti
 import { ILocationTrigger } from '@secret-agent/interfaces/Location';
 import Request from 'awaited-dom/impl/official-klasses/Request';
 import IWaitForOptions from '@secret-agent/interfaces/IWaitForOptions';
-import { IElementIsolate } from 'awaited-dom/base/interfaces/isolate';
+import { IElementIsolate, INodeIsolate } from 'awaited-dom/base/interfaces/isolate';
 import CSSStyleDeclaration from 'awaited-dom/impl/official-klasses/CSSStyleDeclaration';
 import IAgentMeta from '@secret-agent/interfaces/IAgentMeta';
 import IScreenshotOptions from '@secret-agent/interfaces/IScreenshotOptions';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import WebsocketResource from './WebsocketResource';
 import IWaitForResourceFilter from '../interfaces/IWaitForResourceFilter';
 import Resource from './Resource';
@@ -277,12 +278,17 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
     return this.activeTab.getComputedStyle(element, pseudoElement);
   }
 
+  public getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
+    return this.activeTab.getComputedVisibility(node);
+  }
+
   public getJsValue<T>(path: string): Promise<T> {
     return this.activeTab.getJsValue<T>(path);
   }
 
-  public isElementVisible(element: IElementIsolate): Promise<boolean> {
-    return this.activeTab.isElementVisible(element);
+  // @deprecated 2021-04-30: Replaced with getComputedVisibility
+  public async isElementVisible(element: IElementIsolate): Promise<boolean> {
+    return await this.getComputedVisibility(element as any).then(x => x.isVisible);
   }
 
   public takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {

--- a/client/lib/CoreFrameEnvironment.ts
+++ b/client/lib/CoreFrameEnvironment.ts
@@ -6,10 +6,11 @@ import { ICookie } from '@secret-agent/interfaces/ICookie';
 import IWaitForElementOptions from '@secret-agent/interfaces/IWaitForElementOptions';
 import IExecJsPathResult from '@secret-agent/interfaces/IExecJsPathResult';
 import { IRequestInit } from 'awaited-dom/base/interfaces/official';
-import IAttachedState from 'awaited-dom/base/IAttachedState';
+import INodePointer from 'awaited-dom/base/INodePointer';
 import ISetCookieOptions from '@secret-agent/interfaces/ISetCookieOptions';
 import IWaitForOptions from '@secret-agent/interfaces/IWaitForOptions';
 import IFrameMeta from '@secret-agent/interfaces/IFrameMeta';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import CoreCommandQueue from './CoreCommandQueue';
 
 export default class CoreFrameEnvironment {
@@ -48,11 +49,11 @@ export default class CoreFrameEnvironment {
     return await this.commandQueue.run('FrameEnvironment.getJsValue', expression);
   }
 
-  public async fetch(request: string | number, init?: IRequestInit): Promise<IAttachedState> {
+  public async fetch(request: string | number, init?: IRequestInit): Promise<INodePointer> {
     return await this.commandQueue.run('FrameEnvironment.fetch', request, init);
   }
 
-  public async createRequest(input: string | number, init?: IRequestInit): Promise<IAttachedState> {
+  public async createRequest(input: string | number, init?: IRequestInit): Promise<INodePointer> {
     return await this.commandQueue.run('FrameEnvironment.createRequest', input, init);
   }
 
@@ -80,8 +81,8 @@ export default class CoreFrameEnvironment {
     return await this.commandQueue.run('FrameEnvironment.removeCookie', name);
   }
 
-  public async isElementVisible(jsPath: IJsPath): Promise<boolean> {
-    return await this.commandQueue.run('FrameEnvironment.isElementVisible', jsPath);
+  public async getComputedVisibility(jsPath: IJsPath): Promise<INodeVisibility> {
+    return await this.commandQueue.run('FrameEnvironment.getComputedVisibility', jsPath);
   }
 
   public async waitForElement(jsPath: IJsPath, opts: IWaitForElementOptions): Promise<void> {

--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -185,13 +185,6 @@ export default class FrameEnvironment {
     const coreFrame = await getCoreFrameEnvironment(this);
     await coreFrame.waitForLocation(trigger, options);
   }
-
-  public toJSON(): any {
-    // return empty so we can
-    return {
-      type: 'FrameEnvironment',
-    };
-  }
 }
 
 export function getFrameState(object: any): IState {

--- a/client/lib/Request.ts
+++ b/client/lib/Request.ts
@@ -2,12 +2,12 @@ import FetchRequest from 'awaited-dom/impl/official-klasses/Request';
 import AwaitedPath from 'awaited-dom/base/AwaitedPath';
 import StateMachine from 'awaited-dom/base/StateMachine';
 import { IRequestInfo, IRequestInit } from 'awaited-dom/base/interfaces/official';
-import IAttachedState from 'awaited-dom/base/IAttachedState';
+import INodePointer from 'awaited-dom/base/INodePointer';
 import CoreFrameEnvironment from './CoreFrameEnvironment';
 
 interface IState {
   awaitedPath: AwaitedPath;
-  attachedState: IAttachedState;
+  nodePointer: INodePointer;
   remoteInitializerPromise: Promise<void>;
   coreFrame: Promise<CoreFrameEnvironment>;
 }
@@ -37,10 +37,10 @@ async function createRemoteInitializer(
 ): Promise<void> {
   const requestInput = await getRequestIdOrUrl(input);
   const coreFrame = await coreFramePromise;
-  const attachedState = await coreFrame.createRequest(requestInput, init);
-  const awaitedPath = new AwaitedPath().withAttachedId(attachedState.id);
+  const nodePointer = await coreFrame.createRequest(requestInput, init);
+  const awaitedPath = new AwaitedPath(null).withNodeId(null, nodePointer.id);
   setState(instance, {
-    attachedState,
+    nodePointer,
     awaitedPath,
   });
 }

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -11,9 +11,10 @@ import IWaitForResourceOptions from '@secret-agent/interfaces/IWaitForResourceOp
 import IWaitForElementOptions from '@secret-agent/interfaces/IWaitForElementOptions';
 import Response from 'awaited-dom/impl/official-klasses/Response';
 import IWaitForOptions from '@secret-agent/interfaces/IWaitForOptions';
-import { IElementIsolate } from 'awaited-dom/base/interfaces/isolate';
+import { IElementIsolate, INodeIsolate } from 'awaited-dom/base/interfaces/isolate';
 import IScreenshotOptions from '@secret-agent/interfaces/IScreenshotOptions';
 import AwaitedPath from 'awaited-dom/base/AwaitedPath';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import CoreTab from './CoreTab';
 import Resource, { createResource } from './Resource';
 import IWaitForResourceFilter from '../interfaces/IWaitForResourceFilter';
@@ -160,8 +161,13 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     return await this.mainFrameEnvironment.getJsValue(path);
   }
 
+  // @deprecated 2021-04-30: Replaced with getComputedVisibility
   public async isElementVisible(element: IElementIsolate): Promise<boolean> {
-    return await this.mainFrameEnvironment.isElementVisible(element);
+    return await this.getComputedVisibility(element as any).then(x => x.isVisible);
+  }
+
+  public async getComputedVisibility(node: INodeIsolate): Promise<INodeVisibility> {
+    return await this.mainFrameEnvironment.getComputedVisibility(node);
   }
 
   public async takeScreenshot(options?: IScreenshotOptions): Promise<Buffer> {

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -221,13 +221,6 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
     connection.closeTab(this);
     return coreTab.then(x => x.close());
   }
-
-  public toJSON(): any {
-    // return empty so we can
-    return {
-      type: 'Tab',
-    };
-  }
 }
 
 async function getOrCreateFrameEnvironment(

--- a/client/lib/WebsocketResource.ts
+++ b/client/lib/WebsocketResource.ts
@@ -79,7 +79,7 @@ export function createWebsocketResource(
   const resource = new WebsocketResource();
   const request = createResourceRequest(coreTab, resourceMeta.id);
   const response = createResourceResponse(coreTab, resourceMeta.id);
-  const awaitedPath = new AwaitedPath('resources', String(resourceMeta.id));
+  const awaitedPath = new AwaitedPath(null, 'resources', String(resourceMeta.id));
   setState(resource, { coreTab, resource: resourceMeta, request, response, awaitedPath });
   return resource;
 }

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@secret-agent/commons": "1.4.1-alpha.4",
     "@secret-agent/interfaces": "1.4.1-alpha.4",
     "@secret-agent/replay": "1.4.1-alpha.4",
-    "awaited-dom": "1.1.12",
+    "awaited-dom": "1.2.1",
     "uuid": "^8.3.2",
     "ws": "^7.4.4"
   },

--- a/client/test/document.test.ts
+++ b/client/test/document.test.ts
@@ -3,7 +3,7 @@ import '../lib/SetupAwaitedHandler';
 
 import { getState as getElementState } from 'awaited-dom/base/official-klasses/Element';
 import IExecJsPathResult from '@secret-agent/interfaces/IExecJsPathResult';
-import getAttachedStateFnName from '@secret-agent/interfaces/getAttachedStateFnName';
+import getNodePointerFnName from '@secret-agent/interfaces/getNodePointerFnName';
 import { Helpers } from '@secret-agent/testing';
 import ICoreRequestPayload from '@secret-agent/interfaces/ICoreRequestPayload';
 import ICoreResponsePayload from '@secret-agent/interfaces/ICoreResponsePayload';
@@ -31,11 +31,11 @@ describe('document tests', () => {
         if (command === 'FrameEnvironment.execJsPath') {
           const [jsPath] = args;
           const lastPath = jsPath[jsPath.length - 1];
-          if (lastPath && lastPath[0] === getAttachedStateFnName) {
+          if (lastPath && lastPath[0] === getNodePointerFnName) {
             return {
               data: {
                 value: null,
-                attachedState: { id: 1 },
+                nodePointer: { id: 1 },
               } as IExecJsPathResult,
             };
           }
@@ -83,9 +83,7 @@ describe('document tests', () => {
       'Session.close',
       'Core.disconnect',
     ]);
-    expect(outgoingCommands[3][0].args).toMatchObject([
-      [...jsPath, [getAttachedStateFnName, undefined]],
-    ]);
+    expect(outgoingCommands[3][0].args).toMatchObject([[...jsPath, [getNodePointerFnName]]]);
     expect(outgoingCommands[4][0].args).toMatchObject([[1, 'tagName']]);
   });
 });

--- a/core/injected-scripts/Fetcher.ts
+++ b/core/injected-scripts/Fetcher.ts
@@ -1,24 +1,24 @@
+declare let ObjectAtPath: any;
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class Fetcher {
   public static createRequest(input: string | number, init?: RequestInit) {
     let requestOrUrl = input as string | Request;
     if (typeof input === 'number') {
-      requestOrUrl = NodeTracker.getNodeWithId(input) as any;
+      requestOrUrl = NodeTracker.getWatchedNodeWithId(input) as any;
     }
     const request = new Request(requestOrUrl, init);
-    // @ts-ignore
-    return TSON.stringify(ObjectAtPath.createAttachedState(request));
+    return ObjectAtPath.createNodePointer(request);
   }
 
   public static async fetch(input: string | number, init?: RequestInit) {
     let requestOrUrl = input as string | Request;
     if (typeof input === 'number') {
-      requestOrUrl = NodeTracker.getNodeWithId(input) as any;
+      requestOrUrl = NodeTracker.getWatchedNodeWithId(input) as any;
     }
 
     const response = await fetch(requestOrUrl, init);
 
-    // @ts-ignore
-    return TSON.stringify(ObjectAtPath.createAttachedState(response));
+    return ObjectAtPath.createNodePointer(response);
   }
 }

--- a/core/injected-scripts/global.d.ts
+++ b/core/injected-scripts/global.d.ts
@@ -1,13 +1,14 @@
 interface ITson {
   stringify(object: any): string;
   parse(object: string): any;
+  replace(object: any): any;
 }
 
 interface IStaticNodeTracker {
-  getNodeWithId(id: number): Node;
   has(node: Node): boolean;
   getNodeId(node: Node): number | undefined;
-  assignNodeId(node: Node): number | undefined;
+  getWatchedNodeWithId(id: number): Node;
+  watchNode(node: Node): number | undefined;
   track(node: Node): number;
 }
 

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -126,7 +126,7 @@ export default class GlobalPool {
     const browserOrError = await puppet.start({
       ...this.defaultLaunchArgs,
       proxyPort: this.mitmServer.port,
-      showBrowser: engine.isHeaded,
+      showBrowser: engine.isHeaded ?? this.defaultLaunchArgs.showBrowser,
     });
     if (browserOrError instanceof Error) throw browserOrError;
     return puppet;

--- a/core/lib/InjectedScriptError.ts
+++ b/core/lib/InjectedScriptError.ts
@@ -2,7 +2,7 @@ import { IPathStep } from 'awaited-dom/base/AwaitedPath';
 
 export default class InjectedScriptError extends Error {
   private readonly pathState: { step: IPathStep; index: number };
-  constructor(message: string, pathState: { step: IPathStep; index: number }) {
+  constructor(message: string, pathState?: { step: IPathStep; index: number }) {
     super(message);
     this.pathState = pathState;
     this.name = 'InjectedScriptError';

--- a/core/lib/Interactor.ts
+++ b/core/lib/Interactor.ts
@@ -126,12 +126,15 @@ export default class Interactor implements IInteractionsHelper {
         height: 1,
       };
     }
+    if (mousePosition === null) {
+      throw new Error('Null mouse position provided to agent.interact');
+    }
     const jsPath = new JsPath(this.frameEnvironment, mousePosition);
     const rectResult = await jsPath.getClientRect(includeNodeVisibility);
     const rect = rectResult.value;
     const nodePointer = rectResult.nodePointer as INodePointer;
 
-    if (!nodePointer && throwIfNotPresent)
+    if (!nodePointer?.id && throwIfNotPresent)
       throw new Error(
         `The provided interaction->mousePosition did not match any nodes (${formatJsPath(
           mousePosition,
@@ -214,6 +217,11 @@ export default class Interactor implements IInteractionsHelper {
       case InteractionCommand.click:
       case InteractionCommand.doubleclick: {
         const { delayMillis, mouseButton, command, mousePosition } = interaction;
+        if (!mousePosition) {
+          throw new Error(
+            `Null element provided to interact.click. Please double-check your selector`,
+          );
+        }
         const button = mouseButton || 'left';
         const clickCount = command === InteractionCommand.doubleclick ? 2 : 1;
         const isCoordinates = isMousePositionCoordinate(mousePosition);

--- a/core/lib/Interactor.ts
+++ b/core/lib/Interactor.ts
@@ -18,7 +18,7 @@ import IWindowOffset from '@secret-agent/interfaces/IWindowOffset';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import Log from '@secret-agent/commons/Logger';
 import { IBoundLog } from '@secret-agent/interfaces/ILog';
-import { IAttachedState } from '@secret-agent/interfaces/AwaitedDom';
+import { INodePointer } from '@secret-agent/interfaces/AwaitedDom';
 import IPoint from '@secret-agent/interfaces/IPoint';
 import IMouseUpResult from '@secret-agent/interfaces/IMouseUpResult';
 import IResolvablePromise from '@secret-agent/interfaces/IResolvablePromise';
@@ -26,6 +26,7 @@ import { IPuppetKeyboard, IPuppetMouse } from '@secret-agent/interfaces/IPuppetI
 import IHumanEmulator from '@secret-agent/interfaces/IHumanEmulator';
 import IViewport from '@secret-agent/interfaces/IViewport';
 import IElementRect from '@secret-agent/interfaces/IElementRect';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import Tab from './Tab';
 import FrameEnvironment from './FrameEnvironment';
 import { JsPath } from './JsPath';
@@ -60,6 +61,8 @@ export default class Interactor implements IInteractionsHelper {
   }
 
   public logger: IBoundLog;
+
+  private preInteractionPaintStableStatus: { isStable: boolean; timeUntilReadyMs?: number };
 
   private readonly frameEnvironment: FrameEnvironment;
 
@@ -96,6 +99,7 @@ export default class Interactor implements IInteractionsHelper {
   public play(interactions: IInteractionGroups, resolvablePromise: IResolvablePromise<any>): void {
     const finalInteractions = Interactor.injectScrollToPositions(interactions);
 
+    this.preInteractionPaintStableStatus = this.frameEnvironment.navigationsObserver.getPaintStableStatus();
     const humanEmulator = this.humanEmulator;
     humanEmulator
       .playInteractions(finalInteractions, this.playInteraction.bind(this, resolvablePromise), this)
@@ -106,7 +110,14 @@ export default class Interactor implements IInteractionsHelper {
   public async lookupBoundingRect(
     mousePosition: IMousePosition,
     throwIfNotPresent = false,
-  ): Promise<IRect & { elementTag?: string; nodeId?: number; isNodeVisible?: boolean }> {
+    includeNodeVisibility = false,
+  ): Promise<
+    IRect & {
+      elementTag?: string;
+      nodeId?: number;
+      nodeVisibility?: INodeVisibility;
+    }
+  > {
     if (isMousePositionCoordinate(mousePosition)) {
       return {
         x: mousePosition[0] as number,
@@ -116,10 +127,11 @@ export default class Interactor implements IInteractionsHelper {
       };
     }
     const jsPath = new JsPath(this.frameEnvironment, mousePosition);
-    const rect = await jsPath.getClientRect();
-    const attachedState = (rect as any).attachedState as IAttachedState;
+    const rectResult = await jsPath.getClientRect(includeNodeVisibility);
+    const rect = rectResult.value;
+    const nodePointer = rectResult.nodePointer as INodePointer;
 
-    if (!attachedState && throwIfNotPresent)
+    if (!nodePointer && throwIfNotPresent)
       throw new Error(
         `The provided interaction->mousePosition did not match any nodes (${formatJsPath(
           mousePosition,
@@ -127,24 +139,32 @@ export default class Interactor implements IInteractionsHelper {
       );
 
     return {
-      x: rect.left,
-      y: rect.top,
+      x: rect.x,
+      y: rect.y,
       height: rect.height,
       width: rect.width,
       elementTag: rect.tag,
-      nodeId: attachedState?.id,
-      isNodeVisible: rect.isVisible,
+      nodeId: nodePointer?.id,
+      nodeVisibility: rect.nodeVisibility,
     };
   }
 
   public async createMouseupTrigger(
     nodeId: number,
-  ): Promise<{ didTrigger: () => Promise<IMouseUpResult> }> {
+  ): Promise<{
+    didTrigger: (mousePosition: IMousePosition, throwOnFail?: boolean) => Promise<IMouseUpResult>;
+  }> {
     assert(nodeId, 'nodeId should not be null');
     const mouseListener = new MouseupListener(this.frameEnvironment, nodeId);
     await mouseListener.register();
     return {
-      didTrigger: () => mouseListener.didTriggerMouseEvent(),
+      didTrigger: async (mousePosition, throwOnFail = true) => {
+        const result = await mouseListener.didTriggerMouseEvent();
+        if (!result.didClickLocation && throwOnFail) {
+          this.throwMouseUpTriggerFailed(nodeId, result, mousePosition);
+        }
+        return result;
+      },
     };
   }
 
@@ -209,50 +229,29 @@ export default class Interactor implements IInteractionsHelper {
           return;
         }
 
-        let attachedNodeId: number;
-        if (isMousePositionAttachedId(mousePosition)) {
-          attachedNodeId = mousePosition[0] as number;
+        let nodePointerId: number;
+        if (isMousePositionNodeId(mousePosition)) {
+          nodePointerId = mousePosition[0] as number;
         } else {
-          const attachedState = await new JsPath(
-            this.frameEnvironment,
-            mousePosition,
-          ).getAttachedState();
-          attachedNodeId = attachedState.attachedState.id;
+          const nodeLookup = await new JsPath(this.frameEnvironment, mousePosition).getNodeId();
+          if (nodeLookup.value) {
+            nodePointerId = nodeLookup.value;
+          }
         }
 
-        const paintStableStatus = this.frameEnvironment.navigationsObserver.getPaintStableStatus();
-        const result = await this.moveMouseOverTarget(attachedNodeId, interaction, resolvable);
+        const result = await this.moveMouseOverTarget(nodePointerId, interaction, resolvable);
 
         if (result.simulateOptionClick) {
-          await new JsPath(this.frameEnvironment, [attachedNodeId]).simulateOptionClick();
+          await new JsPath(this.frameEnvironment, [nodePointerId]).simulateOptionClick();
           return;
         }
-
-        const { domCoordinates } = result;
 
         await this.mouse.down({ button, clickCount });
         if (delayMillis) await waitFor(delayMillis, resolvable);
 
-        const mouseupTrigger = await this.createMouseupTrigger(attachedNodeId);
+        const mouseupTrigger = await this.createMouseupTrigger(nodePointerId);
         await this.mouse.up({ button, clickCount });
-        const mouseupTriggered = await mouseupTrigger.didTrigger();
-        if (!mouseupTriggered.didClickLocation) {
-          const suggestWaitingMessage = paintStableStatus.isStable
-            ? '\n\nYou might have more predictable results by waiting for the page to stabilize before triggering this click -- agent.waitForPaintingStable()'
-            : '';
-          this.logger.error(
-            `Interaction.click did not trigger mouseup on the requested node.${suggestWaitingMessage}`,
-            {
-              interaction,
-              jsPathNodeId: attachedNodeId,
-              clickedNodeId: mouseupTriggered.targetNodeId,
-              domCoordinates,
-            },
-          );
-          throw new Error(
-            `Interaction.click did not trigger mouseup on the desired node.${suggestWaitingMessage}`,
-          );
-        }
+        await mouseupTrigger.didTrigger(mousePosition);
         break;
       }
       case InteractionCommand.clickUp: {
@@ -345,20 +344,20 @@ export default class Interactor implements IInteractionsHelper {
       const [x, y] = mousePosition as number[];
       return { x: round(x), y: round(y) };
     }
-    const rect = await new JsPath(this.frameEnvironment, mousePosition).getClientRect();
-    const attachedState = (rect as any).attachedState as IAttachedState;
+    const clientRectResult = await new JsPath(this.frameEnvironment, mousePosition).getClientRect();
+    const nodePointer = clientRectResult.nodePointer as INodePointer;
 
-    const point = this.createPointInRect(rect);
-    return { ...point, nodeId: attachedState?.id };
+    const point = this.createPointInRect(clientRectResult.value);
+    return { ...point, nodeId: nodePointer?.id };
   }
 
   private createPointInRect(rect: IElementRect): IPoint {
-    if (rect.bottom === 0 && rect.height === 0 && rect.width === 0 && rect.right === 0) {
+    if (rect.y === 0 && rect.height === 0 && rect.width === 0 && rect.x === 0) {
       return { x: 0, y: 0 };
     }
     // Default is to find exact middle. An emulator should replace an entry with a coordinate to avoid this functionality
-    let x = round(rect.left + rect.width / 2);
-    let y = round(rect.top + rect.height / 2);
+    let x = round(rect.x + rect.width / 2);
+    let y = round(rect.y + rect.height / 2);
     // if coordinates go out of screen, bring back
     if (x > this.viewport.width) x = this.viewport.width - 1;
     if (y > this.viewport.height) y = this.viewport.height - 1;
@@ -367,23 +366,19 @@ export default class Interactor implements IInteractionsHelper {
   }
 
   private async moveMouseOverTarget(
-    attachedNodeId: number,
+    nodeId: number,
     interaction: IInteractionStep,
     resolvable: IResolvablePromise,
   ): Promise<{ domCoordinates: IPoint; simulateOptionClick?: boolean }> {
     // try 2x to hover over the expected target
     for (let retryNumber = 0; retryNumber < 2; retryNumber += 1) {
-      const rect = await this.lookupBoundingRect([attachedNodeId], false);
+      const rect = await this.lookupBoundingRect([nodeId], false, true);
 
       if (rect.elementTag === 'option') {
         return { simulateOptionClick: true, domCoordinates: null };
       }
 
       const targetPoint = this.createPointInRect({
-        left: rect.x,
-        top: rect.y,
-        bottom: rect.y + rect.height,
-        right: rect.x + rect.width,
         tag: rect.elementTag,
         ...rect,
       });
@@ -392,7 +387,7 @@ export default class Interactor implements IInteractionsHelper {
 
       // wait for mouse to be over target
       const waitForTarget = needsMouseoverTest
-        ? await this.createMouseoverTrigger(attachedNodeId)
+        ? await this.createMouseoverTrigger(nodeId)
         : { didTrigger: () => Promise.resolve(true) };
       await this.mouse.move(targetPoint.x, targetPoint.y);
 
@@ -405,7 +400,8 @@ export default class Interactor implements IInteractionsHelper {
         'Interaction.click - moving over target before click did not hover over expected "Interaction.mousePosition" element.',
         {
           mousePosition: interaction.mousePosition,
-          expectedNodeId: attachedNodeId,
+          expectedNodeId: nodeId,
+          isNodeHidden: Object.values(rect.nodeVisibility ?? {}).some(Boolean),
           domCoordinates: targetPoint,
           retryNumber,
         },
@@ -416,12 +412,50 @@ export default class Interactor implements IInteractionsHelper {
       // make sure element is on screen
       await this.playInteraction(resolvable, {
         command: 'scroll',
-        mousePosition: [attachedNodeId],
+        mousePosition: [nodeId],
       });
     }
 
     throw new Error(
       'Interaction.click - could not move mouse over target provided by "Interaction.mousePosition".',
+    );
+  }
+
+  private throwMouseUpTriggerFailed(
+    nodeId: number,
+    mouseUpResult: IMouseUpResult,
+    mousePosition: IMousePosition,
+  ) {
+    let extras = '';
+    const isNodeHidden = mouseUpResult.expectedNodeVisibility.isVisible;
+    if (isNodeHidden && nodeId) {
+      extras = `\n\nNOTE: The target node is not visible in the dom.`;
+    }
+    if (this.preInteractionPaintStableStatus?.isStable === false) {
+      if (!extras) extras += '\n\nNOTE:';
+      extras += ` You might have more predictable results by waiting for the page to stabilize before triggering this click -- agent.waitForPaintingStable()`;
+    }
+    this.logger.error(
+      `Interaction.click did not trigger mouseup on expected "Interaction.mousePosition" path.${extras}`,
+      {
+        'Interaction.mousePosition': mousePosition,
+        expected: {
+          nodeId,
+          element: mouseUpResult.expectedNodePreview,
+          visibility: mouseUpResult.expectedNodeVisibility,
+        },
+        clicked: {
+          nodeId: mouseUpResult.targetNodeId,
+          element: mouseUpResult.targetNodePreview,
+          coordinates: {
+            x: mouseUpResult.pageX,
+            y: mouseUpResult.pageY,
+          },
+        },
+      },
+    );
+    throw new Error(
+      `Interaction.click did not trigger mouseup on expected "Interaction.mousePosition" path.${extras}`,
     );
   }
 
@@ -447,7 +481,7 @@ export default class Interactor implements IInteractionsHelper {
   }
 }
 
-function isMousePositionAttachedId(mousePosition: IMousePosition): boolean {
+function isMousePositionNodeId(mousePosition: IMousePosition): boolean {
   return mousePosition.length === 1 && typeof mousePosition[0] === 'number';
 }
 

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -1,49 +1,59 @@
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
 import IExecJsPathResult from '@secret-agent/interfaces/IExecJsPathResult';
-import getAttachedStateFnName from '@secret-agent/interfaces/getAttachedStateFnName';
 import IElementRect from '@secret-agent/interfaces/IElementRect';
 import IWindowOffset from '@secret-agent/interfaces/IWindowOffset';
+import TypeSerializer from '@secret-agent/commons/TypeSerializer';
+import { IBoundLog } from '@secret-agent/interfaces/ILog';
+import Log from '@secret-agent/commons/Logger';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import FrameEnvironment from './FrameEnvironment';
 import InjectedScripts from './InjectedScripts';
+import { Serializable } from '../interfaces/ISerializable';
+import InjectedScriptError from './InjectedScriptError';
 
+const { log } = Log(module);
 export class JsPath {
   private readonly frameEnvironment: FrameEnvironment;
   private readonly jsPath: IJsPath;
+  private readonly logger: IBoundLog;
 
   constructor(frameEnvironment: FrameEnvironment, jsPath?: IJsPath) {
     this.frameEnvironment = frameEnvironment;
+    this.logger = log.createChild(module, {
+      sessionId: frameEnvironment.session.id,
+      frameId: frameEnvironment.id,
+    });
     this.jsPath = jsPath;
   }
 
-  public getAttachedState<T>(): Promise<IExecJsPathResult<T>> {
-    return this.frameEnvironment.runIsolatedFn<IExecJsPathResult<T>>(
-      `${InjectedScripts.JsPath}.exec`,
-      [...this.jsPath, [getAttachedStateFnName]],
-    );
+  public getNodeId(): Promise<IExecJsPathResult<number>> {
+    return this.runJsPath(`getNodeId`, this.jsPath);
   }
 
-  public exec<T>(propertiesToExtract?: string[]): Promise<IExecJsPathResult<T>> {
-    return this.frameEnvironment.runIsolatedFn(
-      `${InjectedScripts.JsPath}.exec`,
-      this.jsPath,
-      propertiesToExtract,
-    );
+  public async exec<T>(): Promise<IExecJsPathResult<T>> {
+    const result = await this.runJsPath<T>(`exec`, this.jsPath);
+
+    if (result.isValueSerialized === true) {
+      delete result.isValueSerialized;
+      result.value = TypeSerializer.revive(result.value, 'BROWSER');
+    }
+    return result;
   }
 
   public waitForElement(
     waitForVisible: boolean,
     timeoutMillis: number,
-  ): Promise<IExecJsPathResult<boolean>> {
-    return this.frameEnvironment.runIsolatedFn(
-      `${InjectedScripts.JsPath}.waitForElement`,
+  ): Promise<IExecJsPathResult<INodeVisibility>> {
+    return this.runJsPath<INodeVisibility>(
+      `waitForElement`,
       this.jsPath,
       waitForVisible,
       timeoutMillis,
     );
   }
 
-  public isVisible(): Promise<IExecJsPathResult<boolean>> {
-    return this.frameEnvironment.runIsolatedFn(`${InjectedScripts.JsPath}.isVisible`, this.jsPath);
+  public getComputedVisibility(): Promise<IExecJsPathResult<INodeVisibility>> {
+    return this.runJsPath(`getComputedVisibility`, this.jsPath);
   }
 
   public waitForScrollOffset(
@@ -58,21 +68,29 @@ export class JsPath {
     );
   }
 
-  public getClientRect(): Promise<IElementRect> {
-    return this.frameEnvironment.runIsolatedFn(
-      `${InjectedScripts.JsPath}.getClientRect`,
-      this.jsPath,
-    );
+  public getClientRect(includeNodeVisibility = false): Promise<IExecJsPathResult<IElementRect>> {
+    return this.runJsPath(`getClientRect`, this.jsPath, includeNodeVisibility);
   }
 
-  public simulateOptionClick(): Promise<boolean> {
-    return this.frameEnvironment.runIsolatedFn(
-      `${InjectedScripts.JsPath}.simulateOptionClick`,
-      this.jsPath,
-    );
+  public simulateOptionClick(): Promise<IExecJsPathResult<boolean>> {
+    return this.runJsPath(`simulateOptionClick`, this.jsPath);
   }
 
   public getWindowOffset(): Promise<IWindowOffset> {
     return this.frameEnvironment.runIsolatedFn(`${InjectedScripts.JsPath}.getWindowOffset`);
+  }
+
+  private async runJsPath<T>(
+    fnName: string,
+    ...args: Serializable[]
+  ): Promise<IExecJsPathResult<T>> {
+    const result = await this.frameEnvironment.runIsolatedFn<IExecJsPathResult<T>>(
+      `${InjectedScripts.JsPath}.${fnName}`,
+      ...args,
+    );
+    if (result.pathError) {
+      throw new InjectedScriptError(result.pathError.error, result.pathError.pathState);
+    }
+    return result;
   }
 }

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -21,6 +21,7 @@ import IWaitForElementOptions from '@secret-agent/interfaces/IWaitForElementOpti
 import { ILocationTrigger, IPipelineStatus } from '@secret-agent/interfaces/Location';
 import IFrameMeta from '@secret-agent/interfaces/IFrameMeta';
 import { INodeData } from '@secret-agent/interfaces/IDomChangeEvent';
+import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import FrameNavigations from './FrameNavigations';
 import CommandRecorder from './CommandRecorder';
 import FrameEnvironment from './FrameEnvironment';
@@ -292,19 +293,16 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     return this.mainFrameEnvironment.getJsValue(path);
   }
 
-  public execJsPath<T>(
-    jsPath: IJsPath,
-    propertiesToExtract?: string[],
-  ): Promise<IExecJsPathResult<T>> {
-    return this.mainFrameEnvironment.execJsPath<T>(jsPath, propertiesToExtract);
+  public execJsPath<T>(jsPath: IJsPath): Promise<IExecJsPathResult<T>> {
+    return this.mainFrameEnvironment.execJsPath<T>(jsPath);
   }
 
   public getLocationHref(): Promise<string> {
     return this.mainFrameEnvironment.getLocationHref();
   }
 
-  public isElementVisible(jsPath: IJsPath): Promise<boolean> {
-    return this.mainFrameEnvironment.isElementVisible(jsPath);
+  public getComputedVisibility(jsPath: IJsPath): Promise<INodeVisibility> {
+    return this.mainFrameEnvironment.getComputedVisibility(jsPath);
   }
 
   public waitForElement(jsPath: IJsPath, options?: IWaitForElementOptions): Promise<boolean> {

--- a/core/models/CommandsTable.ts
+++ b/core/models/CommandsTable.ts
@@ -1,6 +1,7 @@
 import ICommandMeta from '@secret-agent/interfaces/ICommandMeta';
 import { Database as SqliteDatabase, Statement } from 'better-sqlite3';
 import SqliteTable from '@secret-agent/commons/SqliteTable';
+import TypeSerializer from '@secret-agent/commons/TypeSerializer';
 
 export default class CommandsTable extends SqliteTable<ICommandMeta> {
   private readonly getQuery: Statement;
@@ -26,17 +27,6 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
   }
 
   public insert(commandMeta: ICommandMeta) {
-    let stringifiedError: string;
-    if (commandMeta.result instanceof Error) {
-      stringifiedError = JSON.stringify({
-        ...commandMeta.result,
-        name: commandMeta.result.name,
-        message: commandMeta.result.message,
-        stack: commandMeta.result.stack,
-      });
-    } else {
-      stringifiedError = JSON.stringify(commandMeta.result);
-    }
     this.queuePendingInsert([
       commandMeta.id,
       commandMeta.tabId,
@@ -45,7 +35,7 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
       commandMeta.args,
       commandMeta.startDate,
       commandMeta.endDate,
-      stringifiedError,
+      TypeSerializer.stringify(commandMeta.result),
       commandMeta.result?.constructor
         ? commandMeta.result.constructor.name
         : typeof commandMeta.result,

--- a/core/package.json
+++ b/core/package.json
@@ -24,7 +24,7 @@
     "@secret-agent/mitm": "1.4.1-alpha.4",
     "@secret-agent/puppet": "1.4.1-alpha.4",
     "@types/ua-parser-js": "^0.7.35",
-    "awaited-dom": "1.1.12",
+    "awaited-dom": "1.2.1",
     "better-sqlite3": "^7.1.4",
     "moment": "^2.24.1",
     "ua-parser-js": "^0.7.22",

--- a/core/test/DomEnv.test.ts
+++ b/core/test/DomEnv.test.ts
@@ -30,7 +30,7 @@ it('can operate when unsafe eval not on', async () => {
   await tab.goto(inputUrl);
   const input = await tab.execJsPath(['document', ['querySelector', 'input'], 'value']);
   expect(input.value).toBe('');
-  const x = await tab.execJsPath([['document.querySelector', 'body'], 'scrollTop']);
+  const x = await tab.execJsPath(['document', ['querySelector', 'body'], 'scrollTop']);
   expect(x.value).toBe(0);
   await session.close();
 });

--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -35,12 +35,9 @@ describe('basic Navigation tests', () => {
     const { tab } = await createSession();
     await tab.goto(koaServer.baseUrl);
 
-    const elem = await tab.execJsPath(
-      ['document', ['querySelector', 'a']],
-      ['nodeName', 'baseURI'],
-    );
+    const elem = await tab.execJsPath(['document', ['querySelector', 'a'], 'nodeName']);
     const hrefAttribute = await tab.execJsPath(['document', ['querySelector', 'a'], 'href']);
-    expect(elem.value).toMatchObject({ nodeName: 'A' });
+    expect(elem.value).toBe('A');
     expect(hrefAttribute.value).toBe('https://www.iana.org/domains/example');
   });
 
@@ -524,18 +521,20 @@ describe('PaintingStable tests', () => {
     });
 
     await tab.goto(`${koaServer.baseUrl}/grid/index.html`);
-    const trs = await tab.execJsPath<{ length: number }>(
-      ['document', ['querySelectorAll', '.record']],
-      ['length'],
-    );
+    const trs = await tab.execJsPath<number>([
+      'document',
+      ['querySelectorAll', '.record'],
+      'length',
+    ]);
 
-    expect(trs.value.length).toBe(0);
+    expect(trs.value).toBe(0);
     await tab.waitForLoad(LocationStatus.PaintingStable);
-    const trs2 = await tab.execJsPath<{ length: number }>(
-      ['document', ['querySelectorAll', '.record']],
-      ['length'],
-    );
-    expect(trs2.value.length).toBe(200 * 4);
+    const trs2 = await tab.execJsPath<number>([
+      'document',
+      ['querySelectorAll', '.record'],
+      'length',
+    ]);
+    expect(trs2.value).toBe(200 * 4);
   });
 });
 

--- a/core/test/tab.test.ts
+++ b/core/test/tab.test.ts
@@ -50,7 +50,7 @@ describe('basic Tab tests', () => {
 
     await expect(
       tab.waitForElement(['document', ['querySelector', 'a#notthere']], { timeoutMs: 500 }),
-    ).rejects.toThrowError(/Timeout waiting for element .* to be visible/);
+    ).rejects.toThrowError(/Timeout waiting for element to be visible/);
   });
 
   it('will wait for an element to be visible', async () => {

--- a/emulate-browsers/base/injected-scripts/_proxyUtils.ts
+++ b/emulate-browsers/base/injected-scripts/_proxyUtils.ts
@@ -85,7 +85,6 @@ function proxyConstructor<T, K extends keyof T>(
 ) {
   const descriptor = Object.getOwnPropertyDescriptor(owner, key);
   const toString = descriptor.value.toString();
-
   descriptor.value = new Proxy(descriptor.value, {
     construct() {
       try {
@@ -96,6 +95,7 @@ function proxyConstructor<T, K extends keyof T>(
       } catch (err) {
         throw cleanErrorStack(err);
       }
+      return ReflectCached.construct(...arguments);
     },
   });
   overriddenFns.set(descriptor.value, toString);

--- a/emulate-browsers/base/lib/DomOverridesBuilder.ts
+++ b/emulate-browsers/base/lib/DomOverridesBuilder.ts
@@ -57,7 +57,7 @@ export default class DomOverridesBuilder {
 
     if (name.startsWith('polyfill.')) {
       wrapper = `// if main frame and HTML element not loaded yet, give it a sec
-  if (window.self === window.top && !document.documentElement) {
+  if (!document.documentElement) {
     new MutationObserver((list, observer) => {
       observer.disconnect();
       ${wrapper}

--- a/emulate-humans/ghost/index.ts
+++ b/emulate-humans/ghost/index.ts
@@ -129,6 +129,7 @@ export default class HumanEmulatorGhost {
 
     const targetRect = await helper.lookupBoundingRect(
       nodeId ? [nodeId] : interactionStep.mousePosition,
+      true,
     );
 
     const targetPoint = getRandomRectPoint(targetRect, HumanEmulatorGhost.boxPaddingPercent);
@@ -136,7 +137,7 @@ export default class HumanEmulatorGhost {
     const didMoveMouse = await this.moveMouseToPoint(targetPoint, targetRect.width, run, helper);
 
     const finalRect = didMoveMouse
-      ? await helper.lookupBoundingRect([targetRect.nodeId], true)
+      ? await helper.lookupBoundingRect([targetRect.nodeId], true, true)
       : targetRect;
 
     const isFinalRectVisible = this.isRectVisible(finalRect, helper);

--- a/full-client/test/document.test.ts
+++ b/full-client/test/document.test.ts
@@ -109,7 +109,7 @@ describe('basic Document tests', () => {
     }
   });
 
-  it('can re-await an element to refresh the underlying attached nodeids', async () => {
+  it('can re-await an element to refresh the underlying nodePointer ids', async () => {
     koaServer.get('/refresh-element', ctx => {
       ctx.body = `
         <body>
@@ -216,18 +216,55 @@ describe('basic Document tests', () => {
     });
     const agent = await openBrowser(`/isVisible`);
     const { document } = agent;
-    await expect(agent.isElementVisible(document.querySelector('#elem-1'))).resolves.toBe(true);
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-1')),
+    ).resolves.toMatchObject({
+      isVisible: true,
+    });
     // visibility
-    await expect(agent.isElementVisible(document.querySelector('#elem-2'))).resolves.toBe(false);
-    await expect(agent.isElementVisible(document.querySelector('#elem-3'))).resolves.toBe(true);
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-2')),
+    ).resolves.toMatchObject({
+      isVisible: false,
+      hasCssVisibility: false,
+    });
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-3')),
+    ).resolves.toMatchObject({
+      isVisible: true,
+    });
     // layout
-    await expect(agent.isElementVisible(document.querySelector('#elem-4'))).resolves.toBe(false);
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-4')),
+    ).resolves.toMatchObject({
+      isVisible: false,
+      hasDimensions: false,
+    });
     // opacity
-    await expect(agent.isElementVisible(document.querySelector('#elem-5'))).resolves.toBe(false);
-    await expect(agent.isElementVisible(document.querySelector('#elem-6'))).resolves.toBe(true);
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-5')),
+    ).resolves.toMatchObject({
+      isVisible: false,
+      hasCssOpacity: false,
+    });
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-6')),
+    ).resolves.toMatchObject({
+      isVisible: true,
+    });
     // overlay
-    await expect(agent.isElementVisible(document.querySelector('#elem-7'))).resolves.toBe(true);
-    await expect(agent.isElementVisible(document.querySelector('#elem-8'))).resolves.toBe(false);
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-7')),
+    ).resolves.toMatchObject({
+      isVisible: true,
+      isUnobstructedByOtherElements: true,
+    });
+    await expect(
+      agent.getComputedVisibility(document.querySelector('#elem-8')),
+    ).resolves.toMatchObject({
+      isVisible: false,
+      isUnobstructedByOtherElements: false,
+    });
   });
 
   it('can get computed styles', async () => {

--- a/interfaces/AllowedNames.ts
+++ b/interfaces/AllowedNames.ts
@@ -1,6 +1,12 @@
 type FilterFlags<Base, Condition> = {
   [Key in keyof Base]: Base[Key] extends Condition ? Key : never;
 };
+
+type FilterOutFlags<Base, Condition> = {
+  [Key in keyof Base]: Base[Key] extends Condition ? never : Key;
+};
+
+type OnlyProperties<Base> = FilterOutFlags<Base, (...args: any[]) => any>[keyof Base];
 type AllowedNames<Base, Condition> = FilterFlags<Base, Condition>[keyof Base];
 
-export { FilterFlags, AllowedNames };
+export { FilterFlags, AllowedNames, OnlyProperties };

--- a/interfaces/AllowedNames.ts
+++ b/interfaces/AllowedNames.ts
@@ -9,4 +9,4 @@ type FilterOutFlags<Base, Condition> = {
 type OnlyProperties<Base> = FilterOutFlags<Base, (...args: any[]) => any>[keyof Base];
 type AllowedNames<Base, Condition> = FilterFlags<Base, Condition>[keyof Base];
 
-export { FilterFlags, AllowedNames, OnlyProperties };
+export { FilterOutFlags, FilterFlags, AllowedNames, OnlyProperties };

--- a/interfaces/AwaitedDom.ts
+++ b/interfaces/AwaitedDom.ts
@@ -1,6 +1,6 @@
 import XPathResult from 'awaited-dom/impl/official-klasses/XPathResult';
 import Node from 'awaited-dom/impl/official-klasses/Node';
-import IAttachedState from 'awaited-dom/base/IAttachedState';
+import INodePointer from 'awaited-dom/base/INodePointer';
 
 // export these 2 so you can access the static readonly properties (e.g., XPathResult.ANY_RESULT)
-export { XPathResult, Node, IAttachedState };
+export { XPathResult, Node, INodePointer };

--- a/interfaces/IDevtoolsSession.ts
+++ b/interfaces/IDevtoolsSession.ts
@@ -1,10 +1,28 @@
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
+import ITypedEventEmitter from './ITypedEventEmitter';
+import { FilterFlags, FilterOutFlags } from './AllowedNames';
 
-export default interface IDevtoolsSession {
+export declare type DevtoolsEvents = {
+  [Key in keyof ProtocolMapping.Events]: ProtocolMapping.Events[Key][0];
+} & { disconnected: void };
+
+type DevtoolsCommandParams = {
+  [Key in keyof ProtocolMapping.Commands]: ProtocolMapping.Commands[Key]['paramsType'][0];
+};
+type OptionalParamsCommands = keyof FilterFlags<DevtoolsCommandParams, void | never>;
+type RequiredParamsCommands = keyof FilterOutFlags<DevtoolsCommandParams, void | never>;
+
+export default interface IDevtoolsSession
+  extends Omit<ITypedEventEmitter<DevtoolsEvents>, 'waitOn'> {
   id: string;
-  send<T extends keyof ProtocolMapping.Commands>(
+  send<T extends RequiredParamsCommands>(
     method: T,
-    params: ProtocolMapping.Commands[T]['paramsType'][0],
+    params: DevtoolsCommandParams[T],
+    sendInitiator?: object,
+  ): Promise<ProtocolMapping.Commands[T]['returnType']>;
+  send<T extends OptionalParamsCommands>(
+    method: T,
+    params?: DevtoolsCommandParams[T],
     sendInitiator?: object,
   ): Promise<ProtocolMapping.Commands[T]['returnType']>;
 

--- a/interfaces/IElementRect.ts
+++ b/interfaces/IElementRect.ts
@@ -1,10 +1,10 @@
+import { INodeVisibility } from './INodeVisibility';
+
 export default interface IElementRect {
-  top: number;
-  right: number;
-  bottom: number;
-  left: number;
+  y: number;
+  x: number;
   height: number;
   width: number;
   tag: string;
-  isVisible?: boolean;
+  nodeVisibility?: INodeVisibility;
 }

--- a/interfaces/IExecJsPathResult.ts
+++ b/interfaces/IExecJsPathResult.ts
@@ -1,6 +1,9 @@
-import IAttachedState from 'awaited-dom/base/IAttachedState';
+import INodePointer from 'awaited-dom/base/INodePointer';
+import { IJsPathError } from './IJsPathError';
 
 export default interface IExecJsPathResult<T = any> {
   value: T;
-  attachedState?: IAttachedState;
+  isValueSerialized?: boolean;
+  pathError?: IJsPathError;
+  nodePointer?: INodePointer;
 }

--- a/interfaces/IInteractionsHelper.ts
+++ b/interfaces/IInteractionsHelper.ts
@@ -4,12 +4,25 @@ import IRect from './IRect';
 import IPoint from './IPoint';
 import IViewport from './IViewport';
 import { IBoundLog } from './ILog';
+import { INodeVisibility } from './INodeVisibility';
 
 export default interface IInteractionsHelper {
   lookupBoundingRect(
     mousePosition: IMousePosition,
-  ): Promise<IRect & { elementTag?: string; nodeId?: number; isNodeVisible?: boolean }>;
-  createMouseupTrigger(nodeId: number): Promise<{ didTrigger: () => Promise<IMouseUpResult> }>;
+    throwIfNotPresent?: boolean,
+    includeNodeVisibility?: boolean,
+  ): Promise<
+    IRect & {
+      elementTag?: string;
+      nodeId?: number;
+      nodeVisibility?: INodeVisibility;
+    }
+  >;
+  createMouseupTrigger(
+    nodeId: number,
+  ): Promise<{
+    didTrigger: (mousePosition: IMousePosition, throwOnFail?: boolean) => Promise<IMouseUpResult>;
+  }>;
   createMouseoverTrigger(nodeId: number): Promise<{ didTrigger: () => Promise<boolean> }>;
   mousePosition: IPoint;
   scrollOffset: Promise<IPoint>;

--- a/interfaces/IJsPathError.ts
+++ b/interfaces/IJsPathError.ts
@@ -1,0 +1,9 @@
+import { IPathStep } from 'awaited-dom/base/AwaitedPath';
+
+export interface IJsPathError {
+  error: string;
+  pathState: {
+    step: IPathStep;
+    index: number;
+  };
+}

--- a/interfaces/IMouseUpResult.ts
+++ b/interfaces/IMouseUpResult.ts
@@ -1,7 +1,12 @@
+import { INodeVisibility } from './INodeVisibility';
+
 export default interface IMouseUpResult {
   pageX: number;
   pageY: number;
   targetNodeId: number;
   relatedTargetNodeId: number;
   didClickLocation: boolean;
+  targetNodePreview?: string;
+  expectedNodePreview?: string;
+  expectedNodeVisibility?: INodeVisibility;
 }

--- a/interfaces/INodeVisibility.ts
+++ b/interfaces/INodeVisibility.ts
@@ -1,0 +1,17 @@
+import IElementRect from './IElementRect';
+
+export interface INodeVisibility {
+  isVisible?: boolean;
+  nodeExists?: boolean;
+  isOnscreenVertical?: boolean;
+  isOnscreenHorizontal?: boolean;
+  hasContainingElement?: boolean;
+  isConnected?: boolean;
+  hasCssOpacity?: boolean;
+  hasCssDisplay?: boolean;
+  hasCssVisibility?: boolean;
+  hasDimensions?: boolean;
+  obstructedByElementId?: number;
+  isUnobstructedByOtherElements?: boolean;
+  boundingClientRect?: IElementRect;
+}

--- a/interfaces/getAttachedStateFnName.ts
+++ b/interfaces/getAttachedStateFnName.ts
@@ -1,2 +1,0 @@
-const getAttachedStateFnName = '__getSecretAgentNodeState__';
-export default getAttachedStateFnName;

--- a/interfaces/getNodePointerFnName.ts
+++ b/interfaces/getNodePointerFnName.ts
@@ -1,0 +1,2 @@
+const getNodePointerFnName = '__get_pointer__';
+export default getNodePointerFnName;

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -4,7 +4,7 @@
   "description": "Core interfaces used by SecretAgent",
   "dependencies": {
     "@secret-agent/interfaces": "1.4.1-alpha.4",
-    "awaited-dom": "1.1.12",
+    "awaited-dom": "1.2.1",
     "devtools-protocol": "^0.0.799653"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
   ],
   globalTeardown: './jest.teardown.js',
   globalSetup: './jest.setup.js',
+  setupFilesAfterEnv: ['./jest.setupPerTest.js'],
   testTimeout: 10e3,
   reporters: ['default', 'jest-summary-reporter'],
   roots: workspaces.map(x => `${x}/`),

--- a/jest.setupPerTest.js
+++ b/jest.setupPerTest.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const SetupAwaitedHandler = require('@secret-agent/client/lib/SetupAwaitedHandler');
+
+// Jest tries to deeply recursively extract properties from objects when a test breaks - this does not play nice with AwaitedDom
+const originGetProperty = SetupAwaitedHandler.delegate.getProperty;
+SetupAwaitedHandler.delegate.getProperty = function (...args) {
+  const parentPath = new Error().stack;
+  if (parentPath.includes('deepCyclicCopy')) {
+    return null;
+  }
+  // eslint-disable-next-line prefer-rest-params
+  return originGetProperty(...args);
+};

--- a/mitm-socket/lib/BaseIpcHandler.ts
+++ b/mitm-socket/lib/BaseIpcHandler.ts
@@ -111,7 +111,11 @@ export default abstract class BaseIpcHandler {
     this.ipcSocket = socket;
     this.ipcSocket.on('data', this.onIpcData.bind(this));
     this.ipcSocket.on('error', err => {
-      if (!this.isClosing) this.logger.error(`${this.handlerName}.error`, err);
+      // wait a sec to see if we're shutting down
+      setImmediate(error => {
+        if (!this.isClosing && !this.isExited)
+          this.logger.error(`${this.handlerName}.error`, { error });
+      }, err);
     });
 
     this.waitForConnect.resolve();

--- a/mitm/lib/MitmProxy.ts
+++ b/mitm/lib/MitmProxy.ts
@@ -233,6 +233,7 @@ export default class MitmProxy {
     socket: net.Socket,
     head: Buffer,
   ): Promise<void> {
+    if (this.isClosing) return;
     const sessionId = this.readSessionId(request.headers, request.socket.remotePort);
     if (!sessionId) {
       return RequestSession.sendNeedsAuth(socket);
@@ -422,6 +423,8 @@ export default class MitmProxy {
 
   private static async getCertificate(host: string): Promise<{ cert: string; key: string }> {
     const { networkDb, certificateGenerator } = this;
+
+    if (!certificateGenerator) return null;
 
     await certificateGenerator.waitForConnected;
     const key = await certificateGenerator.getPrivateKey();

--- a/puppet-chrome/lib/ConsoleMessage.ts
+++ b/puppet-chrome/lib/ConsoleMessage.ts
@@ -40,14 +40,12 @@ export default class ConsoleMessage {
   }
 
   static exceptionToError(exceptionDetails: ExceptionDetails) {
-    let message = exceptionDetails.text;
+    const error = new Error(exceptionDetails.text);
     if (exceptionDetails.exception) {
-      message = stringifyRemoteObject(exceptionDetails.exception);
+      error.stack = stringifyRemoteObject(exceptionDetails.exception);
     } else if (exceptionDetails.stackTrace) {
-      message += this.printStackTrace(exceptionDetails.stackTrace);
+      error.stack = this.printStackTrace(exceptionDetails.stackTrace);
     }
-    const error = new Error(message);
-    error.stack = message;
     return error;
   }
 

--- a/puppet-chrome/lib/DevtoolsSession.ts
+++ b/puppet-chrome/lib/DevtoolsSession.ts
@@ -23,6 +23,7 @@ import { TypedEventEmitter } from '@secret-agent/commons/eventUtils';
 import IResolvablePromise from '@secret-agent/interfaces/IResolvablePromise';
 import { createPromise } from '@secret-agent/commons/utils';
 import IDevtoolsSession, {
+  DevtoolsEvents,
   IDevtoolsEventMessage,
   IDevtoolsResponseMessage,
 } from '@secret-agent/interfaces/IDevtoolsSession';
@@ -35,7 +36,7 @@ import RemoteObject = Protocol.Runtime.RemoteObject;
  *
  * https://chromedevtools.github.io/devtools-protocol/
  */
-export class DevtoolsSession extends EventEmitter implements IDevtoolsSession {
+export class DevtoolsSession extends TypedEventEmitter<DevtoolsEvents> implements IDevtoolsSession {
   public connection: Connection;
   public messageEvents = new TypedEventEmitter<IMessageEvents>();
   public get id() {
@@ -88,7 +89,7 @@ export class DevtoolsSession extends EventEmitter implements IDevtoolsSession {
   onMessage(object: IDevtoolsResponseMessage & IDevtoolsEventMessage): void {
     this.messageEvents.emit('receive', { ...object });
     if (!object.id) {
-      this.emit(object.method, object.params);
+      this.emit(object.method as any, object.params);
       return;
     }
 

--- a/puppet-chrome/lib/Worker.ts
+++ b/puppet-chrome/lib/Worker.ts
@@ -5,6 +5,7 @@ import Protocol from 'devtools-protocol';
 import { IPuppetWorker, IPuppetWorkerEvents } from '@secret-agent/interfaces/IPuppetWorker';
 import { createPromise } from '@secret-agent/commons/utils';
 import { IBoundLog } from '@secret-agent/interfaces/ILog';
+import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import { BrowserContext } from './BrowserContext';
 import { DevtoolsSession } from './DevtoolsSession';
 import { NetworkManager } from './NetworkManager';
@@ -80,6 +81,7 @@ export class Worker extends TypedEventEmitter<IPuppetWorkerEvents> implements IP
       this.devtoolsSession.send('Runtime.enable'),
       emulator?.onNewPuppetWorker
         ? emulator.onNewPuppetWorker(this).catch(error => {
+            if (error instanceof CanceledPromiseError) return;
             this.logger.error('Emulator.onNewPuppetWorkerError', {
               error,
             });

--- a/puppet/test/Worker.test.ts
+++ b/puppet/test/Worker.test.ts
@@ -94,7 +94,7 @@ describe('Worker test', () => {
      })()`,
     );
     const { error } = await errorPromise;
-    expect(error.message).toContain('this is my error');
+    expect(error.stack).toContain('this is my error');
   });
 
   it('should clear upon navigation', async () => {

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -316,9 +316,9 @@ Alias for [Tab.goForward](/docs/basic-interfaces/tab#forward)
 
 Alias for [Tab.goto](/docs/basic-interfaces/tab#goto)
 
-### agent.isElementVisible*(element)*
+### agent.getComputedVisibility*(element)*
 
-Alias for [Tab.isElementVisible](/docs/basic-interfaces/tab#is-element-visible)
+Alias for [Tab.getComputedVisibility](/docs/basic-interfaces/tab#get-computed-visibility)
 
 ### agent.reload*(timeoutMs?)*
 

--- a/website/docs/BasicInterfaces/FrameEnvironment.md
+++ b/website/docs/BasicInterfaces/FrameEnvironment.md
@@ -122,10 +122,9 @@ const response = await mainFrame.fetch(postUrl, {
 });
 ```
 
-
 ### frameEnvironment.getFrameEnvironment*(frameElement)* {#find-frame}
 
-Get the [FrameEnvironment](/docs/basic-interfaces/frame-environment) object corresponding to the provided HTMLFrameElement or HTMLIFrameElement. Use this function to attach to the full environment of the given DOM element. 
+Get the [FrameEnvironment](/docs/basic-interfaces/frame-environment) object corresponding to the provided HTMLFrameElement or HTMLIFrameElement. Use this function to attach to the full environment of the given DOM element.
 
 #### **Arguments**:
 
@@ -141,7 +140,6 @@ const iframeElement = document.querySelector('iframe.interactive');
 const iframe = await agent.findFrame(iframeElement);
 
 const h4 = await iframe.document.querySelector('h4').textContent; // should be something like HTML demo: <iframe>
-
 ```
 
 ### frameEnvironment.getComputedStyle*(element, pseudoElement)* <div class="specs"><i>W3C</i></div> {#computed-style}
@@ -162,6 +160,37 @@ const selector = document.querySelector('h1');
 const style = await getComputedStyle(selector);
 const opacity = await style.getProperty('opacity');
 ```
+
+### frameEnvironment.getComputedVisibility*(element)* {#get-computed-visibility}
+
+Determines if a node from the [mainFrameEnvironment](#main-frame-environment) is visible to an end user. This method checks whether a node (or containing element) has:
+
+- layout: width, height, x and y.
+- opacity: non-zero opacity.
+- css visibility: the element does not have a computed style where visibility=hidden.
+- no overlay: no other element which overlays more than one fourth of this element and has at least 1 pixel over the center of the element.
+- on the visible screen (not beyond the horizontal or vertical viewport)
+
+Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/basic-interfaces/frame-environment#get-computed-visibility).
+
+#### **Arguments**:
+
+- node [`SuperNode`](/docs/awaited-dom/super-node). The node to compute visibility.
+
+#### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
+
+- INodeVisibility `object`
+  - isVisible `boolean`. Is the node ultimately visible (convenience sum of other properties).
+  - isFound `boolean`. Was the node found in the DOM.
+  - isOnscreenVertical `boolean`. The node is on-screen vertically.
+  - isOnscreenHorizontal `boolean`. The node is on-screen horizontally.
+  - hasContainingElement `boolean`. The node is an element or has a containing Element providing layout.
+  - isConnected `boolean`. The node is connected to the DOM.
+  - hasCssOpacity `boolean`. The display `opacity` property is not "0".
+  - hasCssDisplay `boolean`. The display `display` property is not "none".
+  - hasCssVisibility `boolean`. The visibility `style` property is not "hidden".
+  - hasDimensions `boolean`. The node has width and height.
+  - isUnobstructedByOtherElements `boolean`. The node is not hidden or obscured > 50% by another element.
 
 ### frameEnvironment.getJsValue*(path)* {#get-js-value}
 
@@ -216,7 +245,7 @@ Wait until a specific element is present in the dom.
 - element [`SuperElement`](/docs/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
-  - waitForVisible `boolean`. Wait until this element is visible to a user (see [isElementVisible](#is-element-visible).
+  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visility).
 
 #### **Returns**: `Promise`
 

--- a/website/docs/BasicInterfaces/Tab.md
+++ b/website/docs/BasicInterfaces/Tab.md
@@ -216,22 +216,36 @@ Executes a navigation request for the document associated with the parent Secret
 
 #### **Returns**: [`Promise<Resource>`](/docs/advanced/resource) The loaded resource representing this page.
 
-### tab.isElementVisible*(element)* {#is-element-visible}
+### tab.getComputedVisibility*(node)* {#get-computed-visibility}
 
-Determines if an element from the [mainFrameEnvironment](#main-frame-environment) is visible to an end user. This method checks whether an element has:
+Determines if a node from the [mainFrameEnvironment](#main-frame-environment) is visible to an end user. This method checks whether a node (or containing element) has:
 
 - layout: width, height, x and y.
 - opacity: non-zero opacity.
 - css visibility: the element does not have a computed style where visibility=hidden.
 - no overlay: no other element which overlays more than one fourth of this element and has at least 1 pixel over the center of the element.
+- on the visible screen (not beyond the horizontal or vertical viewport)
 
-Alias for [tab.mainFrameEnvironment.isElementVisible](/docs/basic-interfaces/frame-environment#is-element-visible).
+Alias for [tab.mainFrameEnvironment.getComputedVisibility](/docs/basic-interfaces/frame-environment#get-computed-visibility).
 
 #### **Arguments**:
 
-- element [`SuperElement`](/docs/awaited-dom/super-element). The element to determine visibility.
+- node [`SuperNode`](/docs/awaited-dom/super-node). The node to determine visibility.
 
-#### **Returns**: `Promise<boolean>` Whether the element is visible to an end user.
+#### **Returns**: `Promise<INodeVisibility>` Boolean values indicating if the node (or closest element) is visible to an end user.
+
+- INodeVisibility `object`
+  - isVisible `boolean`. Is the node ultimately visible.
+  - isFound `boolean`. Was the node found in the DOM.
+  - isOnscreenVertical `boolean`. The node is on-screen vertically.
+  - isOnscreenHorizontal `boolean`. The node is on-screen horizontally.
+  - hasContainingElement `boolean`. The node is an Element or has a containing Element providing layout. 
+  - isConnected `boolean`. The node is connected to the DOM.
+  - hasCssOpacity `boolean`. The display `opacity` property is not "0".
+  - hasCssDisplay `boolean`. The display `display` property is not "none".
+  - hasCssVisibility `boolean`. The visibility `style` property is not "hidden".
+  - hasDimensions `boolean`. The node has width and height.
+  - isUnobstructedByOtherElements `boolean`. The node is not hidden or obscured > 50% by another element.
 
 ### tab.reload*(timeoutMs?)* {#reload}
 
@@ -281,7 +295,7 @@ Alias for [tab.mainFrameEnvironment.waitForElement](/docs/basic-interfaces/frame
 - element [`SuperElement`](/docs/awaited-dom/super-element)
 - options `object` Accepts any of the following:
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
-  - waitForVisible `boolean`. Wait until this element is visible to a user (see [isElementVisible](#is-element-visible).
+  - waitForVisible `boolean`. Wait until this element is visible to a user (see [getComputedVisibility](#get-computed-visibility).
 
 #### **Returns**: `Promise`
 

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@microflash/gridsome-plugin-feed": "^1.2.1",
     "@types/json2md": "^1.5.0",
     "@types/lodash.kebabcase": "^4.1.6",
-    "awaited-dom": "1.1.12",
+    "awaited-dom": "1.2.1",
     "babel-runtime": "^6.26.0",
     "decamelize": "^4.0.0",
     "docsearch.js": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4421,10 +4421,10 @@ autoprefixer@^9.4.7, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awaited-dom@1.1.12:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.1.12.tgz#92ec9fa9916a689d299b9e3ad66a26271b2e9cd3"
-  integrity sha512-N8CjUxxxqCOPQtcuRtedDw5Rt3G4E2ZjIqitQfgJ5DQ5PQ8QW/Kauu2B0UF2ZMXE4fzJbm2k5SU+XdO2WiCOGA==
+awaited-dom@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.2.1.tgz#1d8a5127d9df7e6988b5781db89a0eb53c785b58"
+  integrity sha512-b9kKF8pyHWK3JMODk+/bN1psPSAD0z9DxN2VlKGUc1RFCGotulxLYcoLLRFezgYR5Ph6fz1GdX4YuJRhvtOPyw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR pulls in the latest noderdom, which changes attachedState into "nodepointers".

There are a few other fixes/changes in this PR:
1) Improve messages when not clicking on the right nodes in "interactor"
2) Migrate isElementVisible to "getComputedVisiblity". (isElementVisible is left as a deprecated client property for now)
3) Add "typing" to devtools api events (now accessible from browser emulators)
4) Fix "isHeaded" flags for new browser emulator structure