### PR TITLE
fix(mitm): proper errors when mitm binary missing

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -112,14 +112,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install mitm
-        run: yarn run build
-        working-directory: ./mitm-socket
-        env:
-          SA_REBUILD_MITM_SOCKET: true
-
-      - name: Copy built mitm
-        run: cp -r mitm-socket/dist build/mitm-socket
+      - name: Copy mitm source
+        run: cp -r mitm-socket/go build/mitm-socket/go
 
       - name: Build modules
         run: yarn --network-timeout 1000000
@@ -127,6 +121,7 @@ jobs:
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           SA_REPLAY_SKIP_BINARY_DOWNLOAD: 1
+          SA_REBUILD_MITM_SOCKET: 1
 
       - name: Linux - Apt Install Chrome(s)
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/commons/downloadFile.ts
+++ b/commons/downloadFile.ts
@@ -42,7 +42,10 @@ export default function downloadFile(
   }
 }
 
-function httpGet(url: string, response: (x: http.IncomingMessage) => void): http.ClientRequest {
+export function httpGet(
+  url: string,
+  response: (x: http.IncomingMessage) => void,
+): http.ClientRequest {
   const options = getRequestOptionsWithProxy(url);
   const httpModule = options.protocol === 'https:' ? https : http;
 

--- a/copyfiles.js
+++ b/copyfiles.js
@@ -16,13 +16,7 @@ const copyArgs = [
   '.*ignore',
 ];
 if (isBuild) {
-  copyArgs.push(
-    'testing/*/**',
-    'core/test/html/**',
-    'puppet/test/*/**',
-    'mitm-socket/dist/*',
-    'yarn.lock',
-  );
+  copyArgs.push('testing/*/**', 'core/test/html/**', 'puppet/test/*/**', 'yarn.lock');
 }
 
 for (const workspace of workspaces) {

--- a/mitm-socket/lib/BaseIpcHandler.ts
+++ b/mitm-socket/lib/BaseIpcHandler.ts
@@ -8,9 +8,13 @@ import { IBoundLog } from '@secret-agent/interfaces/ILog';
 import { CanceledPromiseError } from '@secret-agent/commons/interfaces/IPendingWaitEvent';
 import { bindFunctions } from '@secret-agent/commons/utils';
 import { createId, createIpcSocketPath } from '@secret-agent/commons/IpcUtils';
+import * as Fs from 'fs';
+import * as Path from 'path';
 
 const ext = os.platform() === 'win32' ? '.exe' : '';
-const libPath = `${__dirname}/../dist/connect${ext}`;
+const libPath = Path.join(__dirname, '/../dist/', `connect${ext}`);
+
+const distExists = Fs.existsSync(libPath);
 
 const { log } = Log(module);
 
@@ -41,6 +45,10 @@ export default abstract class BaseIpcHandler {
 
   protected constructor(options: Partial<IGoIpcOpts>) {
     this.options = this.getDefaultOptions(options);
+
+    if (!distExists) {
+      throw new Error(`Required files missing! The MitmSocket library was not found at ${libPath}`);
+    }
 
     const mode = this.options.mode;
     this.handlerName = `${mode[0].toUpperCase() + mode.slice(1)}IpcHandler`;

--- a/mitm-socket/package.build.json
+++ b/mitm-socket/package.build.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "postinstall": "node install.js"
+  }
+}

--- a/mitm-socket/package.json
+++ b/mitm-socket/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node install.js",
-    "build-install": "npm run build",
-    "postinstall": "npm run build"
+    "build-install": "npm run build"
   },
   "dependencies": {
     "@secret-agent/commons": "1.4.1-alpha.4",

--- a/replay/package.dist.json
+++ b/replay/package.dist.json
@@ -7,6 +7,7 @@
     "progress": "^2.0.3",
     "tar": "^6.1.0",
     "compare-versions": "^3.6.0",
-    "proper-lockfile": "^4.1.1"
+    "proper-lockfile": "^4.1.1",
+    "@secret-agent/commons": "^1.4.1-alpha.5"
   }
 }

--- a/replay/package.json
+++ b/replay/package.json
@@ -75,7 +75,8 @@
     "source-map-support": "^0.5.19",
     "tar": "^6.1.0",
     "uuid": "^8.3.2",
-    "ws": "^7.4.4"
+    "ws": "^7.4.4",
+    "@secret-agent/commons": "^1.4.1-alpha.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.113",


### PR DESCRIPTION
This PR adds proxy checking to the replay and mitm downloads. It also throws a more informative error when the mitm-socket was not installed

Closes #261 #262 