### PR TITLE
Interactor should be able to provide string commands, like examples

### DIFF
--- a/client/lib/Interactor.ts
+++ b/client/lib/Interactor.ts
@@ -49,7 +49,7 @@ export default class Interactor {
 }
 
 function convertToInteractionGroups(interactions: IInteractions): IInteractionGroups {
-  const lastPosition: IMousePosition = [0, 0];
+  let lastPosition: ICoreMousePosition = [0, 0];
   const interactionGroups: IInteractionGroups = [];
   interactions.forEach(interaction => {
     if (typeof interaction === 'string') {
@@ -58,6 +58,7 @@ function convertToInteractionGroups(interactions: IInteractions): IInteractionGr
       interactionGroups.push([interactionStep]);
     } else {
       const interactionGroup = convertInteractionToInteractionGroup(interaction);
+      lastPosition = interactionGroup[interactionGroup.length - 1].mousePosition;
       interactionGroups.push(interactionGroup);
     }
   });

--- a/core/models/ResourcesTable.ts
+++ b/core/models/ResourcesTable.ts
@@ -50,6 +50,15 @@ export default class ResourcesTable extends SqliteTable<IResourcesRecord> {
     );
   }
 
+  public updateResource(id: number, data: { tabId: number; browserRequestId: string }): void {
+    if (this.hasPending(x => x[0] === id)) {
+      this.flush();
+    }
+    this.db
+      .prepare(`update ${this.tableName} set tabId=?, devtoolsRequestId=? where id=?`)
+      .run(data.tabId, data.browserRequestId, id);
+  }
+
   public insert(
     tabId: number,
     meta: IResourceMeta,

--- a/mitm/lib/DnsOverTlsSocket.ts
+++ b/mitm/lib/DnsOverTlsSocket.ts
@@ -85,7 +85,9 @@ export default class DnsOverTlsSocket {
     this.mitmSocket.on('eof', async () => {
       removeEventListeners([registration]);
       this.mitmSocket.close();
-      await this.connect();
+      this.isConnected = this.connect();
+
+      await this.isConnected;
       // re-run pending queries
       for (const [id, entry] of this.pending) {
         this.pending.delete(id);

--- a/mitm/test/dns.test.ts
+++ b/mitm/test/dns.test.ts
@@ -84,17 +84,17 @@ describe('DnsOverTlsSocket', () => {
     }
   });
 
-  // this test has to wait for the upstream to disconnect, so skip by default
-  test.skip('should be able to lookup a record after a miss', async () => {
+  test('should be able to lookup a record after a miss', async () => {
     const item1 = await cloudflareDnsSocket.lookupARecords('double-agent.collect');
     expect(item1).toBeTruthy();
-    await new Promise(resolve => setTimeout(resolve, 15e3));
+    // @ts-ignore - trigger internal eof
+    cloudflareDnsSocket.mitmSocket.emit('eof');
     const response = await Promise.all([
       cloudflareDnsSocket.lookupARecords('sub.double-agent.collect'),
       cloudflareDnsSocket.lookupARecords(' double-agent-external.collect'),
     ]);
     expect(response).toHaveLength(2);
-  }, 20e3);
+  });
 });
 
 test('should cache and round robin results', async () => {


### PR DESCRIPTION
Right now, if you pass in `interact({ move: element }, 'click')`, as per the examples, the second command tries to click at 0,0. This PR fixes the last location passed in.

In addition, this fixes some stability issues with tests