### PR TITLE
Hero Fixes

### DIFF
--- a/client/lib/ScriptInstance.ts
+++ b/client/lib/ScriptInstance.ts
@@ -8,7 +8,7 @@ const { log } = Log(module);
 export default class ScriptInstance {
   public readonly id: string = uuidv1();
   public readonly entrypoint = require.main?.filename ?? process.argv[1];
-  public readonly startDate = new Date().getTime();
+  public readonly startDate = Date.now();
   private sessionNameCountByName: { [name: string]: number } = {};
 
   public get meta(): IScriptInstanceMeta {

--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -143,7 +143,7 @@ function translateToPrintable(
       result.error = value;
     }
     const printable = translateValueToPrintable(value);
-    if (!printable) continue;
+    if (printable === null || printable === undefined) continue;
     printData[key] = printable;
   }
   return result;

--- a/commons/SqliteTable.ts
+++ b/commons/SqliteTable.ts
@@ -88,7 +88,7 @@ export default abstract class SqliteTable<T> {
   private addRecordToPublish(record: IRecord): void {
     if (!this.insertCallbackFn) return;
     this.insertSubscriptionRecords.push(this.insertToObject(record));
-    if (new Date().getTime() - this.lastSubscriptionPublishTime.getTime() > 500) {
+    if (Date.now() - this.lastSubscriptionPublishTime.getTime() > 500) {
       return this.publishPendingRecords();
     }
     clearTimeout(this.subscriptionThrottle);

--- a/core/connections/ConnectionToClient.ts
+++ b/core/connections/ConnectionToClient.ts
@@ -134,8 +134,7 @@ export default class ConnectionToClient extends TypedEventEmitter<{
     clearTimeout(this.autoShutdownTimer);
     const closeAll: Promise<any>[] = [];
     for (const id of this.sessionIds) {
-      const promise = Session.get(id)?.close();
-      if (promise) closeAll.push(promise.catch(err => err));
+      closeAll.push(this.closeSession({ sessionId: id }).catch(err => err));
     }
     await Promise.all(closeAll);
     this.isPersistent = false;

--- a/core/index.ts
+++ b/core/index.ts
@@ -42,8 +42,8 @@ export default class Core {
   public static onShutdown: () => void;
 
   public static allowDynamicPluginLoading = true;
+  public static isClosing: Promise<void>;
   private static wasManuallyStarted = false;
-  private static isClosing: Promise<void>;
   private static isStarting = false;
 
   public static addConnection(): ConnectionToClient {
@@ -107,6 +107,7 @@ export default class Core {
     log.info('Core started', {
       sessionId: null,
       parentLogId: startLogId,
+      sessionsDir: GlobalPool.sessionsDir,
     });
   }
 

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -26,7 +26,7 @@ class JsPath {
       top = maxScrollY;
     }
 
-    const endTime = new Date().getTime() + (timeoutMillis ?? 50);
+    const endTime = Date.now() + (timeoutMillis ?? 50);
     let count = 0;
     do {
       if (Math.abs(window.scrollX - left) <= 1 && Math.abs(window.scrollY - top) <= 1) {
@@ -37,7 +37,7 @@ class JsPath {
       }
       await new Promise(requestAnimationFrame);
       count += 1;
-    } while (new Date().getTime() < endTime);
+    } while (Date.now() < endTime);
 
     return false;
   }

--- a/core/lib/DevtoolsPreferences.ts
+++ b/core/lib/DevtoolsPreferences.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Modifications copyright (c) Data Liberation Foundation Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import IDevtoolsSession, { Protocol } from '@ulixee/hero-interfaces/IDevtoolsSession';
+import * as fs from 'fs';
+import { bindFunctions } from '@ulixee/commons/utils';
+import BindingCalledEvent = Protocol.Runtime.BindingCalledEvent;
+
+const devtoolsPreferencesCallback = '_DevtoolsPreferencesCallback';
+
+export default class DevtoolsPreferences {
+  private cachedPreferences: any;
+  constructor(readonly preferencesPath: string) {
+    bindFunctions(this);
+  }
+
+  installOnConnect(session: IDevtoolsSession): Promise<void> {
+    session.on('Runtime.bindingCalled', event => this.onPreferenceAction(session, event));
+
+    return Promise.all([
+      session.send('Runtime.enable'),
+      session.send('Runtime.addBinding', { name: devtoolsPreferencesCallback }),
+      session.send('Page.enable'),
+      session.send('Page.addScriptToEvaluateOnNewDocument', {
+        source: `(function devtoolsPreferencesInterceptor() {
+    const toIntercept = ['getPreferences', 'setPreference', 'removePreference', 'clearPreferences'];
+
+    let inspector;
+    Object.defineProperty(window, 'InspectorFrontendHost', {
+      configurable: true,
+      enumerable: true,
+      get() { return inspector; },
+      set(v) {
+         inspector = v;
+         // devtoolsHost is initiated when Inspector is created
+         window.DevToolsHost.sendMessageToEmbedder = new Proxy(window.DevToolsHost.sendMessageToEmbedder, {
+          apply(target, thisArg, args) {
+            const method = JSON.parse(args[0]).method;
+            if (toIntercept.includes(method)) {
+              return window.${devtoolsPreferencesCallback}(args[0]);
+            }
+            return Reflect.apply(...arguments);
+          }
+         });
+      },
+    });
+})()`,
+      }),
+      session.send('Runtime.runIfWaitingForDebugger'),
+    ]).catch(() => null);
+  }
+
+  private async onPreferenceAction(
+    session: IDevtoolsSession,
+    event: BindingCalledEvent,
+  ): Promise<void> {
+    if (event.name !== devtoolsPreferencesCallback) return;
+
+    const { id, method, params } = JSON.parse(event.payload);
+
+    this.load();
+
+    let result;
+    if (method === 'getPreferences') {
+      result = this.cachedPreferences;
+    } else {
+      if (method === 'setPreference') {
+        this.cachedPreferences[params[0]] = params[1];
+      } else if (method === 'removePreference') {
+        delete this.cachedPreferences[params[0]];
+      } else if (method === 'clearPreferences') {
+        this.cachedPreferences = {};
+      }
+      this.save();
+    }
+
+    await session
+      .send('Runtime.evaluate', {
+        // built-in devtools function/api
+        expression: `window.DevToolsAPI.embedderMessageAck(${id}, ${JSON.stringify(result)})`,
+        contextId: event.executionContextId,
+      })
+      .catch(() => null);
+  }
+
+  private save(): void {
+    fs.writeFileSync(this.preferencesPath, JSON.stringify(this.cachedPreferences, null, 2), 'utf8');
+  }
+
+  private load(): any {
+    if (this.cachedPreferences === undefined) {
+      try {
+        const json = fs.readFileSync(this.preferencesPath, 'utf8');
+        this.cachedPreferences = JSON.parse(json);
+      } catch (e) {
+        this.cachedPreferences = {};
+      }
+    }
+  }
+}

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -12,6 +12,7 @@ import { CanceledPromiseError } from '@ulixee/commons/interfaces/IPendingWaitEve
 import IPuppetLaunchArgs from '@ulixee/hero-interfaces/IPuppetLaunchArgs';
 import SessionsDb from '../dbs/SessionsDb';
 import Session from './Session';
+import DevtoolsPreferences from './DevtoolsPreferences';
 
 const { log } = Log(module);
 let sessionsDir = process.env.HERO_SESSIONS_DIR || Path.join(Os.tmpdir(), '.ulixee'); // transferred to GlobalPool below class definition
@@ -63,6 +64,8 @@ export default class GlobalPool {
   }
 
   public static close(): Promise<void> {
+    if (this.isClosing) return;
+    this.isClosing = true;
     const logId = log.stats('GlobalPool.Closing');
 
     for (const { promise } of this.waitingForAvailability) {
@@ -99,10 +102,19 @@ export default class GlobalPool {
 
     this.puppets.push(puppet);
 
-    return puppet.start();
+    const browserDir = browserEngine.executablePath.split(browserEngine.fullVersion).shift();
+
+    const preferencesInterceptor = new DevtoolsPreferences(
+      `${browserDir}/devtoolsPreferences.json`,
+    );
+
+    return puppet.start({
+      attachToDevtools: preferencesInterceptor.installOnConnect,
+      onClose: this.onEngineClosed.bind(this, browserEngine),
+    });
   }
 
-  private static async startMitm() {
+  private static async startMitm(): Promise<void> {
     if (this.mitmServer || disableMitm === true) return;
     if (this.mitmStartPromise) await this.mitmStartPromise;
     else {
@@ -142,7 +154,20 @@ export default class GlobalPool {
     }
   }
 
-  private static releaseConnection() {
+  private static async onEngineClosed(engine: IBrowserEngine): Promise<void> {
+    if (this.isClosing) return;
+    for (const session of Session.sessionsWithBrowserEngine(engine)) {
+      await session.close();
+    }
+    log.info('PuppetEngine.closed', {
+      engine,
+      sessionId: null,
+    });
+    const idx = this.puppets.findIndex(x => x.browserEngine === engine);
+    if (idx >= 0) this.puppets.splice(idx, 1);
+  }
+
+  private static releaseConnection(): void {
     this._activeSessionCount -= 1;
 
     const wasTransferred = this.resolveWaitingConnection();
@@ -155,7 +180,7 @@ export default class GlobalPool {
     }
   }
 
-  private static resolveWaitingConnection() {
+  private static resolveWaitingConnection(): boolean {
     if (!this.waitingForAvailability.length) {
       return false;
     }
@@ -169,7 +194,7 @@ export default class GlobalPool {
     return true;
   }
 
-  private static getPuppetLaunchArgs() {
+  private static getPuppetLaunchArgs(): IPuppetLaunchArgs {
     this.defaultLaunchArgs ??= {
       showBrowser: Boolean(
         JSON.parse(process.env.HERO_SHOW_BROWSER ?? process.env.SHOW_BROWSER ?? 'false'),

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -41,6 +41,7 @@ export default class GlobalPool {
   }[] = [];
 
   public static async start(): Promise<void> {
+    this.isClosing = false;
     log.info('StartingGlobalPool', {
       sessionId: null,
     });

--- a/core/lib/GlobalPool.ts
+++ b/core/lib/GlobalPool.ts
@@ -29,6 +29,7 @@ export default class GlobalPool {
     return this.activeSessionCount < GlobalPool.maxConcurrentHeroesCount;
   }
 
+  private static isClosing = false;
   private static defaultLaunchArgs: IPuppetLaunchArgs;
   private static _activeSessionCount = 0;
   private static puppets: Puppet[] = [];
@@ -39,15 +40,14 @@ export default class GlobalPool {
     promise: IResolvablePromise<Session>;
   }[] = [];
 
-  public static async start() {
+  public static async start(): Promise<void> {
     log.info('StartingGlobalPool', {
       sessionId: null,
     });
     await this.startMitm();
-    this.resolveWaitingConnection();
   }
 
-  public static createSession(options: ISessionCreateOptions) {
+  public static createSession(options: ISessionCreateOptions): Promise<Session> {
     log.info('AcquiringChrome', {
       sessionId: null,
       activeSessionCount: this.activeSessionCount,
@@ -64,7 +64,7 @@ export default class GlobalPool {
   }
 
   public static close(): Promise<void> {
-    if (this.isClosing) return;
+    if (this.isClosing) return Promise.resolve();
     this.isClosing = true;
     const logId = log.stats('GlobalPool.Closing');
 

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -467,7 +467,9 @@ export default class Session extends TypedEventEmitter<{
     return session.tabsById.get(meta.tabId) ?? session.detachedTabsById.get(meta.tabId);
   }
 
-  public static sessionsWithBrowserEngine(engine: IBrowserEngine): Session[] {
-    return Object.values(this.byId).filter(x => x.browserEngine === engine);
+  public static sessionsWithBrowserEngine(
+    isEngineMatch: (engine: IBrowserEngine) => boolean,
+  ): Session[] {
+    return Object.values(this.byId).filter(x => isEngineMatch(x.browserEngine));
   }
 }

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -447,7 +447,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     // wait for a real url to be requested
     if (newTab.url === 'about:blank' || !newTab.url) {
       let timeoutMs = options?.timeoutMs ?? 10e3;
-      const millis = new Date().getTime() - startTime.getTime();
+      const millis = Date.now() - startTime.getTime();
       timeoutMs -= millis;
       await newTab.navigations.waitOn('navigation-requested', null, timeoutMs).catch(() => null);
     }

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -186,7 +186,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
       if (!top || top.resourceId.isResolved) continue;
 
       if (
-        finalUrl === top.finalUrl ||
+        (top.finalUrl && finalUrl === top.finalUrl) ||
         requestedUrl === top.requestedUrl ||
         browserRequestId === top.browserRequestId
       ) {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -247,6 +247,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     }
 
     try {
+      this.puppetPage.off('close', this.close);
       // run this one individually
       await this.puppetPage.close();
     } catch (error) {
@@ -612,6 +613,8 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
   private listen(): void {
     const page = this.puppetPage;
 
+    this.close = this.close.bind(this);
+    page.on('close', this.close);
     page.on('page-error', this.onPageError.bind(this), true);
     page.on('crashed', this.onTargetCrashed.bind(this));
     page.on('console', this.onConsole.bind(this), true);

--- a/core/models/TabsTable.ts
+++ b/core/models/TabsTable.ts
@@ -9,7 +9,7 @@ export default class TabsTable extends SqliteTable<ITabsRecord> {
       ['parentId', 'INTEGER'],
       ['detachedAtCommandId', 'INTEGER'],
       ['pageTargetId', 'TEXT'],
-      ['sessionId', 'TEXT'],
+      ['devtoolsSessionId', 'TEXT'],
       ['viewportWidth', 'INTEGER'],
       ['viewportHeight', 'INTEGER'],
       ['browserPositionX', 'INTEGER'],
@@ -36,7 +36,7 @@ export default class TabsTable extends SqliteTable<ITabsRecord> {
       viewPort.height,
       viewPort.positionX,
       viewPort.positionY,
-      new Date().getTime(),
+      Date.now(),
     ]);
   }
 }
@@ -46,7 +46,7 @@ export interface ITabsRecord {
   parentId: number | null;
   detachedAtCommandId: number | null;
   pageTargetId: string;
-  sessionId: string;
+  devtoolsSessionId: string;
   viewportWidth: number;
   viewportHeight: number;
   browserPositionX: number;

--- a/fullstack/index.cjs
+++ b/fullstack/index.cjs
@@ -1,3 +1,9 @@
-require('./index.js');
+const cjsImport = require('./index.js');
 
-module.exports = require('@ulixee/hero');
+// create a true default export
+module.exports = cjsImport.default;
+
+for (const key in cjsImport) {
+  if (!cjsImport.hasOwnProperty(key) || key in module.exports) continue;
+  module.exports[key] = cjsImport[key];
+}

--- a/fullstack/index.ts
+++ b/fullstack/index.ts
@@ -1,21 +1,24 @@
 import '@ulixee/commons/SourceMapSupport';
 import {
-  ConnectionToRemoteCoreServer,
-  ConnectionToCore,
-  InteractionCommand,
-  MouseButton,
-  ResourceType,
-  KeyboardKeys,
   BlockedResourceType,
-  Node,
+  ConnectionToCore,
+  ConnectionToRemoteCoreServer,
   FrameEnvironment,
-  Tab,
-  XPathResult,
+  InteractionCommand,
+  KeyboardKeys,
   LocationStatus,
   LocationTrigger,
+  MouseButton,
+  Node,
+  ResourceType,
+  Tab,
+  XPathResult,
 } from '@ulixee/hero';
 import Core from '@ulixee/hero-core';
+import ShutdownHandler from '@ulixee/commons/ShutdownHandler';
 import Hero from './lib/Hero';
+
+ShutdownHandler.exitOnSignal = false;
 
 Core.start().catch(error => {
   console.log('ERROR starting Core within Fullstack', error); // eslint-disable-line no-console
@@ -36,6 +39,6 @@ export {
   XPathResult,
   LocationStatus,
   LocationTrigger,
-}
+};
 
 export default Hero;

--- a/fullstack/index.ts
+++ b/fullstack/index.ts
@@ -14,7 +14,7 @@ import {
   Tab,
   XPathResult,
 } from '@ulixee/hero';
-import Core from '@ulixee/hero-core';
+import Core, { GlobalPool } from '@ulixee/hero-core';
 import ShutdownHandler from '@ulixee/commons/ShutdownHandler';
 import Hero from './lib/Hero';
 
@@ -24,6 +24,10 @@ Core.start().catch(error => {
   console.log('ERROR starting Core within Fullstack', error); // eslint-disable-line no-console
 });
 
+if (process.env.NODE_ENV !== 'test') {
+  GlobalPool.events.on('browser-closed-all-windows', ({ puppet }) => puppet.close());
+  GlobalPool.events.on('all-browsers-closed', () => Core.shutdown());
+}
 export {
   Core,
   ConnectionToRemoteCoreServer,

--- a/fullstack/test/basic.test.ts
+++ b/fullstack/test/basic.test.ts
@@ -131,7 +131,7 @@ describe('basic Full Client tests', () => {
     }
     {
       const expires = new Date();
-      expires.setTime(new Date().getTime() + 10e3);
+      expires.setTime(Date.now() + 10e3);
       await cookieStorage.setItem('Cookie2', 'test2', { expires });
       expect(await cookieStorage.length).toBe(2);
       const cookie = await cookieStorage.getItem('Cookie2');

--- a/interfaces/IDevtoolsSession.ts
+++ b/interfaces/IDevtoolsSession.ts
@@ -1,4 +1,5 @@
 import { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping';
+import Protocol from 'devtools-protocol';
 import ITypedEventEmitter from './ITypedEventEmitter';
 import { FilterFlags, FilterOutFlags } from './AllowedNames';
 
@@ -28,6 +29,8 @@ export default interface IDevtoolsSession
 
   onMessage(object: IDevtoolsResponseMessage & IDevtoolsEventMessage): void;
 }
+
+export { Protocol };
 
 export interface IDevtoolsResponseMessage {
   sessionId: string;

--- a/interfaces/IPuppetBrowser.ts
+++ b/interfaces/IPuppetBrowser.ts
@@ -2,8 +2,10 @@ import { IBoundLog } from './ILog';
 import IPuppetContext from './IPuppetContext';
 import IProxyConnectionOptions from './IProxyConnectionOptions';
 import ICorePlugins from './ICorePlugins';
+import IDevtoolsSession from './IDevtoolsSession';
 
 export default interface IPuppetBrowser {
+  onDevtoolsAttached?: (devtoolsSession: IDevtoolsSession) => Promise<any>;
   getFeatures(): Promise<{
     supportsPerBrowserContextProxy: boolean;
     version: { major: string; minor: string };

--- a/mitm-socket/go/connect.go
+++ b/mitm-socket/go/connect.go
@@ -101,7 +101,7 @@ func handleSocket(connectArgs ConnectArgs, sessionArgs SessionArgs, signals *Sig
 	domainSocketPiper := &DomainSocketPiper{
 		client:  domainConn,
 		id:      connectArgs.Id,
-		debug:   sessionArgs.Debug,
+		debug:   sessionArgs.DebugData,
 		signals: signals,
 	}
 	defer domainSocketPiper.Close()
@@ -162,5 +162,6 @@ type SessionArgs struct {
 	TcpTtl             int
 	TcpWindowSize      int
 	Debug              bool
+	DebugData          bool
 	Mode               string
 }

--- a/mitm-socket/lib/BaseIpcHandler.ts
+++ b/mitm-socket/lib/BaseIpcHandler.ts
@@ -212,4 +212,5 @@ export interface IGoIpcOpts {
   tcpWindowSize?: number;
   rejectUnauthorized?: boolean;
   debug?: boolean;
+  debugData?: boolean; // include bytes read from client/remote (NOTE: lots of output)
 }

--- a/mitm-socket/lib/BaseIpcHandler.ts
+++ b/mitm-socket/lib/BaseIpcHandler.ts
@@ -63,24 +63,26 @@ export default abstract class BaseIpcHandler {
   }
 
   public close(): void {
+    if (this.isClosing) return;
     const parentLogId = this.logger.info(`${this.handlerName}.Closing`);
-    if (this.isClosing || !this.child) return;
     this.isClosing = true;
 
-    try {
-      // fix for node 13 throwing errors on closed sockets
-      this.child.stdin.on('error', () => {
-        // catch
-      });
-      // NOTE: windows writes to stdin
-      // MUST SEND SIGNALS BEFORE DISABLING PIPE!!
-      this.child.send('disconnect');
-    } catch (err) {
-      // don't log epipes
-    }
+    if (this.child) {
+      try {
+        // fix for node 13 throwing errors on closed sockets
+        this.child.stdin.on('error', () => {
+          // catch
+        });
+        // NOTE: windows writes to stdin
+        // MUST SEND SIGNALS BEFORE DISABLING PIPE!!
+        this.child.send('disconnect');
+      } catch (err) {
+        // don't log epipes
+      }
 
-    this.child.kill('SIGINT');
-    this.child.unref();
+      this.child.kill('SIGINT');
+      this.child.unref();
+    }
 
     try {
       this.onExit();

--- a/mitm-socket/lib/CertificateGenerator.ts
+++ b/mitm-socket/lib/CertificateGenerator.ts
@@ -53,8 +53,12 @@ export default class CertificateGenerator extends BaseIpcHandler {
     if (this.isClosing) return;
     const message = JSON.parse(rawMessage);
     if (this.options.debug) {
+      const toLog = { ...message };
+      if (message.status === 'init') {
+        toLog.privateKey = `-----BEGIN RSA PRIVATE KEY-----\n...key used by man-in-the-middle removed for logs...\n-----END RSA PRIVATE KEY-----\n`;
+      }
       this.logger.info('CertificateGenerator.onMessage', {
-        ...message,
+        ...toLog,
       });
     }
 

--- a/mitm/lib/Http2SessionBinding.ts
+++ b/mitm/lib/Http2SessionBinding.ts
@@ -1,0 +1,88 @@
+import { Http2Session } from 'http2';
+import { Log } from '@ulixee/commons/Logger';
+import { IBoundLog } from '@ulixee/hero-interfaces/ILog';
+import { bindFunctions } from '@ulixee/commons/utils';
+
+export default class Http2SessionBinding {
+  private logger: IBoundLog;
+
+  constructor(
+    readonly clientSession: Http2Session,
+    readonly serverSession: Http2Session,
+    logData: { sessionId: string } & any,
+  ) {
+    this.logger = new Log(module, logData) as IBoundLog;
+    bindFunctions(this);
+    this.bind();
+  }
+
+  private bind(): void {
+    const clientSession = this.clientSession;
+    const serverSession = this.serverSession;
+
+    clientSession?.on('ping', this.pingServer);
+
+    serverSession.on('error', this.onServerError);
+    serverSession.on('close', this.onServerClose);
+    serverSession.on('goaway', this.onServerGoaway);
+
+    serverSession.on('remoteSettings', remoteSettings => {
+      this.logger.stats('Http2Client.remoteSettings', {
+        settings: remoteSettings,
+      });
+    });
+
+    serverSession.on('frameError', (frameType, errorCode) => {
+      this.logger.warn('Http2Client.frameError', {
+        frameType,
+        errorCode,
+      });
+    });
+
+    serverSession.on('altsvc', (alt, altOrigin) => {
+      this.logger.stats('Http2.altsvc', {
+        altOrigin,
+        alt,
+      });
+    });
+
+    serverSession.on('origin', origins => {
+      this.logger.stats('Http2.origin', {
+        origins,
+      });
+    });
+  }
+
+  private pingServer(bytes: Buffer): void {
+    if (this.serverSession.destroyed) return;
+    this.serverSession.ping(bytes, () => null);
+  }
+
+  private onServerClose(): void {
+    this.logger.info('Http2Client.close');
+    if (!this.clientSession || this.clientSession.destroyed) return;
+    this.clientSession.close();
+  }
+
+  private onServerError(error: Error): void {
+    this.logger.warn('Http2Client.error', {
+      error,
+    });
+    if (!this.clientSession || this.clientSession.destroyed) return;
+    this.clientSession.destroy(error);
+  }
+
+  private onServerGoaway(
+    code: number,
+    lastStreamID?: number,
+    opaqueData?: NodeJS.ArrayBufferView,
+  ): void {
+    this.logger.stats('Http2.goaway', {
+      code,
+      lastStreamID,
+      opaqueData,
+    });
+    if (!this.clientSession || this.clientSession.destroyed) return;
+    this.clientSession.goaway(code);
+  }
+}

--- a/mitm/models/CertificatesTable.ts
+++ b/mitm/models/CertificatesTable.ts
@@ -31,7 +31,7 @@ export default class CertificatesTable extends SqliteTable<ICertificateRecord> {
     if (!record) {
       return null;
     }
-    const millisUntilExpire = (record.expireDate as any) - new Date().getTime();
+    const millisUntilExpire = (record.expireDate as any) - Date.now();
     if (millisUntilExpire < 60 * 60e3) {
       return null;
     }

--- a/puppet-chrome/index.ts
+++ b/puppet-chrome/index.ts
@@ -45,7 +45,7 @@ const PuppetLauncher: IPuppetLauncher = {
     }
 
     browserEngine.launchArguments = chromeArguments;
-    browserEngine.beforeLaunch(options);
+    if (browserEngine.beforeLaunch) browserEngine.beforeLaunch(options);
 
     return browserEngine.launchArguments;
   },

--- a/puppet-chrome/lib/BrowserContext.ts
+++ b/puppet-chrome/lib/BrowserContext.ts
@@ -28,13 +28,13 @@ import { Page } from './Page';
 import { Browser } from './Browser';
 import { DevtoolsSession } from './DevtoolsSession';
 import Frame from './Frame';
-
 import CookieParam = Protocol.Network.CookieParam;
 import TargetInfo = Protocol.Target.TargetInfo;
 
 export class BrowserContext
   extends TypedEventEmitter<IPuppetContextEvents>
-  implements IPuppetContext {
+  implements IPuppetContext
+{
   public logger: IBoundLog;
 
   public workersById = new Map<string, IPuppetWorker>();
@@ -219,13 +219,15 @@ export class BrowserContext
     if (this.isClosing) return;
     this.isClosing = true;
 
-    await Promise.all([...this.pagesById.values()].map(x => x.close()));
-    await this.sendWithBrowserDevtoolsSession('Target.disposeBrowserContext', {
-      browserContextId: this.id,
-    }).catch(err => {
-      if (err instanceof CanceledPromiseError) return;
-      throw err;
-    });
+    if (this.browser.devtoolsSession.isConnected()) {
+      await Promise.all([...this.pagesById.values()].map(x => x.close()));
+      await this.sendWithBrowserDevtoolsSession('Target.disposeBrowserContext', {
+        browserContextId: this.id,
+      }).catch(err => {
+        if (err instanceof CanceledPromiseError) return;
+        throw err;
+      });
+    }
     removeEventListeners(this.eventListeners);
     this.browser.browserContextsById.delete(this.id);
   }

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -71,14 +71,6 @@ export default class Puppet {
     }
   }
 
-  public isSameEngine(other: Puppet): boolean {
-    return (
-      this.browserEngine.executablePath === other.browserEngine.executablePath &&
-      this.browserEngine.launchArguments.toString() ===
-        other.browserEngine.launchArguments.toString()
-    );
-  }
-
   public newContext(
     plugins: ICorePlugins,
     logger: IBoundLog,

--- a/puppet/index.ts
+++ b/puppet/index.ts
@@ -8,6 +8,7 @@ import ICorePlugins from '@ulixee/hero-interfaces/ICorePlugins';
 import IProxyConnectionOptions from '@ulixee/hero-interfaces/IProxyConnectionOptions';
 import IPuppetLaunchArgs from '@ulixee/hero-interfaces/IPuppetLaunchArgs';
 import IPuppetContext from '@ulixee/hero-interfaces/IPuppetContext';
+import IDevtoolsSession from '@ulixee/hero-interfaces/IDevtoolsSession';
 import launchProcess from './lib/launchProcess';
 import PuppetLaunchError from './lib/PuppetLaunchError';
 
@@ -36,7 +37,10 @@ export default class Puppet {
     puppBrowserCounter += 1;
   }
 
-  public async start(): Promise<Puppet> {
+  public async start(options?: {
+    attachToDevtools?: (session: IDevtoolsSession) => Promise<any>;
+    onClose?: () => any;
+  }): Promise<Puppet> {
     try {
       this.isStarted = true;
 
@@ -47,9 +51,11 @@ export default class Puppet {
       const launchedProcess = await launchProcess(
         this.browserEngine.executablePath,
         this.browserEngine.launchArguments,
+        options?.onClose,
       );
 
       this.browser = await this.launcher.createPuppet(launchedProcess, this.browserEngine);
+      this.browser.onDevtoolsAttached = options?.attachToDevtools;
 
       const features = await this.browser.getFeatures();
       this.supportsBrowserContextProxy = features?.supportsPerBrowserContextProxy ?? false;

--- a/puppet/lib/launchProcess.ts
+++ b/puppet/lib/launchProcess.ts
@@ -31,6 +31,7 @@ const logProcessExit = process.env.NODE_ENV !== 'test';
 export default async function launchProcess(
   executablePath: string,
   processArguments: string[],
+  onClose?: () => any,
   env?: NodeJS.ProcessEnv,
 ): Promise<ILaunchedProcess> {
   const stdio: StdioOptions = ['ignore', 'pipe', 'pipe'];
@@ -82,6 +83,7 @@ export default async function launchProcess(
   let processKilled = false;
   launchedProcess.once('exit', (exitCode, signal) => {
     processKilled = true;
+    if (onClose) onClose();
 
     if (!websocketEndpointResolvable.isResolved) {
       websocketEndpointResolvable.reject(new Error('Chrome exited during launch'));
@@ -116,6 +118,7 @@ export default async function launchProcess(
         launchedProcess.kill('SIGKILL');
       }
       if (dataDir) cleanDataDir(dataDir);
+      if (onClose) onClose();
       return closed;
     } catch (error) {
       // might have already been kill off

--- a/replay/backend/api/ReplayTabState.ts
+++ b/replay/backend/api/ReplayTabState.ts
@@ -225,7 +225,7 @@ export default class ReplayTabState extends EventEmitter {
     if (!newTick) return;
     if (!this.replayTime.close) {
       // give ticks time to load. TODO: need a better strategy for this
-      if (new Date().getTime() - new Date(newTick.timestamp).getTime() < 2e3) return;
+      if (Date.now() - new Date(newTick.timestamp).getTime() < 2e3) return;
     }
 
     // console.log('Loading tick %s', newTickIdx);
@@ -503,8 +503,7 @@ export default class ReplayTabState extends EventEmitter {
   public checkBroadcast() {
     clearTimeout(this.broadcastTimer);
 
-    const shouldBroadcast =
-      !this.lastBroadcast || new Date().getTime() - this.lastBroadcast.getTime() > 500;
+    const shouldBroadcast = !this.lastBroadcast || Date.now() - this.lastBroadcast.getTime() > 500;
 
     // if we haven't updated in 500ms, do so now
     if (shouldBroadcast) {

--- a/replay/backend/api/ReplayTime.ts
+++ b/replay/backend/api/ReplayTime.ts
@@ -16,7 +16,7 @@ export default class ReplayTime {
       this.millis = close.getTime() - start.getTime();
     } else {
       // add 10 seconds to end time
-      this.millis = (new Date().getTime() - start.getTime()) * 1.25;
+      this.millis = (Date.now() - start.getTime()) * 1.25;
     }
   }
 }

--- a/replay/backend/models/ReplayView.ts
+++ b/replay/backend/models/ReplayView.ts
@@ -198,7 +198,7 @@ export default class ReplayView extends ViewBackend {
         const nextTickTime = new Date(this.tabState.nextTick.timestamp);
         const currentTickTime = new Date(this.tabState.currentTick.timestamp);
         const diff = nextTickTime.getTime() - currentTickTime.getTime();
-        const fnDuration = new Date().getTime() - startTime.getTime();
+        const fnDuration = Date.now() - startTime.getTime();
         millisToNextTick = diff - fnDuration + startMillisDeficit;
       }
 
@@ -307,7 +307,7 @@ export default class ReplayView extends ViewBackend {
     if (!this.replayApi) return;
 
     const lastActivityMillis =
-      new Date().getTime() - (this.replayApi.lastActivityDate ?? new Date()).getTime();
+      Date.now() - (this.replayApi.lastActivityDate ?? new Date()).getTime();
 
     if (lastActivityMillis < this.lastInactivityMillis) {
       this.lastInactivityMillis = lastActivityMillis;


### PR DESCRIPTION
Various fixes related to using headed and hero branch
- fullstack not exporting correct variables
- convert new Date().getTime() to Date.now where appropriate
- Properly close track closed puppets
- Don't hang shutting down chrome pages when browser crashes
- Properly disconnect from http2 sessions that "goaway"
- Save preferences for devtools (like preserve log, dock mode, etc)
- Don't log socket "data" packets sent unless specifically requested

Added GlobalPool events to listen for all browsers closed and all windows closed in all browsers.
- all-browsers-closed: this is needed so we know when we should shut down fullstack
- browser-closed-all-windows: this is needed in headed mode and fullstack so we can tell if the user has killed off all browser windows and just wants to close things down