### PR TITLE
Fix iFrames not always rendering in Replay

### DIFF
--- a/core/injected-scripts/domReplayer.ts
+++ b/core/injected-scripts/domReplayer.ts
@@ -54,7 +54,8 @@ window.addEventListener('message', ev => {
     frameNodePath = ev.data.frameNodePath;
   }
   const event = ev.data.event;
-  replayDomEvent(event);
+  domChangeList.push(event);
+  if (document.readyState !== 'loading') applyDomChanges([]);
 });
 
 function applyDomChanges(changeEvents: IFrontendDomChangeEvent[]) {

--- a/replay/backend/api/ReplayTabState.ts
+++ b/replay/backend/api/ReplayTabState.ts
@@ -335,7 +335,7 @@ export default class ReplayTabState extends EventEmitter {
         const paint = this.paintEvents[i];
         if (!paint) continue;
         if (paint.timestamp === timestamp) {
-          paintEvent = paint[i];
+          paintEvent = paint;
           break;
         }
       }
@@ -346,7 +346,7 @@ export default class ReplayTabState extends EventEmitter {
       events.push(event);
 
       // if events are out of order, set the index of paints back to this index
-      if (events.length > 0 && events[events.length - 1].eventIndex > event.eventIndex) {
+      if (events.length > 1 && events[events.length - 2].eventIndex > event.eventIndex) {
         events.sort((a, b) => {
           if (a.frameIdPath === b.frameIdPath) {
             return a.eventIndex - b.eventIndex;

--- a/replay/injected-scripts/domReplayerSubscribe.ts
+++ b/replay/injected-scripts/domReplayerSubscribe.ts
@@ -15,12 +15,32 @@ window.getIsMainFrame = function () {
 };
 window.debugToConsole = false;
 
-console.log(
-  'Loaded: isMain=%s, pid=%s, href=%s',
-  window.getIsMainFrame(),
-  process?.pid,
-  window.location.href,
-);
+if (process.isMainFrame) {
+  console.log(`
+  __,                     _,
+ (                 _/_   / |               _/_
+  \`.  _  _, _   _  /    /--|  _,  _  _ _   /
+(___)(/_(__/ (_(/_(__ _/   |_(_)_(/_/ / /_(__
+                              /|
+                             (/
+`);
+  console.group('About SecretAgent Replay');
+  const osMessage =
+    process.platform === 'win32'
+      ? `\n\nWindows users: you can add this line to the beginning of your script 'process.env.SA_SHOW_BROWSER="true"'.`
+      : '';
+  console.log(
+    `This is a high fidelity %c"Replay"%c of your scraping session.
+
+It is NOT a live Chrome view, so if you notice Javascript is not loaded or cookies/console are not working, that's just because this is not the headless Chrome running your actual script :).
+
+To launch a real browser, use the env variable %cSA_SHOW_BROWSER=true${osMessage}`,
+    'font-weight:bold',
+    'font-weight:normal',
+    'background:#eee;padding:2px;',
+  );
+  console.groupEnd();
+}
 
 function debugLog(message: string, ...args: any[]) {
   if (window.debugToConsole) {
@@ -29,6 +49,13 @@ function debugLog(message: string, ...args: any[]) {
   if (!window.debugLogs) window.debugLogs = [];
   window.debugLogs.push({ message, args });
 }
+
+debugLog(
+  'Loaded: isMain=%s, pid=%s, href=%s',
+  window.getIsMainFrame(),
+  process?.pid,
+  window.location.href,
+);
 
 if (process.isMainFrame) {
   ipcRenderer.on(

--- a/website/docs/BasicInterfaces/FrameEnvironment.md
+++ b/website/docs/BasicInterfaces/FrameEnvironment.md
@@ -122,7 +122,7 @@ const response = await mainFrame.fetch(postUrl, {
 });
 ```
 
-### frameEnvironment.getFrameEnvironment*(frameElement)* {#find-frame}
+### frameEnvironment.getFrameEnvironment*(frameElement)* {#get-frame-environment}
 
 Get the [FrameEnvironment](/docs/basic-interfaces/frame-environment) object corresponding to the provided HTMLFrameElement or HTMLIFrameElement. Use this function to attach to the full environment of the given DOM element.
 
@@ -137,7 +137,7 @@ await agent.goto('https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ifra
 const { document } = agent.activeTab;
 const iframeElement = document.querySelector('iframe.interactive');
 
-const iframe = await agent.findFrame(iframeElement);
+const iframe = await agent.getFrameEnvironment(iframeElement);
 
 const h4 = await iframe.document.querySelector('h4').textContent; // should be something like HTML demo: <iframe>
 ```

--- a/website/docs/Overview/Configuration.md
+++ b/website/docs/Overview/Configuration.md
@@ -8,7 +8,7 @@ Configuration variables can be defined at a few levels:
 
 The internal `@secret-agent/core` module can receive several configuration options on [start](#core-start), or when a [Handler](/docs/basic-interfaces/handler) or [Agent](/docs/basic-interfaces/agent) establishes a [connection](/docs/advanced/connection-to-core).
 
-###  Connection To Core <div class="specs"><i>Agent</i></div>
+### Connection To Core <div class="specs"><i>Agent</i></div>
 
 The [ConnectionToCore](/docs/advanced/connection-to-core) to be used by a [Handler](/docs/basic-interfaces/handler) or [Agent](/docs/basic-interfaces/agent).
 
@@ -97,17 +97,9 @@ Configures a proxy url to route traffic through for a given Agent. This function
 
 An upstream proxy url should be a fully formatted url to the proxy. If your proxy is socks5, start it with `socks5://`, http `http://` or `https://` as needed. An upstream proxy url can optionally include the user authentication parameters in the url. It will be parsed out and used as the authentication.
 
-### Browsers Emulator Ids <div class="specs"><i>Connection</i><i>Agent</i><i>Core</i></div>
+### Browsers Emulator Id <div class="specs"><i>Agent</i></div>
 
-Configures which [BrowserEmulators](/docs/advanced/browser-emulators) to enable or use in a given Agent.
-
-At an Agent level, `browserEmulatorId` configures the module to use.
-
-- Configurable via [`Handler.createAgent()`](/docs/basic-interfaces/handler#create-agent) or [`Handler.dispatchAgent()`](/docs/basic-interfaces/handler#dispatch-agent).
-
-At a Connection or Core level, `browserEmulatorIds` indicates a list of modules to initialize before any Agents are created.
-
-- Configurable via [`Core.start()`](#core-start) or [`ConnectionToCore`](/docs/advanced/connection-to-core).
+Configures which [BrowserEmulator](/docs/advanced/browser-emulators) to use in a given Agent.
 
 ### Human Emulator Id <div class="specs"><i>Agent</i></div>
 
@@ -127,8 +119,6 @@ Update existing settings.
   - maxConcurrentAgentsCount `number` defaults to `10`. Limit concurrent Agent sessions running at any given time.
   - localProxyPortStart `number` defaults to `any open port`. Starting internal port to use for the mitm proxy.
   - sessionsDir `string` defaults to `os.tmpdir()/.secret-agent`. Directory to store session files and mitm certificates.
-  - defaultBlockedResourceTypes `string[]` defaults to `[None]`. Controls enabled browser resources.
-  - defaultUserProfile `IUserProfile`. Define user cookies, session, and more.
-  - replayServerPort `number`. Port to start a live replay server on. Defaults to "any open port".
+  - coreServerPort `number`. Port to run the Core Websocket/Replay server on.
 
 #### **Returns**: `Promise`


### PR DESCRIPTION
We were sometimes loading iframes too quickly in replay, which made them not display properly because the HEAD/HTML elements weren't ready yet.

Also added a message to replay startup to make it clear what is being viewed.

Closes #270 