### PR TITLE
feat: args can now be passed into ExecuteJsPlugin

### DIFF
--- a/plugins/execute-js/lib/ClientPlugin.ts
+++ b/plugins/execute-js/lib/ClientPlugin.ts
@@ -8,20 +8,20 @@ export default class ExecuteJsClientPlugin extends ClientPlugin {
   public static coreDependencyIds = [pluginId];
 
   public onAgent(agent, sendToCore: ISendToCoreFn) {
-    agent.executeJs = fn => {
-      return this.executeJs(fn, sendToCore);
+    agent.executeJs = (fn, ...args) => {
+      return this.executeJs(fn, sendToCore, args);
     };
   }
 
   public onTab(tab, sendToCore: ISendToCoreFn) {
-    tab.executeJs = fn => {
-      return this.executeJs(fn, sendToCore);
+    tab.executeJs = (fn, ...args) => {
+      return this.executeJs(fn, sendToCore, args);
     };
   }
 
   // PRIVATE
 
-  private executeJs(fn, sendToCore): Promise<any> {
+  private executeJs(fn, sendToCore, args): Promise<any> {
     let fnName;
     let fnSerialized;
     if (typeof fn === 'string') {
@@ -29,8 +29,8 @@ export default class ExecuteJsClientPlugin extends ClientPlugin {
       fnSerialized = fn;
     } else {
       fnName = fn.name;
-      fnSerialized = `(${fn.toString()})();`;
+      fnSerialized = `(${fn.toString()})(${JSON.stringify(args).slice(1, -1)});`;
     }
-    return sendToCore(pluginId, fnName, fnSerialized);
+    return sendToCore(pluginId, fnName, fnSerialized, args);
   }
 }

--- a/plugins/execute-js/secret-agent-mods.d.ts
+++ b/plugins/execute-js/secret-agent-mods.d.ts
@@ -3,7 +3,7 @@
 import {} from '@secret-agent/client';
 
 type ExecuteJsPluginAdditions = {
-  executeJs(fn: string | ((...args: any[]) => any));
+  executeJs(fn: string | ((...args: any[]) => any), ...args: any[]);
 };
 
 declare module '@secret-agent/client' {


### PR DESCRIPTION
Solves  #281. Args can now be passed into `agent.executeJs`.