### PR TITLE
fix(mitm): http2 session frame emulator data

### DIFF
--- a/hero/core/lib/Session.ts
+++ b/hero/core/lib/Session.ts
@@ -92,22 +92,30 @@ export default class Session extends TypedEventEmitter<{
     this.awaitedEventListener = new AwaitedEventListener(this);
 
     const {
-      userAgent: userAgentSelector,
       browserEmulatorId,
       humanEmulatorId,
       dependencyMap,
       corePluginPaths,
+      userProfile,
+      userAgent,
     } = options;
+
+    const userAgentSelector = userAgent ?? userProfile?.userAgentString;
     this.plugins = new CorePlugins(
-      { userAgentSelector, browserEmulatorId, humanEmulatorId, dependencyMap, corePluginPaths },
+      {
+        userAgentSelector,
+        browserEmulatorId,
+        humanEmulatorId,
+        dependencyMap,
+        corePluginPaths,
+        deviceProfile: userProfile?.deviceProfile,
+      },
       this.logger,
     );
 
     this.browserEngine = this.plugins.browserEngine;
 
-    if (options.userProfile) {
-      this.userProfile = options.userProfile;
-    }
+    this.userProfile = options.userProfile;
     this.upstreamProxyUrl = options.upstreamProxyUrl;
     this.geolocation = options.geolocation;
 

--- a/hero/core/lib/UserProfile.ts
+++ b/hero/core/lib/UserProfile.ts
@@ -30,6 +30,8 @@ export default class UserProfile {
     return {
       cookies,
       storage,
+      userAgentString: session.plugins.browserEmulator.userAgentString,
+      deviceProfile: session.plugins.browserEmulator.deviceProfile,
     } as IUserProfile;
   }
 

--- a/hero/core/test/user-profile.test.ts
+++ b/hero/core/test/user-profile.test.ts
@@ -55,6 +55,8 @@ describe('UserProfile cookie tests', () => {
     await tab2.waitForLoad('PaintingStable');
     expect(cookie).not.toBeTruthy();
 
+    expect(profile.userAgentString).toBeTruthy();
+
     const meta3 = await connection.createSession({
       userProfile: profile,
     });
@@ -62,6 +64,9 @@ describe('UserProfile cookie tests', () => {
     Helpers.needsClosing.push(tab3.session);
     const cookiesBefore = await connection.exportUserProfile(meta3);
     expect(cookiesBefore.cookies).toHaveLength(1);
+    expect(cookiesBefore.userAgentString).toBe(profile.userAgentString);
+    expect(tab3.session.plugins.browserEmulator.userAgentString).toBe(profile.userAgentString);
+    expect(cookiesBefore.deviceProfile).toEqual(profile.deviceProfile);
 
     await tab3.goto(`${koaServer.baseUrl}/cookie2`);
     await tab3.waitForLoad('PaintingStable');

--- a/hero/full-client/test/emulate.test.ts
+++ b/hero/full-client/test/emulate.test.ts
@@ -206,6 +206,44 @@ describe('geolocation', () => {
 describe('user agent and platform', () => {
   const propsToGet = `appVersion, platform, userAgent, deviceMemory`.split(',').map(x => x.trim());
 
+  it('should be able to configure a userAgent', async () => {
+    const userAgent =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4472.124 Safari/537.36';
+    const agent = await handler.createAgent({
+      userAgent,
+    });
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+    expect(agentMeta.userAgentString).toBe(userAgent);
+  });
+
+  it('should be able to configure a userAgent with a range', async () => {
+    const agent = await handler.createAgent({
+      userAgent: '~ chrome >= 88 && chrome < 89',
+    });
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+    const chromeMatch = agentMeta.userAgentString.match(/Chrome\/(\d+)/);
+    expect(chromeMatch).toBeTruthy();
+    const version = Number(chromeMatch[1]);
+    expect(version).toBe(88);
+  });
+
+  it('should be able to configure a userAgent with a wildcard', async () => {
+    const agent = await handler.createAgent({
+      userAgent: '~ chrome = 88.x',
+    });
+    Helpers.needsClosing.push(agent);
+
+    const agentMeta = await agent.meta;
+    const chromeMatch = agentMeta.userAgentString.match(/Chrome\/(\d+)/);
+    expect(chromeMatch).toBeTruthy();
+    const version = Number(chromeMatch[1]);
+    expect(version).toBe(88);
+  });
+
   it('should add user agent and platform to window & frames', async () => {
     const agent = await handler.createAgent();
     Helpers.needsClosing.push(agent);

--- a/hero/interfaces/ICorePlugin.ts
+++ b/hero/interfaces/ICorePlugin.ts
@@ -14,8 +14,13 @@ import { IPuppetPage } from './IPuppetPage';
 import { IPuppetWorker } from './IPuppetWorker';
 import IViewport from './IViewport';
 import IGeolocation from './IGeolocation';
+import IDeviceProfile from './IDeviceProfile';
+import IHttp2ConnectSettings from './IHttp2ConnectSettings';
 
-export default interface ICorePlugin extends ICorePluginMethods, IBrowserEmulatorMethods, IHumanEmulatorMethods {
+export default interface ICorePlugin
+  extends ICorePluginMethods,
+    IBrowserEmulatorMethods,
+    IHumanEmulatorMethods {
   id: string;
 }
 
@@ -94,6 +99,7 @@ export interface IBrowserEmulator extends ICorePlugin {
   operatingSystemVersion: IVersion;
 
   userAgentString: string;
+  deviceProfile: IDeviceProfile;
 }
 
 export interface IBrowserEmulatorMethods {
@@ -103,6 +109,10 @@ export interface IBrowserEmulatorMethods {
   onTcpConfiguration?(settings: ITcpSettings): Promise<any> | void;
   onTlsConfiguration?(settings: ITlsSettings): Promise<any> | void;
 
+  onHttp2SessionConnect?(
+    request: IHttpResourceLoadDetails,
+    settings: IHttp2ConnectSettings,
+  ): Promise<any> | void;
   beforeHttpRequest?(request: IHttpResourceLoadDetails): Promise<any> | void;
   beforeHttpResponse?(resource: IHttpResourceLoadDetails): Promise<any> | void;
 

--- a/hero/interfaces/ICorePluginCreateOptions.ts
+++ b/hero/interfaces/ICorePluginCreateOptions.ts
@@ -2,10 +2,12 @@ import { IBoundLog } from './ILog';
 import IBrowserEngine from './IBrowserEngine';
 import ICorePlugins from './ICorePlugins';
 import IUserAgentOption from './IUserAgentOption';
+import IDeviceProfile from './IDeviceProfile';
 
 export default interface ICorePluginCreateOptions {
   userAgentOption: IUserAgentOption;
   browserEngine: IBrowserEngine;
   corePlugins: ICorePlugins;
   logger: IBoundLog;
+  deviceProfile?: IDeviceProfile;
 }

--- a/hero/interfaces/IDeviceProfile.ts
+++ b/hero/interfaces/IDeviceProfile.ts
@@ -1,0 +1,8 @@
+export default interface IDeviceProfile {
+  deviceMemory?: number;
+  videoDevice?: {
+    deviceId: string;
+    groupId: string;
+  };
+  webGlParameters?: Record<string, string | number | boolean>;
+}

--- a/hero/interfaces/IHttp2ConnectSettings.ts
+++ b/hero/interfaces/IHttp2ConnectSettings.ts
@@ -1,0 +1,6 @@
+import * as http2 from 'http2';
+
+export default interface IHttp2ConnectSettings {
+  settings: http2.Settings;
+  localWindowSize: number;
+}

--- a/hero/interfaces/IUserProfile.ts
+++ b/hero/interfaces/IUserProfile.ts
@@ -1,7 +1,10 @@
 import { ICookie } from './ICookie';
 import IDomStorage from './IDomStorage';
+import IDeviceProfile from './IDeviceProfile';
 
 export default interface IUserProfile {
   cookies?: ICookie[];
   storage?: IDomStorage;
+  userAgentString?: string;
+  deviceProfile?: IDeviceProfile;
 }

--- a/hero/mitm-socket/go/emulate_tls.go
+++ b/hero/mitm-socket/go/emulate_tls.go
@@ -44,7 +44,7 @@ func EmulateTls(dialConn net.Conn, addr string, sessionArgs SessionArgs, connect
 
 	if connectArgs.KeylogPath != "" {
 		var keylog io.Writer
-		keylog, err = os.OpenFile(connectArgs.KeylogPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		keylog, err = os.OpenFile(connectArgs.KeylogPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 		if err != nil {
 			return nil, err
 		}

--- a/hero/mitm/handlers/HeadersHandler.ts
+++ b/hero/mitm/handlers/HeadersHandler.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import * as nodeCommon from '_http_common';
 import IResourceHeaders from '@secret-agent/interfaces/IResourceHeaders';
 import * as http from 'http';
 import * as http2 from 'http2';
@@ -81,8 +79,6 @@ export default class HeadersHandler {
   ): IResourceHeaders {
     const headers: IResourceHeaders = {};
     for (const [headerName, value] of Object.entries(originalRawHeaders)) {
-      if (nodeCommon._checkInvalidHeaderChar(value)) continue;
-
       const canonizedKey = headerName.trim();
 
       const lowerHeaderName = toLowerCase(canonizedKey);
@@ -135,6 +131,21 @@ export default class HeadersHandler {
         else stream.sendTrailers(trailers ?? {});
       });
     }
+  }
+
+  public static prepareHttp2RequestHeadersForSave(
+    headers: IMitmRequestContext['requestHeaders'],
+  ): IMitmRequestContext['requestHeaders'] {
+    const order: string[] = [];
+    for (const key of Object.keys(headers)) {
+      if (key.startsWith(':')) order.unshift(key);
+      else order.push(key);
+    }
+    const newHeaders = {};
+    for (const key of order) {
+      newHeaders[key] = headers[key];
+    }
+    return newHeaders;
   }
 
   public static prepareRequestHeadersForHttp2(ctx: IMitmRequestContext): void {

--- a/hero/plugin-utils/lib/BrowserEmulator.ts
+++ b/hero/plugin-utils/lib/BrowserEmulator.ts
@@ -10,6 +10,7 @@ import ICorePluginCreateOptions from '@secret-agent/interfaces/ICorePluginCreate
 import IBrowserEngine from '@secret-agent/interfaces/IBrowserEngine';
 import ICorePlugins from '@secret-agent/interfaces/ICorePlugins';
 import { IVersion } from '@secret-agent/interfaces/IUserAgentOption';
+import IDeviceProfile from '@secret-agent/interfaces/IDeviceProfile';
 
 @BrowserEmulatorClassDecorator
 export default class BrowserEmulator implements IBrowserEmulator {
@@ -28,10 +29,17 @@ export default class BrowserEmulator implements IBrowserEmulator {
   public readonly userAgentString: string;
   public readonly browserEngine: IBrowserEngine;
   public readonly logger: IBoundLog;
+  public readonly deviceProfile: IDeviceProfile;
 
   protected readonly corePlugins: ICorePlugins;
 
-  constructor({ userAgentOption, browserEngine, corePlugins, logger }: ICorePluginCreateOptions) {
+  constructor({
+    userAgentOption,
+    browserEngine,
+    corePlugins,
+    logger,
+    deviceProfile,
+  }: ICorePluginCreateOptions) {
     this.id = (this.constructor as IBrowserEmulatorClass).id;
     this.browserName = userAgentOption.browserName;
     this.browserVersion = userAgentOption.browserVersion;
@@ -45,6 +53,7 @@ export default class BrowserEmulator implements IBrowserEmulator {
 
     this.corePlugins = corePlugins;
     this.logger = logger;
+    this.deviceProfile = deviceProfile ?? {};
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-10/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-58-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-59-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-60-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-61-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-62-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-63-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-64-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-65-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-66-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-9/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-10-9/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-67-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-68-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-69-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-70-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-71-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-72-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-73-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-74-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-75-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-76-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-77-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-78-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-79-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 4294967295
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-80-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-81-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-83-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-84-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-85-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-86-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,10 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-87-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-88-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-mac-os-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-89-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-11/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-11/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-12/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-12/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-10/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-10/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-7/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-7/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-8-1/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-8-1/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-8/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-chrome-90-0/as-windows-8/http2-session.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "headerTableSize": 65536,
+    "initialWindowSize": 6291456,
+    "maxConcurrentStreams": 1000,
+    "maxHeaderListSize": 262144
+  },
+  "ping": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001",
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 15728640
+}

--- a/hero/plugins/default-browser-emulator/data/as-safari-11-1/as-mac-os-10-13/as-mac-os-10-13/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-safari-11-1/as-mac-os-10-13/as-mac-os-10-13/http2-session.json
@@ -1,0 +1,8 @@
+{
+  "settings": {
+    "maxConcurrentStreams": 100,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 10551295
+}

--- a/hero/plugins/default-browser-emulator/data/as-safari-11-1/as-mac-os-10-14/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-safari-11-1/as-mac-os-10-14/http2-session.json
@@ -1,0 +1,8 @@
+{
+  "settings": {
+    "maxConcurrentStreams": 100,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 10551295
+}

--- a/hero/plugins/default-browser-emulator/data/as-safari-12-1/as-mac-os-10-14/as-mac-os-10-15/http2-session.json
+++ b/hero/plugins/default-browser-emulator/data/as-safari-12-1/as-mac-os-10-14/as-mac-os-10-15/http2-session.json
@@ -1,0 +1,9 @@
+{
+  "settings": {
+    "initialWindowSize": 1048576,
+    "maxConcurrentStreams": 100,
+    "maxHeaderListSize": 4294967295
+  },
+  "initialWindowSize": 65535,
+  "firstFrameWindowSize": 10551295
+}

--- a/hero/plugins/default-browser-emulator/data/browserEngineOptions.json
+++ b/hero/plugins/default-browser-emulator/data/browserEngineOptions.json
@@ -3,42 +3,56 @@
     "id": "chrome-83-0",
     "name": "chrome",
     "fullVersion": "83.0.4103.61",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-84-0",
     "name": "chrome",
     "fullVersion": "84.0.4147.135",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-85-0",
     "name": "chrome",
     "fullVersion": "85.0.4183.102",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-86-0",
     "name": "chrome",
     "fullVersion": "86.0.4240.198",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-87-0",
     "name": "chrome",
     "fullVersion": "87.0.4280.141",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-88-0",
     "name": "chrome",
     "fullVersion": "88.0.4324.150",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   },
   {
     "id": "chrome-89-0",
     "name": "chrome",
     "fullVersion": "89.0.4389.114",
-    "features": ["headless"]
+    "features": [
+      "headless"
+    ]
   }
 ]

--- a/hero/plugins/default-browser-emulator/interfaces/IBrowserData.ts
+++ b/hero/plugins/default-browser-emulator/interfaces/IBrowserData.ts
@@ -9,15 +9,10 @@ export default interface IBrowserData
   windowChrome: IDataWindowChrome;
   windowFraming: IDataWindowFraming;
   windowNavigator: IDataWindowNavigator;
+  http2Settings: IDataHttp2Settings;
   domPolyfill: IDataDomPolyfill;
   windowBaseFraming: IDataWindowFraming;
   headers: IDataHeaders;
-  deviceMemory?: number;
-  videoDevice?: {
-    deviceId: string;
-    groupId: string;
-  };
-  webGLParameters?: Record<string, string | number | boolean>;
 }
 
 export interface IDataBrowserConfig {
@@ -53,6 +48,13 @@ export interface IDataCodecs {
   videoSupport: any;
   webRtcAudioCodecs: any;
   webRtcVideoCodecs: any;
+}
+
+export interface IDataHttp2Settings {
+  settings: any;
+  ping: string;
+  initialWindowSize: number;
+  firstFrameWindowSize: number;
 }
 
 export interface IDataCore {

--- a/hero/plugins/default-browser-emulator/lib/DataLoader.ts
+++ b/hero/plugins/default-browser-emulator/lib/DataLoader.ts
@@ -1,19 +1,48 @@
 import * as Fs from 'fs';
-import IUserAgentOption from "@secret-agent/interfaces/IUserAgentOption";
+import IUserAgentOption from '@secret-agent/interfaces/IUserAgentOption';
 import {
   IDataBrowserEngineOptions,
   IDataCore,
   IDataUserAgentOptions,
-} from "../interfaces/IBrowserData";
+} from '../interfaces/IBrowserData';
 import BrowserData from './BrowserData';
 
 export default class DataLoader implements IDataCore {
   public readonly baseDir: string;
   public readonly dataDir: string;
 
+  private readonly browserOsEmulatorsByVersion: {
+    [versionString: string]: { [os: string]: string[] };
+  } = {};
+
+  private readonly osDataDirs = new Set<string>();
+
   constructor(baseDir: string) {
     this.baseDir = baseDir;
     this.dataDir = `${baseDir}/data`;
+    const browsers = Fs.readdirSync(this.dataDir);
+    for (const browser of browsers) {
+      if (browser.startsWith('as-') && Fs.statSync(`${this.dataDir}/${browser}`).isDirectory()) {
+        this.browserOsEmulatorsByVersion[browser] = {};
+        for (const osDir of Fs.readdirSync(`${this.dataDir}/${browser}`)) {
+          if (
+            osDir.startsWith('as-') &&
+            Fs.statSync(`${this.dataDir}/${browser}/${osDir}`).isDirectory()
+          ) {
+            const isMac = osDir.startsWith('as-mac');
+            const version = osDir.replace('as-mac-os-', '').replace('as-windows-', '');
+            const name = isMac ? 'mac-os' : 'windows';
+            this.browserOsEmulatorsByVersion[browser][name] ??= [];
+            this.browserOsEmulatorsByVersion[browser][name].push(version);
+            this.osDataDirs.add(`${this.dataDir}/${browser}/${osDir}`);
+          }
+        }
+      }
+    }
+  }
+
+  public isSupportedEmulator(osDir: string): boolean {
+    return this.osDataDirs.has(osDir);
   }
 
   public get pkg(): any {
@@ -30,6 +59,10 @@ export default class DataLoader implements IDataCore {
 
   public as(userAgentOption: IUserAgentOption) {
     return new BrowserData(this, userAgentOption);
+  }
+
+  public getBrowserOperatingSystemVersions(browserId: string, osName: string): string[] {
+    return this.browserOsEmulatorsByVersion[`as-${browserId}`][osName];
   }
 }
 

--- a/hero/plugins/default-browser-emulator/lib/helpers/configureDeviceProfile.ts
+++ b/hero/plugins/default-browser-emulator/lib/helpers/configureDeviceProfile.ts
@@ -1,0 +1,16 @@
+import IDeviceProfile from '@secret-agent/interfaces/IDeviceProfile';
+import { randomBytes } from 'crypto';
+
+export default function configureDeviceProfile(deviceProfile: IDeviceProfile): void {
+  deviceProfile.deviceMemory ??= Math.ceil(Math.random() * 4) * 2;
+  deviceProfile.videoDevice ??= {
+    deviceId: randomBytes(32).toString('hex'),
+    groupId: randomBytes(32).toString('hex'),
+  };
+  deviceProfile.webGlParameters ??= {
+    // UNMASKED_VENDOR_WEBGL
+    37445: 'Intel Inc.',
+    // UNMASKED_RENDERER_WEBGL
+    37446: 'Intel Iris OpenGL Engine',
+  };
+}

--- a/hero/plugins/default-browser-emulator/lib/helpers/configureHttp2Session.ts
+++ b/hero/plugins/default-browser-emulator/lib/helpers/configureHttp2Session.ts
@@ -1,0 +1,14 @@
+import { IBrowserEmulator } from '@secret-agent/plugin-utils';
+import IHttp2ConnectSettings from '@secret-agent/interfaces/IHttp2ConnectSettings';
+import IHttpResourceLoadDetails from '@secret-agent/interfaces/IHttpResourceLoadDetails';
+import IBrowserData from '../../interfaces/IBrowserData';
+
+export default function configureHttp2Session(
+  emulator: IBrowserEmulator,
+  data: IBrowserData,
+  resource: IHttpResourceLoadDetails,
+  settings: IHttp2ConnectSettings,
+) {
+  settings.localWindowSize = data.http2Settings.firstFrameWindowSize;
+  settings.settings = data.http2Settings.settings;
+}

--- a/hero/plugins/default-browser-emulator/lib/loadDomOverrides.ts
+++ b/hero/plugins/default-browser-emulator/lib/loadDomOverrides.ts
@@ -11,8 +11,9 @@ export default function loadDomOverrides(
 
   domOverrides.add('Error.captureStackTrace');
   domOverrides.add('Error.constructor');
+  const deviceProfile = emulator.deviceProfile;
 
-  domOverrides.add('navigator.deviceMemory', { memory: data.deviceMemory });
+  domOverrides.add('navigator.deviceMemory', { memory: deviceProfile.deviceMemory });
   domOverrides.add('navigator', {
     userAgentString: emulator.userAgentString,
     platform: emulator.operatingSystemPlatform,
@@ -20,7 +21,7 @@ export default function loadDomOverrides(
   });
 
   domOverrides.add('MediaDevices.prototype.enumerateDevices', {
-    videoDevice: data.videoDevice,
+    videoDevice: deviceProfile.videoDevice,
   });
 
   domOverrides.add('Notification.permission');
@@ -63,7 +64,7 @@ export default function loadDomOverrides(
 
   const windowNavigator = data.windowNavigator;
   domOverrides.add('navigator.plugins', parseNavigatorPlugins(windowNavigator.navigator));
-  domOverrides.add('WebGLRenderingContext.prototype.getParameter', data.webGLParameters);
+  domOverrides.add('WebGLRenderingContext.prototype.getParameter', deviceProfile.webGlParameters);
   domOverrides.add('console.debug');
   domOverrides.add('HTMLIFrameElement.prototype');
   domOverrides.add('Element.prototype.attachShadow');

--- a/hero/plugins/default-browser-emulator/lib/setPageDomOverrides.ts
+++ b/hero/plugins/default-browser-emulator/lib/setPageDomOverrides.ts
@@ -1,11 +1,12 @@
-import { BrowserEmulator } from "@secret-agent/plugin-utils";
 import { IPuppetPage } from '@secret-agent/interfaces/IPuppetPage';
 import IBrowserData from '../interfaces/IBrowserData';
-import loadDomOverrides from './loadDomOverrides';
+import DomOverridesBuilder from './DomOverridesBuilder';
 
-export default async function setPageDomOverrides(emulator: BrowserEmulator, data: IBrowserData, page: IPuppetPage) {
-  const domOverrides = loadDomOverrides(emulator, data);
-
+export default async function setPageDomOverrides(
+  domOverrides: DomOverridesBuilder,
+  data: IBrowserData,
+  page: IPuppetPage,
+) {
   const scripts = domOverrides.build();
   const promises: Promise<any>[] = [];
   for (const script of scripts) {

--- a/hero/plugins/default-browser-emulator/lib/setWorkerDomOverrides.ts
+++ b/hero/plugins/default-browser-emulator/lib/setWorkerDomOverrides.ts
@@ -1,14 +1,12 @@
-import { BrowserEmulator } from '@secret-agent/plugin-utils';
 import { IPuppetWorker } from '@secret-agent/interfaces/IPuppetWorker';
 import IBrowserData from '../interfaces/IBrowserData';
-import loadDomOverrides from './loadDomOverrides';
+import DomOverridesBuilder from './DomOverridesBuilder';
 
 export default function setWorkerDomOverrides(
-  emulator: BrowserEmulator,
+  domOverrides: DomOverridesBuilder,
   data: IBrowserData,
   worker: IPuppetWorker,
 ): Promise<any[]> {
-  const domOverrides = loadDomOverrides(emulator, data);
   const scripts = domOverrides.build([
     'Error.captureStackTrace',
     'Error.constructor',

--- a/hero/puppet/test/_CustomBrowserEmulator.ts
+++ b/hero/puppet/test/_CustomBrowserEmulator.ts
@@ -52,6 +52,7 @@ export default class CustomBrowserEmulator implements IBrowserEmulator {
   locale = locale;
   viewport = viewport;
   timezoneId = timezoneId;
+  deviceProfile = {};
 
   configure(config: IBrowserEmulatorConfig): void {
     config.locale = config.locale || this.locale;

--- a/website/docs/Advanced/UserProfile.md
+++ b/website/docs/Advanced/UserProfile.md
@@ -37,6 +37,15 @@ Cookies for all loaded "origins" for the browsing session.
 
 #### **Type**: [`Cookie[]`](/docs/advanced/cookie-storage#cookie)
 
+### deviceProfile
+
+An object containing hardware device properties emulated in this userProfile like memory and gpu information.
+
+#### **Type**: `object`
+  - deviceMemory `number`. The amount of memory specified for this machine
+  - webGlParameters `object`. Key value of WebGlParameters to override (ie, { 37445: 'WebGl Vendor' })
+  - videoDevice `object { deviceId: string, groupId: string }`. A video device to emulate if none is present, such as on a headless server.
+
 ### storage
 
 An object with a key for each "security origin" of a page, and value all the associated [DomStorage](#dom-storage).
@@ -49,3 +58,10 @@ An object with a key for each "security origin" of a page, and value all the ass
 #### **Type**: `object { [origin: string]: DomStorage }`
   - key `string`. The "security origin" of a page or iFrame as defined by Chrome.
   - value [DomStorage](#dom-storage). The `DomStorage` entry for the given origin.
+
+### userAgentString
+
+The user agent used in this profile. Many sites that track user fingerprint information track the useragent information and expect it to remain the same. You can still override this (eg, to update a browser version) by overriding the `userAgent` parameter when constructing a new [`Agent`](/docs/basic-interfaces/agent).
+
+#### **Type** string
+

--- a/website/docs/Plugins/CorePlugins.md
+++ b/website/docs/Plugins/CorePlugins.md
@@ -4,7 +4,6 @@
 
 ## Creating Your Own Core Plugin
 
-
 Adding a new plugin is as simple as creating a javascript class with the correct properties and methods, then registering it with `agent.use()`.
 
 We recommend using the CorePlugin base class provided by @secret-agent/plugin-utils, which handles setting most of the required properties and methods, everything except the static `id` property. Here's a simple plugin that adds a single hello() method to agent, which outputs to the browser's console.
@@ -16,8 +15,8 @@ export class ClientHelloPlugin extends ClientPlugin {
   static readonly id = 'hello-plugin';
 
   onAgent(agent, sendToCore) {
-    agent.hello = async (name) => await sendToCore('hello-plugin', name));  
-  } 
+    agent.hello = async (name) => await sendToCore('hello-plugin', name));
+  }
 }
 
 export class CoreHelloPlugin extends CorePlugin {
@@ -25,13 +24,13 @@ export class CoreHelloPlugin extends CorePlugin {
 
   onClientCommand({ puppetPage }, name) {
     `Hello ${name}`);
-  } 
+  }
 }
 ```
 
 As shown above, you can export multiple plugins from the same file. Also a client/core plugin combination can share the same `id` (unlike two core plugins, which must each have unique ids).
 
-To register this plugin in SecretAgent, just pass it to `agent.use()`. In the following example we pass through a path to the plugin file instead of the plugin class itself -- we're doing this because by default Core runs in a separate process from Client.  
+To register this plugin in SecretAgent, just pass it to `agent.use()`. In the following example we pass through a path to the plugin file instead of the plugin class itself -- we're doing this because by default Core runs in a separate process from Client.
 
 ```javascript
 import agent from 'secret-agent';
@@ -46,6 +45,7 @@ The rest of this page documents the various functionalities you can add to your 
 ## Constructor
 
 ### new CorePlugin<em>(createOptions)</em>
+
 New instance of CorePlugin is created for every agent instance. The createOptions object has three properties.
 
 #### **Arguments**:
@@ -58,27 +58,31 @@ New instance of CorePlugin is created for every agent instance. The createOption
 
 ## Class Properties
 
-### CorePlugin.id *required*
+### CorePlugin.id _required_
+
 This should usually be set to the plugin's npm package name.
+
 #### **Type**: `string`
 
-### CorePlugin.type *required*
+### CorePlugin.type _required_
+
 This tells SecretAgent that the plugin is a CorePlugin. It must always be set.
+
 #### **Type**: `string`. This must always be set to `'CorePlugin'`.
 
-
 ## Instance Method Hooks
+
 The following methods are optional. Add them to your plugin as needed.
 
 ### configure<em>(config)</em>
 
-This hook is called during the initialization of a session/browserEmulator as well as every time agent.configure is called from the client. 
+This hook is called during the initialization of a session/browserEmulator as well as every time agent.configure is called from the client.
 
 #### **Arguments**:
 
 - config `object` Receives any (or none) of the following:
   - viewport `Viewport`. This is an object containing browser width and height as well as screenWidth and screenHeight, among other properties.
-  - geolocation `Geolocation`. This is an object containing longtitude and latitude, among other properties.  
+  - geolocation `Geolocation`. This is an object containing longtitude and latitude, among other properties.
   - timezoneId `string`. The configured unicode TimezoneId or host default (eg, America/New_York).
   - locale `string`. The configured locale in use (eg, en-US).
 
@@ -86,20 +90,22 @@ Modify any value in the object to change it session-wide.
 
 #### **Returns** `void`
 
-### onClientCommand<em>(meta, ...args)</em> *optional*
+### onClientCommand<em>(meta, ...args)</em> _optional_
+
 This method is called every time a ClientPlugin calls sendToCore to this plugin's ID.
 
 #### **Arguments**:
+
 - meta `OnClientommandMeta`. This object currently has a single property - puppetPage.
 - args: `any[]`. Whatever args the ClientPlugin passed through sendToCore.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### onDnsConfiguration<em>(settings: IDnsSettings)</em>
 
 Configures the DNS over TLS connection that Chrome defaults to using if your DNS provider supports it.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### onTcpConfiguration<em>(settings: ITcpSettings)</em>
 
@@ -111,27 +117,40 @@ Current supports:
 
 Alter the object's values to change session-wide.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### onTlsConfiguration<em>(settings: ITlsSettings)</em>
 
 Emulate the ClientHello signature, which can vary between browser versions
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
+
+### onHttp2SessionConnect<em>(request: IHttpResourceLoadDetails, settings: IHttp2ConnectSettings)</em>
+
+A callback is provided for each HTTP2 Session that is created allowing you to customize the initial SETTINGS and WINDOW_UPDATE frames.
+
+Current Supports
+- `settings`. Http2RequestSettings using keys from Node.js settings (https://nodejs.org/api/http2.html#http2_settings_object)
+- `localWindowSize`. A value to trigger a WINDOW_UPDATE frame with the initial connect.
+
+Alter the object's values per Http2 Session.
+
+#### **Returns** `Promise` | `void`
 
 ### beforeHttpRequest<em>(request: IHttpResourceLoadDetails)</em>
 
 A callback is provided for each HTTP request where you are given the opportunity to re-order, re-case, and add or remove headers so that they resemble real browser requests. Headless Chrome is known to provide headers is different order on occasion from headed. See [https://github.com/ulixee/double-agent](https://github.com/ulixee/double-agent) for details.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### beforeHttpResponse<em>(resource: IHttpResourceLoadDetails)</em>
 
 Callbacks on each cookie set, and to return the valid list of cookies. This callback can be used to simulate cookie behavior that varies from the underlying browser - for instance Safari 13.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### onNewPuppetPage<em>(page: IPuppetPage)</em>
+
 This is called every time a new page/iframe is loaded. Use this hook to modify the DOM environment (i.e., to emulate various browser features) before a website loads.
 
 #### **Returns** `Promise`
@@ -146,14 +165,14 @@ This is called every time a new worker is loaded within a page. Use this hook to
 
 Callback to indicate a domain has "first-party" interaction. Some browsers, like Safari 13.1, started granting cookie storage to websites only after a user has directly interacted with them.
 
-#### **Returns** `Promise`
+#### **Returns** `Promise` | `void`
 
 ### playInteractions<em>(interactions, runFn, helper)</em>
 
 Use this method if you want to change the speed or randomness of user Interactions (mouse movements, typing, etc).
 
 #### **Returns** `Promise`
-  
+
 ### getStartingMousePoint<em>(helper)</em>
 
 This is used within Core to run the mouse Interactions correctly.


### PR DESCRIPTION
Major Change:
1) Include data for http2 session settings and initial window_update frame (Closes #278)
2) Export userAgent and deviceSettings with the userProfile

Fixes:
1) Fix userAgent selection with wildcards
2) Fix fallback option for a userAgent where the OS doesn't exist