### PR TITLE
fix(puppet): clean data dir on close

### DIFF
--- a/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
+++ b/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
@@ -57,14 +57,12 @@ export function configureBrowserLaunchArgs(
   );
 
   if (options.showBrowser) {
-    engine.launchArguments.push(
-      `--user-data-dir=${Path.join(
-        os.tmpdir(),
-        engine.fullVersion.replace('.', '-'),
-        '-data',
-        String((sessionDirCounter += 1)),
-      )}`,
-    ); // required to allow multiple browsers to be headed
+    const dataDir = Path.join(
+      os.tmpdir(),
+      engine.fullVersion.replace('.', '-'),
+      `${String(Date.now()).substr(0, 10)}-${(sessionDirCounter += 1)}`,
+    );
+    engine.launchArguments.push(`--user-data-dir=${dataDir}`); // required to allow multiple browsers to be headed
 
     if (!options.disableDevtools) engine.launchArguments.push('--auto-open-devtools-for-tabs');
   } else {

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -21,6 +21,7 @@ import * as Path from 'path';
 import Log from '@secret-agent/commons/Logger';
 import ILaunchedProcess from '@secret-agent/interfaces/ILaunchedProcess';
 import Resolvable from '@secret-agent/commons/Resolvable';
+import * as Fs from 'fs';
 import { WebSocketTransport } from './WebSocketTransport';
 
 const { log } = Log(module);
@@ -44,6 +45,11 @@ export default async function launchProcess(
     env,
     stdio,
   });
+
+  const dataDir = processArguments
+    .find(x => x.startsWith('--user-data-dir='))
+    ?.split('--user-data-dir=')
+    ?.pop();
   // Prevent Unhandled 'error' event.
   launchedProcess.on('error', () => {});
 
@@ -109,6 +115,7 @@ export default async function launchProcess(
       } else {
         launchedProcess.kill('SIGKILL');
       }
+      if (dataDir) Fs.rmdirSync(dataDir, { recursive: true });
       return closed;
     } catch (error) {
       // might have already been kill off

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -115,10 +115,20 @@ export default async function launchProcess(
       } else {
         launchedProcess.kill('SIGKILL');
       }
-      if (dataDir) Fs.rmdirSync(dataDir, { recursive: true });
+      if (dataDir) cleanDataDir(dataDir);
       return closed;
     } catch (error) {
       // might have already been kill off
+    }
+  }
+
+  function cleanDataDir(datadir: string, retries = 3): void {
+    try {
+      if (Fs.existsSync(datadir)) Fs.rmdirSync(dataDir, { recursive: true });
+    } catch (err) {
+      if (retries >= 0) {
+        cleanDataDir(datadir, retries - 1);
+      }
     }
   }
 }


### PR DESCRIPTION
When running "headed", if the data directory is not cleaned up, it could result in not being able to launch a second time.