### PR TITLE
fix: useragent was not correctly parsing mac os 11

### DIFF
--- a/plugins/default-browser-emulator/lib/BrowserData.ts
+++ b/plugins/default-browser-emulator/lib/BrowserData.ts
@@ -12,7 +12,7 @@ import IBrowserData, {
 } from '../interfaces/IBrowserData';
 import DataLoader, { loadData } from './DataLoader';
 import getLocalOperatingSystemMeta from './utils/getLocalOperatingSystemMeta';
-import { findClosestVersionMatch } from './VersionUtils';
+import { convertMacOsVersionString, findClosestVersionMatch } from "./VersionUtils";
 
 const localOsMeta = getLocalOperatingSystemMeta();
 
@@ -118,6 +118,13 @@ function createBrowserId(userAgentOption: IUserAgentOption) {
 
 function createOperatingSystemId(userAgentOption: IUserAgentOption) {
   const { operatingSystemName: name, operatingSystemVersion: version } = userAgentOption;
-  const minor = name.startsWith('win') && version.minor === '0' ? null : version.minor;
-  return [name, version.major, minor].filter(x => x).join('-');
+  let { major, minor } = version;
+
+  if (name.startsWith('mac')) {
+    [major, minor] = convertMacOsVersionString([major, minor].filter(x => x).join('.')).split('.');
+  } else if (name.startsWith('win') && version.minor === '0') {
+    minor = null;
+  }
+
+  return [name, major, minor].filter(x => x).join('-');
 }

--- a/plugins/default-browser-emulator/lib/VersionUtils.ts
+++ b/plugins/default-browser-emulator/lib/VersionUtils.ts
@@ -1,3 +1,14 @@
+import * as macOsVersionAliasMap from "../data/macOsVersionAliasMap.json";
+
+export function convertMacOsVersionString(versionString: string) {
+  let newVersionString = macOsVersionAliasMap[versionString];
+  if (!newVersionString) {
+    const [majorVersion] = versionString.split('.');
+    newVersionString = macOsVersionAliasMap[`${majorVersion}.*`];
+  }
+  return newVersionString || versionString;
+}
+
 export function findClosestVersionMatch(versionToMatch: string, versions: string[]) {
   if (versions.length === 1 && versions[0] === 'ALL') return 'ALL';
 

--- a/plugins/default-browser-emulator/lib/utils/getLocalOperatingSystemMeta.ts
+++ b/plugins/default-browser-emulator/lib/utils/getLocalOperatingSystemMeta.ts
@@ -1,7 +1,6 @@
 import * as Os from 'os';
-import { convertVersionsToTree, getClosestNumberMatch } from '../VersionUtils';
+import { convertMacOsVersionString, convertVersionsToTree, getClosestNumberMatch } from "../VersionUtils";
 import * as darwinToMacOsVersionMap from '../../data/darwinToMacOsVersionMap.json';
-import * as macOsVersionAliasMap from '../../data/macOsVersionAliasMap.json';
 import * as windowsToWindowsVersionMap from '../../data/windowsToWindowsVersionMap.json';
 
 export default function getLocalOperatingSystemMeta() {
@@ -75,12 +74,3 @@ const platformToOsName = {
 
 const darwinVersionTree = convertVersionsToTree(Object.keys(darwinToMacOsVersionMap));
 const windowsVersionTree = convertVersionsToTree(Object.keys(windowsToWindowsVersionMap));
-
-function  convertMacOsVersionString(versionString: string) {
-  let newVersionString = macOsVersionAliasMap[versionString];
-  if (!newVersionString) {
-    const [majorVersion] = versionString.split('.');
-    newVersionString = macOsVersionAliasMap[`${majorVersion}.*`];
-  }
-  return newVersionString || versionString;
-}

--- a/plugins/default-browser-emulator/test/VersionUtils.test.ts
+++ b/plugins/default-browser-emulator/test/VersionUtils.test.ts
@@ -1,11 +1,26 @@
+import * as Path from 'path';
 import { findClosestVersionMatch } from '../lib/VersionUtils';
+import DefaultBrowserEmulator from '../index';
+import DataLoader from "../lib/DataLoader";
 
 test('it should findClosestVersionMatch even if minor is not matched', async () => {
   const versionMatch1 = findClosestVersionMatch('10-16', ['11']);
   const versionMatch2 = findClosestVersionMatch('11-2', ['11']);
   const versionMatch3 = findClosestVersionMatch('11-3', ['11']);
+  const versionMatch4 = findClosestVersionMatch('11-4', ['11']);
 
   expect(versionMatch1).toBe('11');
   expect(versionMatch2).toBe('11');
   expect(versionMatch3).toBe('11');
+  expect(versionMatch4).toBe('11');
 }, 60e3);
+
+test('it should find correct browser meta', async () => {
+  const browserMeta = DefaultBrowserEmulator.selectBrowserMeta(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36',
+  );
+  const dataLoader = new DataLoader(Path.resolve(__dirname, '../'));
+  const data = dataLoader.as(browserMeta.userAgentOption) as any;
+  const asOsId = data.osDataDir.split('/').pop();
+  expect(asOsId).toEqual('as-mac-os-11');
+});


### PR DESCRIPTION
BrowserData now uses the same mac os version converter as getLocalOperatingSystemMeta.ts, which had been correctly converting 11.x to just 11.