### PR TITLE
feat: dynamically require core extender plugins required by client

### DIFF
--- a/core/index.ts
+++ b/core/index.ts
@@ -39,6 +39,7 @@ export default class Core {
 
   public static onShutdown: () => void;
 
+  public static allowDynamicPluginDependencies = true;
   private static wasManuallyStarted = false;
   private static isClosing: Promise<void>;
   private static isStarting = false;

--- a/core/lib/Plugins.ts
+++ b/core/lib/Plugins.ts
@@ -20,6 +20,7 @@ import IPlugins from '@secret-agent/interfaces/IPlugins';
 import IPlugin, { IPluginClass } from '@secret-agent/interfaces/IPlugin';
 import IPluginCreateOptions from '@secret-agent/interfaces/IPluginCreateOptions';
 import IBrowserEngine from '@secret-agent/interfaces/IBrowserEngine';
+import { PluginTypes } from '@secret-agent/interfaces/IPluginTypes';
 import Core from '../index';
 
 const DefaultBrowserEmulatorId = 'default-browser-emulator';
@@ -30,9 +31,12 @@ interface IOptionsCreate {
   humanEmulatorId?: string;
   browserEmulatorId?: string;
   selectBrowserMeta?: ISelectBrowserMeta;
+  dependencyMap?: { [clientPluginId: string]: string[] };
 }
 
 export default class Plugins implements IPlugins {
+  public static pluginClassesById: { [id: string]: IPluginClass } = {};
+
   public readonly browserEngine: IBrowserEngine;
   public readonly browserEmulator: IBrowserEmulator;
   public readonly humanEmulator: IHumanEmulator;
@@ -45,6 +49,7 @@ export default class Plugins implements IPlugins {
   constructor(options: IOptionsCreate, logger: IBoundLog) {
     const {
       userAgentSelector,
+      dependencyMap,
       browserEmulatorId = DefaultBrowserEmulatorId,
       humanEmulatorId = DefaultHumanEmulatorId,
     } = options;
@@ -62,15 +67,36 @@ export default class Plugins implements IPlugins {
     const { browserEngine, userAgentOption } =
       options.selectBrowserMeta || BrowserEmulator.selectBrowserMeta(userAgentSelector);
     this.createOptions = { browserEngine, logger, plugins: this };
-    this.logger = logger;
     this.browserEngine = browserEngine;
+    this.logger = logger;
 
     this.browserEmulator = new BrowserEmulator(this.createOptions, userAgentOption);
     this.addPluginInstance(this.browserEmulator);
 
     this.humanEmulator = new HumanEmulator(this.createOptions);
     this.addPluginInstance(this.humanEmulator);
+
     Core.pluginMap.coreExtenders.forEach(x => this.use(x));
+
+    if (dependencyMap && Core.allowDynamicPluginDependencies) {
+      Object.entries(dependencyMap).forEach(([clientPluginId, dependentPluginIds]) => {
+        dependentPluginIds.forEach(pluginId => {
+          if (this.instanceById[pluginId]) return;
+          this.logger.info(`Dynamically using ${pluginId} required by ${clientPluginId}`);
+          const Plugin = this.require(pluginId);
+          if (!Plugin) {
+            this.logger.warn(`Could not find ${pluginId} required by ${clientPluginId}`);
+            return;
+          }
+          const CoreExtender = (Plugin as any).CoreExtender || Plugin;
+          if (CoreExtender.pluginType !== PluginTypes.CoreExtender) {
+            this.logger.warn(`Could not use ${pluginId} because it's not a CoreExtender`);
+            return;
+          }
+          this.use(CoreExtender);
+        });
+      });
+    }
   }
 
   // BROWSER EMULATORS
@@ -164,11 +190,26 @@ export default class Plugins implements IPlugins {
   // ADDING PLUGINS TO THE STACK
 
   public use(Plugin: IPluginClass) {
+    if (this.instanceById[Plugin.id]) return;
     this.addPluginInstance(new Plugin(this.createOptions));
   }
 
   private addPluginInstance(plugin: IPlugin) {
     this.instances.push(plugin);
     this.instanceById[plugin.id] = plugin;
+  }
+
+  private require(pluginId: string): IPluginClass {
+    if (!Plugins.pluginClassesById[pluginId]) {
+      try {
+        // eslint-disable-next-line global-require,import/no-dynamic-require
+        const Plugin = require(pluginId);
+        if (!Plugin) return;
+        Plugins.pluginClassesById[pluginId] = Plugin;
+      } catch (error) {
+        return;
+      }
+    }
+    return Plugins.pluginClassesById[pluginId];
   }
 }

--- a/core/lib/Plugins.ts
+++ b/core/lib/Plugins.ts
@@ -205,7 +205,7 @@ export default class Plugins implements IPlugins {
         // eslint-disable-next-line global-require,import/no-dynamic-require
         const Plugin = require(pluginId);
         if (!Plugin) return;
-        Plugins.pluginClassesById[pluginId] = Plugin;
+        Plugins.pluginClassesById[pluginId] = Plugin.default || Plugin;
       } catch (error) {
         return;
       }

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -94,9 +94,9 @@ export default class Session extends TypedEventEmitter<{
     this.logger = log.createChild(module, { sessionId: this.id });
     this.awaitedEventListener = new AwaitedEventListener(this);
 
-    const { userAgent: userAgentSelector, browserEmulatorId, humanEmulatorId } = options;
+    const { userAgent: userAgentSelector, browserEmulatorId, humanEmulatorId, dependencyMap } = options;
     this.plugins = new Plugins(
-      { userAgentSelector, browserEmulatorId, humanEmulatorId },
+      { userAgentSelector, browserEmulatorId, humanEmulatorId, dependencyMap },
       this.logger,
     );
 


### PR DESCRIPTION
ClientExtender plugins are allowed to specify an array of CoreExtender plugin IDs that it requires (see execute-js-plugin). However, those same CoreExtender plugins must be installed in Core. This can be frustrating/difficult since by default the Core is started automatically and in another process -- therefore, the developer has no easy access to adding the CoreExtender through Core.use().

This PR allows Core to automatically require the CoreExtender so long as it available through the node require. As a security precaution it checks to ensure the package is actually a CoreExtender.

Also, Core now includes a allowDynamicPluginDependencies static property that can be set to false (but is true by default). Setting this property to false disables the ability to dynamically require these CoreExtender dependencies.