### PR TITLE
feat(core): improve mouse message when not there

### DIFF
--- a/core/injected-scripts/MouseEvents.ts
+++ b/core/injected-scripts/MouseEvents.ts
@@ -11,6 +11,11 @@ class MouseEvents {
 
     const node = NodeTracker.getWatchedNodeWithId(nodeId);
     if (!node) throw new Error('Node not found');
+    if (!node.isConnected) {
+      throw new Error(
+        `Target node for "${mouseEvent}" is not connected to the DOM, and won't receive mouse events.`,
+      );
+    }
 
     if (mouseEvent === 'mouseover') {
       this.pendingMouseover = new EventResolvable(nodeId, () => {


### PR DESCRIPTION
Improves the messages when a dom node can't be hovered prior to clicking.