### PR TITLE
feat(client): allow awaiting xpath

### DIFF
--- a/client/lib/CoreCommandQueue.ts
+++ b/client/lib/CoreCommandQueue.ts
@@ -2,6 +2,7 @@ import ISessionMeta from '@secret-agent/interfaces/ISessionMeta';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import Queue from '@secret-agent/commons/Queue';
 import ConnectionToCore from '../connections/ConnectionToCore';
+import { convertJsPathArgs } from './SetupAwaitedHandler';
 
 export default class CoreCommandQueue {
   public lastCommandId = 0;
@@ -31,6 +32,11 @@ export default class CoreCommandQueue {
   public run<T>(command: string, ...args: any[]): Promise<T> {
     if (this.connection.isDisconnecting) {
       return Promise.resolve(null);
+    }
+    for (const arg of args) {
+      if (Array.isArray(arg)) {
+        convertJsPathArgs(arg);
+      }
     }
     return this.internalQueue
       .run<T>(async () => {

--- a/jest.setupPerTest.js
+++ b/jest.setupPerTest.js
@@ -3,7 +3,7 @@ const SetupAwaitedHandler = require('@secret-agent/client/lib/SetupAwaitedHandle
 
 // Jest tries to deeply recursively extract properties from objects when a test breaks - this does not play nice with AwaitedDom
 const originGetProperty = SetupAwaitedHandler.delegate.getProperty;
-SetupAwaitedHandler.delegate.getProperty = function (...args) {
+SetupAwaitedHandler.delegate.getProperty = function getProperty(...args) {
   const parentPath = new Error().stack;
   if (parentPath.includes('deepCyclicCopy')) {
     return null;

--- a/puppet-chrome/lib/DevtoolsSession.ts
+++ b/puppet-chrome/lib/DevtoolsSession.ts
@@ -17,7 +17,6 @@
 
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
 import { Protocol } from 'devtools-protocol';
-import { EventEmitter } from 'events';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import { TypedEventEmitter } from '@secret-agent/commons/eventUtils';
 import IResolvablePromise from '@secret-agent/interfaces/IResolvablePromise';


### PR DESCRIPTION
This PR just adds a test for awaiting xpath result nodes. We needed to ensure we were serializing any jspath args in general, so this adds that capability.

Resolves #239 