### PR TITLE
fix(core): fix interact with elements in iframes

### DIFF
--- a/client/connections/ConnectionToCore.ts
+++ b/client/connections/ConnectionToCore.ts
@@ -299,6 +299,7 @@ export default abstract class ConnectionToCore extends TypedEventEmitter<{
         this.isDisconnecting ||
         responseError.name === SessionClosedOrMissingError.name ||
         (responseError as any).isDisconnecting === true;
+      delete (responseError as any).isDisconnecting;
 
       if (!isInternalRequest && isDisconnected) {
         responseError = new DisconnectedFromCoreError(this.resolvedHost);

--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -34,6 +34,7 @@ import Agent from './Agent';
 import { delegate as AwaitedHandler, getAwaitedPathAsMethodArg } from './SetupAwaitedHandler';
 import CoreFrameEnvironment from './CoreFrameEnvironment';
 import Tab from './Tab';
+import { IMousePosition } from '../interfaces/IInteractions';
 
 const { getState, setState } = StateMachine<FrameEnvironment, IState>();
 const awaitedPathState = StateMachine<
@@ -224,6 +225,15 @@ export function getCoreFrameEnvironment(
 ): Promise<CoreFrameEnvironment> {
   return getState(frameEnvironment).coreFrame;
 }
+
+export function getCoreFrameEnvironmentForPosition(
+  mousePosition: IMousePosition,
+): Promise<CoreFrameEnvironment> {
+  const state = awaitedPathState.getState(mousePosition);
+  if (!state) return;
+  return state?.awaitedOptions?.coreFrame;
+}
+
 // CREATE
 
 export function createFrame(

--- a/core/injected-scripts/MouseEvents.ts
+++ b/core/injected-scripts/MouseEvents.ts
@@ -33,8 +33,8 @@ class MouseEvents {
           : undefined;
 
         const result: IMouseUpResult = {
-          pageX: event.pageX - window.pageXOffset,
-          pageY: event.pageY - window.pageYOffset,
+          pageX: event.pageX - window.scrollX,
+          pageY: event.pageY - window.scrollY,
           targetNodeId,
           relatedTargetNodeId,
           didClickLocation: node.contains(event.target as Node) || node === event.target,

--- a/core/interfaces/ICommandWithResult.ts
+++ b/core/interfaces/ICommandWithResult.ts
@@ -11,6 +11,7 @@ export default interface ICommandWithResult {
   isError: boolean;
   result: any;
   resultType?: string;
+  frameIdPath?: string;
   resultNodeIds?: number[];
   resultNodeType?: string;
   failedJsPathStepIndex?: number;

--- a/core/interfaces/ISerializable.ts
+++ b/core/interfaces/ISerializable.ts
@@ -1,4 +1,6 @@
-export type Serializable = number | string | boolean | null | Serializable[] | IJSONObject;
+import IPoint from '@secret-agent/interfaces/IPoint';
+
+export type Serializable = number | string | boolean | null | Serializable[] | IJSONObject | IPoint;
 export interface IJSONObject {
   [key: string]: Serializable;
 }

--- a/core/lib/JsPath.ts
+++ b/core/lib/JsPath.ts
@@ -7,6 +7,7 @@ import Log from '@secret-agent/commons/Logger';
 import { INodeVisibility } from '@secret-agent/interfaces/INodeVisibility';
 import INodePointer from 'awaited-dom/base/INodePointer';
 import IJsPathResult from '@secret-agent/interfaces/IJsPathResult';
+import IPoint from '@secret-agent/interfaces/IPoint';
 import FrameEnvironment from './FrameEnvironment';
 import InjectedScripts from './InjectedScripts';
 import { Serializable } from '../interfaces/ISerializable';
@@ -36,16 +37,23 @@ export class JsPath {
     });
   }
 
-  public exec<T>(jsPath: IJsPath): Promise<IExecJsPathResult<T>> {
-    return this.runJsPath<T>(`exec`, jsPath);
+  public exec<T>(jsPath: IJsPath, containerOffset: IPoint): Promise<IExecJsPathResult<T>> {
+    return this.runJsPath<T>(`exec`, jsPath, containerOffset);
   }
 
   public waitForElement(
     jsPath: IJsPath,
+    containerOffset: IPoint,
     waitForVisible: boolean,
     timeoutMillis: number,
   ): Promise<IExecJsPathResult<INodeVisibility>> {
-    return this.runJsPath<INodeVisibility>(`waitForElement`, jsPath, waitForVisible, timeoutMillis);
+    return this.runJsPath<INodeVisibility>(
+      `waitForElement`,
+      jsPath,
+      containerOffset,
+      waitForVisible,
+      timeoutMillis,
+    );
   }
 
   public simulateOptionClick(jsPath: IJsPath): Promise<IExecJsPathResult<boolean>> {
@@ -68,12 +76,16 @@ export class JsPath {
     );
   }
 
-  public async runJsPaths(jsPaths: IJsPathHistory[]): Promise<IJsPathResult[]> {
+  public async runJsPaths(
+    jsPaths: IJsPathHistory[],
+    containerOffset: IPoint,
+  ): Promise<IJsPathResult[]> {
     if (!jsPaths?.length) return [];
 
     const results = await this.frameEnvironment.runIsolatedFn<IJsPathResult[]>(
       `${InjectedScripts.JsPath}.execJsPaths`,
       jsPaths as any,
+      containerOffset,
     );
 
     for (const { result, jsPath } of results) {

--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -556,17 +556,17 @@ export default class SessionState {
 
     for (const mouseEvent of mouseEvents) {
       lastCommand = this.getCommandForTimestamp(lastCommand, mouseEvent[8]);
-      this.db.mouseEvents.insert(tabId, lastCommand.id, mouseEvent);
+      this.db.mouseEvents.insert(tabId, frameId, lastCommand.id, mouseEvent);
     }
 
     for (const focusEvent of focusEvents) {
       lastCommand = this.getCommandForTimestamp(lastCommand, focusEvent[3]);
-      this.db.focusEvents.insert(tabId, lastCommand.id, focusEvent);
+      this.db.focusEvents.insert(tabId, frameId, lastCommand.id, focusEvent);
     }
 
     for (const scrollEvent of scrollEvents) {
       lastCommand = this.getCommandForTimestamp(lastCommand, scrollEvent[2]);
-      this.db.scrollEvents.insert(tabId, lastCommand.id, scrollEvent);
+      this.db.scrollEvents.insert(tabId, frameId, lastCommand.id, scrollEvent);
     }
   }
 

--- a/core/models/FocusEventsTable.ts
+++ b/core/models/FocusEventsTable.ts
@@ -6,6 +6,7 @@ export default class FocusEventsTable extends SqliteTable<IFocusRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'FocusEvents', [
       ['tabId', 'INTEGER'],
+      ['frameId', 'INTEGER'],
       ['event', 'INTEGER'],
       ['targetNodeId', 'INTEGER'],
       ['relatedTargetNodeId', 'INTEGER'],
@@ -13,15 +14,16 @@ export default class FocusEventsTable extends SqliteTable<IFocusRecord> {
     ]);
   }
 
-  public insert(tabId: number, commandId: number, focusEvent: IFocusEvent) {
+  public insert(tabId: number, frameId: number, commandId: number, focusEvent: IFocusEvent) {
     const [type, targetNodeId, relatedTargetNodeId, timestamp] = focusEvent;
-    const record = [tabId, type, targetNodeId, relatedTargetNodeId, timestamp];
+    const record = [tabId, frameId, type, targetNodeId, relatedTargetNodeId, timestamp];
     this.queuePendingInsert(record);
   }
 }
 
 export interface IFocusRecord {
   tabId: number;
+  frameId: number;
   event: FocusEventType;
   targetNodeId?: number;
   relatedTargetNodeId?: number;

--- a/core/models/MouseEventsTable.ts
+++ b/core/models/MouseEventsTable.ts
@@ -6,6 +6,7 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'MouseEvents', [
       ['tabId', 'INTEGER'],
+      ['frameId', 'INTEGER'],
       ['event', 'INTEGER'],
       ['commandId', 'INTEGER'],
       ['pageX', 'INTEGER'],
@@ -19,7 +20,7 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
     ]);
   }
 
-  public insert(tabId: number, commandId: number, mouseEvent: IMouseEvent) {
+  public insert(tabId: number, frameId: number, commandId: number, mouseEvent: IMouseEvent) {
     const [
       event,
       pageX,
@@ -33,6 +34,7 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
     ] = mouseEvent;
     const record = [
       tabId,
+      frameId,
       event,
       commandId,
       pageX,
@@ -50,6 +52,7 @@ export default class MouseEventsTable extends SqliteTable<IMouseEventRecord> {
 
 export interface IMouseEventRecord {
   tabId: number;
+  frameId: number;
   event: MouseEventType;
   commandId: number;
   pageX: number;

--- a/core/models/ScrollEventsTable.ts
+++ b/core/models/ScrollEventsTable.ts
@@ -6,6 +6,7 @@ export default class ScrollEventsTable extends SqliteTable<IScrollRecord> {
   constructor(readonly db: SqliteDatabase) {
     super(db, 'ScrollEvents', [
       ['tabId', 'INTEGER'],
+      ['frameId', 'INTEGER'],
       ['scrollX', 'INTEGER'],
       ['scrollY', 'INTEGER'],
       ['commandId', 'INTEGER'],
@@ -13,15 +14,16 @@ export default class ScrollEventsTable extends SqliteTable<IScrollRecord> {
     ]);
   }
 
-  public insert(tabId: number, commandId: number, scrollEvent: IScrollEvent) {
+  public insert(tabId: number, frameId: number, commandId: number, scrollEvent: IScrollEvent) {
     const [scrollX, scrollY, timestamp] = scrollEvent;
-    const record = [tabId, scrollX, scrollY, commandId, timestamp];
+    const record = [tabId, frameId, scrollX, scrollY, commandId, timestamp];
     this.queuePendingInsert(record);
   }
 }
 
 export interface IScrollRecord {
   tabId: number;
+  frameId: number;
   scrollX: number;
   scrollY: number;
   commandId: number;

--- a/core/test/detach.test.ts
+++ b/core/test/detach.test.ts
@@ -159,7 +159,10 @@ describe('basic Detach tests', () => {
 
     // now should be able to create a second detached tab and replay the paths with same result
     const { detachedTab: secondDetached } = await session.detachTab(tab, 'callsite3');
-    const prefetch = await secondDetached.mainFrameEnvironment.jsPath.runJsPaths(jsPaths);
+    const prefetch = await secondDetached.mainFrameEnvironment.jsPath.runJsPaths(jsPaths, {
+      x: 0,
+      y: 0,
+    });
 
     const manualResults = [];
     for (let i = 0; i < execJsPath.mock.calls.length; i += 1) {

--- a/interfaces/IWindowOffset.ts
+++ b/interfaces/IWindowOffset.ts
@@ -1,6 +1,6 @@
 export default interface IWindowOffset {
   innerWidth: number;
   innerHeight: number;
-  pageXOffset: number;
-  pageYOffset: number;
+  scrollX: number;
+  scrollY: number;
 }

--- a/replay/backend/api/ReplayTick.ts
+++ b/replay/backend/api/ReplayTick.ts
@@ -8,11 +8,11 @@ export default class ReplayTick {
 
   public documentLoadPaintIndex: number;
 
-  public highlightNodeIds?: number[] = null;
+  public highlightNodeIds?: { frameIdPath: string; nodeIds: number[] } = null;
   public paintEventIdx?: number = null;
-  public scrollEventIdx?: number = null;
-  public focusEventIdx?: number = null;
-  public mouseEventIdx?: number = null;
+  public scrollEventTick?: number = null;
+  public focusEventTick?: number = null;
+  public mouseEventTick?: number = null;
   public get playbarOffsetPercent() {
     return this._playbarOffsetPercent;
   }
@@ -28,7 +28,7 @@ export default class ReplayTick {
   constructor(
     state: ReplayTabState,
     readonly eventType: IEventType,
-    public eventTypeIdx: number,
+    public eventTypeTick: number,
     readonly commandId: number,
     readonly timestamp: number,
     readonly label?: string,

--- a/replay/backend/api/index.ts
+++ b/replay/backend/api/index.ts
@@ -323,11 +323,6 @@ export default class ReplayApi {
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       shell: true,
       windowsHide: true,
-      env: {
-        NODE_ENV: process.env.NODE_ENV,
-        SA_REPLAY_DEBUG: process.env.SA_REPLAY_DEBUG,
-        DEBUG: process.env.DEBUG,
-      },
     });
 
     child.on('error', console.error);

--- a/replay/backend/models/ReplayView.ts
+++ b/replay/backend/models/ReplayView.ts
@@ -247,7 +247,12 @@ export default class ReplayView extends ViewBackend {
   }
 
   private async publishTickChanges(
-    events: [IFrontendDomChangeEvent[], number[], IFrontendMouseEvent, IScrollRecord],
+    events: [
+      IFrontendDomChangeEvent[],
+      { frameIdPath: string; nodeIds: number[] },
+      IFrontendMouseEvent,
+      IScrollRecord,
+    ],
   ) {
     if (!events || !events.length) return;
     const [domChanges] = events;

--- a/replay/shared/interfaces/ICommandResult.ts
+++ b/replay/shared/interfaces/ICommandResult.ts
@@ -9,6 +9,7 @@ export default interface ICommandWithResult {
   endDate?: number;
   duration: number;
   isError: boolean;
+  frameIdPath?: string;
   result: any;
   resultType?: string;
   resultNodeIds?: number[];

--- a/replay/shared/interfaces/ISaSession.ts
+++ b/replay/shared/interfaces/ISaSession.ts
@@ -26,6 +26,7 @@ export interface ISessionTab {
 }
 
 export interface IMouseEvent {
+  frameIdPath: string;
   commandId: number;
   pageX: number;
   pageY: number;
@@ -44,6 +45,7 @@ export interface IFrontendMouseEvent
 }
 
 export interface IFocusRecord {
+  frameIdPath: string;
   event: 0 | 1;
   commandId: number;
   targetNodeId?: number;
@@ -52,6 +54,7 @@ export interface IFocusRecord {
 }
 
 export interface IScrollRecord {
+  frameIdPath: string;
   scrollX: number;
   scrollY: number;
   commandId: number;


### PR DESCRIPTION
Prior to this fix, you couldn't pass nested frame elements to click/interact. Issues:
- Was assuming all elements were in main frame
- Didn't account for the frame offset in interaction functions (mouse over, mouse verified, etc)
- Didn't replay correctly