### PR TITLE
fix(core): fix headed browser size/viewport docs

### DIFF
--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -174,7 +174,7 @@ export default class GlobalPool {
       showBrowser: Boolean(
         JSON.parse(process.env.SA_SHOW_BROWSER ?? process.env.SHOW_BROWSER ?? 'false'),
       ),
-      disableDevtools: Boolean(JSON.parse(process.env.SA_DISABLE_DEVTOOLS ?? 'false')),
+      disableDevtools: Boolean(JSON.parse(process.env.SA_DISABLE_DEVTOOLS ?? 'true')),
       noChromeSandbox: Boolean(JSON.parse(process.env.SA_NO_CHROME_SANDBOX ?? 'false')),
       disableGpu: Boolean(JSON.parse(process.env.SA_DISABLE_GPU ?? 'false')),
       enableMitm: !disableMitm,

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -421,6 +421,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
   }
 
   public takeScreenshot(options: IScreenshotOptions = {}): Promise<Buffer> {
+    options.rectangle.scale ??= 1;
     return this.puppetPage.screenshot(options.format, options.rectangle, options.jpegQuality);
   }
 

--- a/interfaces/IViewport.ts
+++ b/interfaces/IViewport.ts
@@ -1,19 +1,9 @@
 export default interface IViewport {
-  /** The page width in pixels. */
   width: number;
-  /** The page height in pixels. */
   height: number;
-  /**
-   * Specify device scale factor (can be thought of as dpr).
-   * @default 1
-   */
   deviceScaleFactor?: number;
-  /** The screen width in pixels. */
-  screenWidth: number;
-  /** The screen height in pixels. */
-  screenHeight: number;
-  /** Overriding view X position on screen in pixels (minimum 0, maximum 10000000). */
-  positionX: number;
-  /** Overriding view Y position on screen in pixels (minimum 0, maximum 10000000). */
-  positionY: number;
+  screenWidth?: number;
+  screenHeight?: number;
+  positionX?: number;
+  positionY?: number;
 }

--- a/plugins/default-browser-emulator/index.ts
+++ b/plugins/default-browser-emulator/index.ts
@@ -116,7 +116,7 @@ export default class DefaultBrowserEmulator extends BrowserEmulator {
       setUserAgent(this, devtools),
       setTimezone(this, devtools),
       setLocale(this, devtools),
-      setScreensize(this, devtools),
+      setScreensize(this, page, devtools),
       setActiveAndFocused(this, devtools),
       setPageDomOverrides(this.domOverridesBuilder, this.data, page),
       setGeolocation(this, page),

--- a/plugins/default-browser-emulator/lib/Viewports.ts
+++ b/plugins/default-browser-emulator/lib/Viewports.ts
@@ -1,5 +1,5 @@
 import IViewport from '@secret-agent/interfaces/IViewport';
-import { IDataWindowFraming } from "../interfaces/IBrowserData";
+import { IDataWindowFraming } from '../interfaces/IBrowserData';
 
 const defaultWindowFraming = {
   screenGapLeft: 0,
@@ -10,12 +10,17 @@ const defaultWindowFraming = {
   frameBorderHeight: 0,
 };
 
+export const defaultScreen = {
+  width: 1440,
+  height: 900,
+};
+
 export default class Viewports {
   static getDefault(windowBaseFraming: IDataWindowFraming, windowFraming: IDataWindowFraming) {
     windowFraming = windowFraming || { ...defaultWindowFraming };
     const base = windowBaseFraming || { ...defaultWindowFraming };
-    const screenWidth = 1440;
-    const screenHeight = 900;
+    const screenWidth = defaultScreen.width;
+    const screenHeight = defaultScreen.height;
 
     const windowInnerWidth =
       screenWidth - (base.screenGapLeft + base.screenGapRight + base.frameBorderWidth);

--- a/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
+++ b/plugins/default-browser-emulator/lib/helpers/configureBrowserLaunchArgs.ts
@@ -1,6 +1,7 @@
 import * as Path from 'path';
 import * as os from 'os';
 import BrowserEngine from '@secret-agent/plugin-utils/lib/BrowserEngine';
+import { defaultScreen } from '../Viewports';
 
 let sessionDirCounter = 0;
 
@@ -50,6 +51,8 @@ export function configureBrowserLaunchArgs(
     '--password-store=basic', // Avoid potential instability of using Gnome Keyring or KDE wallet.
     '--use-mock-keychain', // Use mock keychain on Mac to prevent blocking permissions dialogs
     '--allow-running-insecure-content',
+
+    `--window-size=${defaultScreen.width},${defaultScreen.height}`,
 
     // don't leak private ip
     '--force-webrtc-ip-handling-policy=default_public_interface_only',

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -124,7 +124,11 @@ export default async function launchProcess(
 
   function cleanDataDir(datadir: string, retries = 3): void {
     try {
-      if (Fs.existsSync(datadir)) Fs.rmdirSync(dataDir, { recursive: true });
+      if (Fs.existsSync(datadir)) {
+        // rmdir is deprecated in node 16+
+        const fn = 'rmSync' in Fs ? 'rmSync' : 'rmdirSync';
+        Fs[fn](dataDir, { recursive: true });
+      }
     } catch (err) {
       if (retries >= 0) {
         cleanDataDir(datadir, retries - 1);

--- a/puppet/test/_CustomBrowserEmulator.ts
+++ b/puppet/test/_CustomBrowserEmulator.ts
@@ -6,11 +6,12 @@ import {
 import { PluginTypes } from '@secret-agent/interfaces/IPluginTypes';
 import IUserAgentOption from '@secret-agent/interfaces/IUserAgentOption';
 import DefaultBrowserEmulator from '@secret-agent/default-browser-emulator';
+import IViewport from '@secret-agent/interfaces/IViewport';
 
 const id = 'test';
 const locale = 'en';
 const timezoneId = 'est';
-const viewport = {
+const viewport: IViewport = {
   screenHeight: 900,
   screenWidth: 1024,
   positionY: 0,

--- a/website/docs/Advanced/Session.md
+++ b/website/docs/Advanced/Session.md
@@ -1,6 +1,6 @@
 # Session
 
-> A Session tracks a single "scraping" session. It tracks and coordinates the [HumanEmulator](/docs/advanced/human-emulators), [BrowserEmulator](/docs/advanced/browser-emulators) and [SecretAgent](/docs/basic-interfaces/agent) that will be used.
+> A Session tracks a single "scraping" session. It tracks and coordinates the [HumanEmulator](/docs/plugins/human-emulators), [BrowserEmulator](/docs/plugins/browser-emulators) and [SecretAgent](/docs/basic-interfaces/agent) that will be used.
 
 Sessions store data into a Sqlite database using a module called SessionState. This database tracks all the information needed to recreate a session in [SessionReplay](/docs/advanced/session-replay).
 

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -28,7 +28,7 @@ Agent instances can have multiple [Tabs](/docs/basic-interfaces/tab), but only a
 
 #### Sandboxed
 
-Each Agent instance creates a private environment with its own cache, cookies, session data and [BrowserEmulator](/docs/advanced/browser-emulators). No data is shared between instances -- each operates within an airtight sandbox to ensure no identities leak across requests.
+Each Agent instance creates a private environment with its own cache, cookies, session data and [BrowserEmulator](/docs/plugins/browser-emulators). No data is shared between instances -- each operates within an airtight sandbox to ensure no identities leak across requests.
 
 ## Default Instance {#default}
 
@@ -83,6 +83,13 @@ const { Agent } = require('secret-agent');
   - timezoneId `string`. Overrides the host timezone. A list of valid ids are available at [unicode.org](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/zone_tzid.html)
   - locale `string`. Overrides the host languages settings (eg, en-US). Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules.
   - viewport `IViewport`. Sets the emulated screen size, window position in the screen, inner/outer width and height. If not provided, the most popular resolution is used from [statcounter.com](https://gs.statcounter.com/screen-resolution-stats/desktop/united-states-of-america).
+    - width `number`. The page width in pixels (minimum 0, maximum 10000000).
+    - height `number`. The page height in pixels (minimum 0, maximum 10000000).
+    - deviceScaleFactor `number` defaults to 1. Specify device scale factor (can be thought of as dpr).
+    - screenWidth? `number`. The optional screen width in pixels (minimum 0, maximum 10000000).
+    - screenHeight? `number`. The optional screen height in pixels (minimum 0, maximum 10000000).
+    - positionX? `number`. Optional override browser X position on screen in pixels (minimum 0, maximum 10000000).
+    - positionY? `number`. Optional override browser Y position on screen in pixels (minimum 0, maximum 10000000).
   - blockedResourceTypes `BlockedResourceType[]`. Controls browser resource loading. Valid options are listed [here](/docs/overview/configuration#blocked-resources).
   - userProfile `IUserProfile`. Previous user's cookies, session, etc.
   - input `object`. An object containing properties to attach to the agent. NOTE: if using the default agent, this object will be populated with command line variables starting with `--input.{json path}`. The `{json path}` will be translated into an object set to `agent.input`.
@@ -150,8 +157,8 @@ Retrieves metadata about the agent configuration:
 
 - sessionId `string`. The session identifier.
 - sessionName `string`. The unique session name that will be visible in Replay.
-- browserEmulatorId `string`. The id of the [Browser Emulator](/docs/advanced/browser-emulators) in use.
-- humanEmulatorId `string`. The id of the [Human Emulator](/docs/advanced/human-emulators) in use.
+- browserEmulatorId `string`. The id of the [Browser Emulator](/docs/plugins/browser-emulators) in use.
+- humanEmulatorId `string`. The id of the [Human Emulator](/docs/plugins/human-emulators) in use.
 - timezoneId `string`. The configured unicode TimezoneId or host default (eg, America/New_York).
 - locale `string`. The configured locale in use (eg, en-US).
 - geolocation `IGeolocation`. The configured geolocation of the user (if set).
@@ -267,14 +274,14 @@ Update existing configuration settings.
   - userProfile `IUserProfile`. Previous user's cookies, session, etc.
   - timezoneId `string`. Overrides the host timezone. A list of valid ids are available at [unicode.org](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/zone_tzid.html)
   - locale `string`. Overrides the host languages settings (eg, en-US). Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules.
-  - viewport `IViewport`. Sets the emulated screen size, window position in the screen, inner/outer width.
+  - viewport `IViewport`. Sets the emulated screen size, window position in the screen, inner/outer width. (See constructor for parameters).
   - blockedResourceTypes `BlockedResourceType[]`. Controls browser resource loading. Valid options are listed [here](/docs/overview/configuration#blocked-resources).
   - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
   - connectionToCore `options | ConnectionToCore`. An object containing `IConnectionToCoreOptions` used to connect, or an already created `ConnectionToCore` instance. Defaults to booting up and connecting to a local `Core`.
 
 #### **Returns**: `Promise`
 
-See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/advanced/browser-emulators) and [HumanEmulators](/docs/advanced/human-emulators).
+See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/plugins/browser-emulators) and [HumanEmulators](/docs/plugins/human-emulators).
 
 ### agent.detach*(tab\[, key])* {#detach-tab}
 

--- a/website/docs/BasicInterfaces/Handler.md
+++ b/website/docs/BasicInterfaces/Handler.md
@@ -98,7 +98,7 @@ Sets default properties to apply to any new Agent created. Accepts any of the co
 
 #### **Returns**: `IAgentCreateOptions`
 
-See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/advanced/browser-emulators) and [HumanEmulators](/docs/advanced/human-emulators).
+See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/plugins/browser-emulators) and [HumanEmulators](/docs/plugins/human-emulators).
 
 #### **Type**: [`Tab`](/docs/basic-interfaces/tab)
 
@@ -156,7 +156,7 @@ NOTE: when using this method, you must call [`agent.close()`](/docs/basic-interf
   - input `object`. An object containing properties to attach to the agent (more frequently used with [`dispatchAgent`](#dispatch-agent))
   - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
 
-See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/advanced/browser-emulators) and [HumanEmulators](/docs/advanced/human-emulators).
+See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/plugins/browser-emulators) and [HumanEmulators](/docs/plugins/human-emulators).
 
 #### **Returns**: [`Promise<Agent>`](/docs/basic-interfaces/agent)
 

--- a/website/docs/BasicInterfaces/Interactions.md
+++ b/website/docs/BasicInterfaces/Interactions.md
@@ -12,7 +12,7 @@ Multiple Interactions can be passed through as multiple arguments:
 agent.interact({ click: [250, 356] }, { type: 'hello world' });
 ```
 
-The timing of Interactions are controlled by an emulation layer, called [HumanEmulators](/docs/advanced/human-emulators), which generate realistic-looking, human-like movements on the remote webpage.
+The timing of Interactions are controlled by an emulation layer, called [HumanEmulators](/docs/plugins/human-emulators), which generate realistic-looking, human-like movements on the remote webpage.
 
 Interaction Commands fall into three broad categories:
 

--- a/website/docs/Help/troubleshooting.md
+++ b/website/docs/Help/troubleshooting.md
@@ -12,7 +12,7 @@ You can remove the library and reinstall or rebuild manually using npm run build
 
 #### Browser Emulators
 
-When you install SecretAgent, it also downloads a recent version of Chrome 83 (~277MB Mac, ~282MB Linux, ~280MB Win). Each [BrowserEmulator](/docs/advanced/browser-emulators) you install (ie, Chrome80, Safari13) can install additional browser engines as needed.
+When you install SecretAgent, it also downloads a recent version of Chrome 83 (~277MB Mac, ~282MB Linux, ~280MB Win). Each [BrowserEmulator](/docs/plugins/browser-emulators) you install (ie, Chrome80, Safari13) can install additional browser engines as needed.
 
 Browsers will be saved to a shared location on each OS. Each browser version will be downloaded only once and can be shared across multiple SecretAgent npm installations.
 

--- a/website/docs/Overview/BasicConcepts.md
+++ b/website/docs/Overview/BasicConcepts.md
@@ -77,4 +77,4 @@ const doc = await agent.fetch('https://secretagent.dev/docs/overview/configurati
 
 ## Mice and Keyboards Are Human Too
 
-SecretAgent drives mice and keyboards with [Human Emulators](/docs/advanced/human-emulators). Human emulators translate your clicks and moves into randomized human-like patterns that can pass bot-blocker checks.
+SecretAgent drives mice and keyboards with [Human Emulators](/docs/plugins/human-emulators). Human emulators translate your clicks and moves into randomized human-like patterns that can pass bot-blocker checks.

--- a/website/docs/Overview/Configuration.md
+++ b/website/docs/Overview/Configuration.md
@@ -99,11 +99,11 @@ An upstream proxy url should be a fully formatted url to the proxy. If your prox
 
 ### Browsers Emulator Id <div class="specs"><i>Agent</i></div>
 
-Configures which [BrowserEmulator](/docs/advanced/browser-emulators) to use in a given Agent.
+Configures which [BrowserEmulator](/docs/plugins/browser-emulators) to use in a given Agent.
 
 ### Human Emulator Id <div class="specs"><i>Agent</i></div>
 
-Configures which [HumanEmulator](/docs/advanced/human-emulators) to use in an Agent instance.
+Configures which [HumanEmulator](/docs/plugins/human-emulators) to use in an Agent instance.
 
 ## Core Configuration
 


### PR DESCRIPTION
This PR cleans up the headed browsers to match the configured viewports. Also fixes a few random documentation issues.

other:
- rmdir is deprecated in node 16 (now just rm)
- default the "scale" property when passing a rectangle to screenshot