### PR TITLE
fix(mitm): fix install script, reuse same h2 conn

### DIFF
--- a/client/lib/ResourceResponse.ts
+++ b/client/lib/ResourceResponse.ts
@@ -68,7 +68,7 @@ export default class ResourceResponse {
   }
 
   public text(): Promise<string> {
-    return this.data.then(x => x.toString());
+    return this.data.then(x => x?.toString());
   }
 
   public json(): Promise<any> {

--- a/emulate-browsers/base/lib/modifyHeaders.ts
+++ b/emulate-browsers/base/lib/modifyHeaders.ts
@@ -26,7 +26,8 @@ export default function modifyHeaders(
     let hasKeepAlive = false;
     for (const [header, value] of Object.entries(headers)) {
       let key = header;
-      if (resource.isServerHttp2 === false) {
+      // don't capitalize sec-ch-ua headers!
+      if (resource.isServerHttp2 === false && !header.match(/^sec-ch-ua/i)) {
         key = key
           .split('-')
           .map(x => `${x[0].toUpperCase()}${x.slice(1)}`)

--- a/mitm-socket/install.js
+++ b/mitm-socket/install.js
@@ -103,7 +103,7 @@ function buildFilename() {
   let platform = String(os.platform());
   let arch = os.arch();
   if (arch === 'x64') arch = 'x86_64';
-  if (arch === 'ia32') arch = '386';
+  if (arch === 'ia32') arch = 'i386';
 
   if (platform === 'win32') {
     platform = 'win';


### PR DESCRIPTION
1. Fix mitm/install.js for 32 bit windows installs
2. Reuse http2 connections when they resolve to the same host
3. Don't blow up if no http response is returned

Resolves #241 