### PR TITLE
feat(core): keepalive and resume a session

### DIFF
--- a/commons/SqliteTable.ts
+++ b/commons/SqliteTable.ts
@@ -104,11 +104,22 @@ export default abstract class SqliteTable<T> {
   }
 
   private createTableStatement(): string {
+    const primaryKey = this.columns.filter(x => x[2]?.includes('PRIMARY KEY'));
+    let primaryKeyAddon = '';
+    if (primaryKey.length > 1) {
+      primaryKeyAddon = `PRIMARY KEY (${primaryKey.map(x => x[0]).join(', ')})`;
+      for (const key of primaryKey) {
+        key.length = 2;
+      }
+    }
     const definitions = this.columns.map(x => {
       let columnDef = `${x[0]} ${x[1]}`;
       if (x.length > 2) columnDef = `${columnDef} ${x[2]}`;
       return columnDef;
     });
+    if (primaryKeyAddon) {
+      definitions.push(primaryKeyAddon);
+    }
     return `CREATE TABLE IF NOT EXISTS ${this.tableName} (${definitions})`;
   }
 

--- a/core/injected-scripts/jsPath.ts
+++ b/core/injected-scripts/jsPath.ts
@@ -431,13 +431,20 @@ class ObjectAtPath {
       preview: generateNodePreview(objectAtPath),
     } as INodePointer;
 
+    const ids = [nodeId];
+
     if (isIterableOrArray(objectAtPath)) {
       state.iterableItems = Array.from(objectAtPath);
 
       if (state.iterableItems.length && isCustomType(state.iterableItems[0])) {
         state.iterableIsState = true;
         state.iterableItems = state.iterableItems.map(x => this.createNodePointer(x));
+        ids.push(...(state.iterableItems as any).map(x => x.id));
       }
+    }
+
+    if ('replayInteractions' in window) {
+      window.replayInteractions({ frameIdPath: '', nodeIds: ids });
     }
 
     return state;

--- a/core/injected-scripts/pageEventsRecorder.ts
+++ b/core/injected-scripts/pageEventsRecorder.ts
@@ -169,6 +169,18 @@ class PageEventsRecorder {
       Date.now(),
     ] as IMouseEvent;
 
+    if ('replayInteractions' in window) {
+      const [, pageX, pageY, offsetX, offsetY, buttons] = event;
+      window.replayInteractions(undefined, {
+        buttons,
+        frameIdPath: '',
+        offsetX,
+        pageX,
+        pageY,
+        offsetY,
+        targetNodeId: nodeId,
+      });
+    }
     this.mouseEvents.push(event);
   }
 

--- a/core/lib/CommandRecorder.ts
+++ b/core/lib/CommandRecorder.ts
@@ -4,6 +4,7 @@ import ICommandMeta from '@ulixee/hero-interfaces/ICommandMeta';
 import TypeSerializer from '@ulixee/commons/TypeSerializer';
 import Session from './Session';
 import Tab from './Tab';
+import FrameEnvironment from './FrameEnvironment';
 
 const { log } = Log(module);
 type AsyncFunc = (...args: any[]) => Promise<any>;
@@ -30,7 +31,8 @@ export default class CommandRecorder {
   }
 
   private async runCommandFn<T>(commandFn: AsyncFunc, ...args: any[]): Promise<T> {
-    if (!this.fnNames.has(commandFn.name)) throw new Error(`Unsupported function requested ${commandFn.name}`);
+    if (!this.fnNames.has(commandFn.name))
+      throw new Error(`Unsupported function requested ${commandFn.name}`);
 
     const { session } = this;
     const sessionState = session.sessionState;
@@ -48,6 +50,11 @@ export default class CommandRecorder {
       frameId,
       name: commandFn.name,
       args: args.length ? TypeSerializer.stringify(args) : undefined,
+      run: session.resumeCounter,
+      url: (
+        session.getTab(tabId)?.frameEnvironmentsById.get(frameId) ??
+        this.session.getLastActiveTab()?.mainFrameEnvironment
+      )?.url,
     } as ICommandMeta;
 
     if (sessionState.nextCommandMeta) {
@@ -58,16 +65,23 @@ export default class CommandRecorder {
       commandMeta.clientStartDate = startDate?.getTime();
     }
 
+    if (commandMeta.run > 0 && this.fulfillCommandWithLastRun(commandMeta)) {
+      return commandMeta.result;
+    }
+
+    const tab = session.getTab(tabId);
+    tab?.willRunCommand(commandMeta);
+
+    let frame: FrameEnvironment;
     if (frameId) {
-      const tab = session.getTab(tabId);
-      const frame = tab.frameEnvironmentsById.get(frameId);
+      frame = tab.frameEnvironmentsById.get(frameId);
       frame.navigationsObserver.willRunCommand(commandMeta, commandHistory);
     }
     const id = this.logger.info('Command.run', commandMeta);
 
     let result: T;
     try {
-      commandMeta.runStartDate = new Date().getTime();
+      commandMeta.runStartDate = Date.now();
       sessionState.recordCommandStart(commandMeta);
 
       result = await commandFn.call(this.owner, ...args);
@@ -76,11 +90,71 @@ export default class CommandRecorder {
       result = err;
       throw err;
     } finally {
-      commandMeta.endDate = new Date().getTime();
+      commandMeta.endDate = Date.now();
       commandMeta.result = result;
       // NOTE: second insert on purpose -- it will do an update
       sessionState.recordCommandFinished(commandMeta);
+      tab?.didRunCommand(commandMeta);
       this.logger.stats('Command.done', { result, parentLogId: id });
     }
+  }
+
+  private fulfillCommandWithLastRun(commandMeta: ICommandMeta): boolean {
+    const { session } = this;
+    const sessionState = session.sessionState;
+    const commandHistory = sessionState.commands;
+    const { tabId, frameId, id } = commandMeta;
+
+    const { sessionResume } = session.options;
+    if (!sessionResume) return;
+    // don't use any cached commands if sessionStart
+    if (sessionResume.startLocation === 'sessionStart') return;
+
+    const startAtPageStart = sessionResume.startLocation === 'pageStart';
+    const currentUrl = session.tabsById.get(tabId).frameEnvironmentsById.get(frameId)?.url;
+
+    // make sure last command reused a command run
+    const lastCommand = sessionState.lastCommand;
+    if (
+      lastCommand &&
+      lastCommand.run === commandMeta.run &&
+      lastCommand.reusedCommandFromRun === undefined
+    ) {
+      return false;
+    }
+
+    const lastRun = commandMeta.run - 1;
+    for (let i = commandHistory.length - 1; i >= 0; i -= 1) {
+      const previous = commandHistory[i];
+      if (previous.run < lastRun) break;
+
+      if (
+        previous.run === lastRun &&
+        previous.id === id &&
+        previous.tabId === commandMeta.tabId &&
+        previous.args === commandMeta.args &&
+        previous.name === commandMeta.name &&
+        !previous.resultType?.includes('Error')
+      ) {
+        // if page start, we should break if url is the same.
+        // NOTE: this will not handle a flow that goes to the same url multiple times
+        if (
+          startAtPageStart &&
+          currentUrl === previous.url &&
+          commandMeta.name !== 'waitForLocation' // can't wait for location again here
+        ) {
+          break;
+        }
+
+        commandMeta.result = previous.result;
+        commandMeta.runStartDate = previous.runStartDate;
+        commandMeta.endDate = previous.endDate;
+        commandMeta.reusedCommandFromRun = previous.reusedCommandFromRun ?? previous.run;
+        commandMeta.url = previous.url;
+        sessionState.recordCommandStart(commandMeta);
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -241,6 +241,7 @@ export default class FrameEnvironment {
       result: entry.result,
       runStartDate,
       endDate,
+      run: this.session.resumeCounter,
     };
     if (this.sessionState.nextCommandMeta) {
       const { commandId, sendDate, startDate: clientStartDate } = this.sessionState.nextCommandMeta;

--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -21,6 +21,7 @@ import { IMouseEvent } from '@ulixee/hero-interfaces/IMouseEvent';
 import { IDomChangeEvent } from '@ulixee/hero-interfaces/IDomChangeEvent';
 import injectedSourceUrl from '@ulixee/hero-interfaces/injectedSourceUrl';
 import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
+import IDeviceProfile from '@ulixee/hero-interfaces/IDeviceProfile';
 import ResourcesTable from '../models/ResourcesTable';
 import SessionsDb from '../dbs/SessionsDb';
 import SessionDb from '../dbs/SessionDb';
@@ -113,8 +114,10 @@ export default class SessionState {
     browserEmulatorId: string;
     browserVersion: string;
     humanEmulatorId: string;
+    userAgentString: string;
     timezoneId?: string;
     locale?: string;
+    deviceProfile?: IDeviceProfile;
     sessionOptions: ISessionCreateOptions;
   }) {
     const { sessionName, scriptInstanceMeta, ...optionsToStore } = options.sessionOptions;
@@ -123,12 +126,14 @@ export default class SessionState {
       this.sessionName,
       options.browserEmulatorId,
       options.browserVersion,
+      options.userAgentString,
       options.humanEmulatorId,
       this.createDate,
       this.scriptInstanceMeta?.id,
       this.scriptInstanceMeta?.entrypoint,
       this.scriptInstanceMeta?.startDate,
       options.timezoneId,
+      options.deviceProfile,
       this.viewport,
       options.locale,
       optionsToStore,
@@ -340,13 +345,8 @@ export default class SessionState {
     tabId: number,
     resourceEvent: IRequestSessionResponseEvent | IRequestSessionRequestEvent,
   ): IResourceMeta {
-    const {
-      request,
-      response,
-      resourceType,
-      browserRequestId,
-      redirectedToUrl,
-    } = resourceEvent as IRequestSessionResponseEvent;
+    const { request, response, resourceType, browserRequestId, redirectedToUrl } =
+      resourceEvent as IRequestSessionResponseEvent;
 
     if (browserRequestId) {
       // NOTE: browserRequestId can be shared amongst redirects

--- a/core/models/CommandsTable.ts
+++ b/core/models/CommandsTable.ts
@@ -11,6 +11,7 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
       'Commands',
       [
         ['id', 'INTEGER', 'NOT NULL PRIMARY KEY'],
+        ['run', 'INTEGER', 'NOT NULL PRIMARY KEY'],
         ['tabId', 'INTEGER'],
         ['frameId', 'INTEGER'],
         ['name', 'TEXT'],
@@ -22,6 +23,7 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
         ['endDate', 'INTEGER'],
         ['result', 'TEXT'],
         ['resultType', 'TEXT'],
+        ['reusedCommandFromRun', 'INTEGER'],
       ],
       true,
     );
@@ -30,8 +32,11 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
   }
 
   public insert(commandMeta: ICommandMeta) {
+    commandMeta.resultType = commandMeta.result?.constructor?.name ?? typeof commandMeta.result;
+
     this.queuePendingInsert([
       commandMeta.id,
+      commandMeta.run,
       commandMeta.tabId,
       commandMeta.frameId,
       commandMeta.name,
@@ -42,9 +47,8 @@ export default class CommandsTable extends SqliteTable<ICommandMeta> {
       commandMeta.runStartDate,
       commandMeta.endDate,
       TypeSerializer.stringify(commandMeta.result),
-      commandMeta.result?.constructor
-        ? commandMeta.result.constructor.name
-        : typeof commandMeta.result,
+      commandMeta.resultType,
+      commandMeta.reusedCommandFromRun,
     ]);
   }
 

--- a/core/models/SessionTable.ts
+++ b/core/models/SessionTable.ts
@@ -1,6 +1,8 @@
 import { Database as SqliteDatabase } from 'better-sqlite3';
 import IViewport from '@ulixee/hero-interfaces/IViewport';
 import SqliteTable from '@ulixee/commons/SqliteTable';
+import IDeviceProfile from '@ulixee/hero-interfaces/IDeviceProfile';
+import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
 
 export default class SessionTable extends SqliteTable<ISessionRecord> {
   constructor(readonly db: SqliteDatabase) {
@@ -13,14 +15,14 @@ export default class SessionTable extends SqliteTable<ISessionRecord> {
         ['browserEmulatorId', 'TEXT'],
         ['browserVersion', 'TEXT'],
         ['humanEmulatorId', 'TEXT'],
-        ['screenWidth', 'INTEGER'],
-        ['screenHeight', 'INTEGER'],
-        ['deviceScaleFactor', 'INTEGER'],
         ['startDate', 'INTEGER'],
         ['closeDate', 'INTEGER'],
         ['scriptInstanceId', 'TEXT'],
         ['scriptEntrypoint', 'TEXT'],
         ['scriptStartDate', 'INTEGER'],
+        ['userAgentString', 'TEXT'],
+        ['viewport', 'TEXT'],
+        ['deviceProfile', 'TEXT'],
         ['timezoneId', 'TEXT'],
         ['locale', 'TEXT'],
         ['createSessionOptions', 'TEXT'],
@@ -34,30 +36,32 @@ export default class SessionTable extends SqliteTable<ISessionRecord> {
     name: string,
     browserEmulatorId: string,
     browserVersion: string,
+    userAgentString: string,
     humanEmulatorId: string,
     startDate: Date,
     scriptInstanceId: string,
     scriptEntrypoint: string,
     scriptStartDate: number,
     timezoneId: string,
+    deviceProfile: IDeviceProfile,
     viewport: IViewport,
     locale: string,
     createSessionOptions: any,
-  ) {
+  ): void {
     const record = [
       id,
       name,
       browserEmulatorId,
       browserVersion,
       humanEmulatorId,
-      viewport.screenWidth,
-      viewport.screenHeight,
-      viewport.deviceScaleFactor,
       startDate.getTime(),
       null,
       scriptInstanceId,
       scriptEntrypoint,
       scriptStartDate,
+      userAgentString,
+      JSON.stringify(viewport),
+      JSON.stringify(deviceProfile),
       timezoneId,
       locale,
       JSON.stringify(createSessionOptions),
@@ -65,7 +69,7 @@ export default class SessionTable extends SqliteTable<ISessionRecord> {
     this.insertNow(record);
   }
 
-  public close(id: string, closeDate: Date) {
+  public close(id: string, closeDate: Date): void {
     const values = [closeDate.getTime(), id];
     const fields = ['closeDate'];
     const sql = `UPDATE ${this.tableName} SET ${fields.map(n => `${n}=?`).join(', ')} WHERE id=?`;
@@ -73,8 +77,12 @@ export default class SessionTable extends SqliteTable<ISessionRecord> {
     if (this.insertCallbackFn) this.insertCallbackFn([]);
   }
 
-  public get() {
-    return this.db.prepare(`select * from ${this.tableName}`).get() as ISessionRecord;
+  public get(): ISessionRecord {
+    const record = this.db.prepare(`select * from ${this.tableName}`).get() as ISessionRecord;
+    record.createSessionOptions = JSON.parse(record.createSessionOptions as string);
+    record.viewport = JSON.parse((record.viewport as any) ?? 'undefined');
+    record.deviceProfile = JSON.parse((record.deviceProfile as any) ?? 'undefined');
+    return record;
   }
 }
 
@@ -84,15 +92,15 @@ export interface ISessionRecord {
   browserEmulatorId: string;
   browserVersion: string;
   humanEmulatorId: string;
-  screenWidth: number;
-  screenHeight: number;
-  deviceScaleFactor: number;
   startDate: number;
   closeDate: number;
   scriptInstanceId: string;
   scriptEntrypoint: string;
   scriptStartDate: number;
+  userAgentString: string;
+  viewport: IViewport;
   timezoneId: string;
   locale: string;
-  createSessionOptions: string;
+  deviceProfile: IDeviceProfile;
+  createSessionOptions: ISessionCreateOptions;
 }

--- a/core/test/sessionResume.test.ts
+++ b/core/test/sessionResume.test.ts
@@ -1,0 +1,554 @@
+import { Helpers } from '@ulixee/hero-testing';
+import { ITestKoaServer } from '@ulixee/hero-testing/helpers';
+import ISessionCreateOptions from '@ulixee/hero-interfaces/ISessionCreateOptions';
+import HumanEmulator from '@ulixee/hero-plugin-utils/lib/HumanEmulator';
+import IUserProfile from '@ulixee/hero-interfaces/IUserProfile';
+import Core, { Tab } from '../index';
+import ConnectionToClient from '../connections/ConnectionToClient';
+import Session from '../lib/Session';
+import Interactor from '../lib/Interactor';
+
+const playInteractionSpy = jest.spyOn(Interactor.prototype, 'play');
+let koaServer: ITestKoaServer;
+let connectionToClient: ConnectionToClient;
+beforeAll(async () => {
+  Core.use(
+    class BasicHumanEmulator extends HumanEmulator {
+      static id = 'basic';
+    },
+  );
+  await Core.start();
+  connectionToClient = Core.addConnection();
+  await connectionToClient.connect();
+  Helpers.onClose(() => connectionToClient.disconnect(), true);
+  koaServer = await Helpers.runKoaServer();
+});
+
+afterAll(Helpers.afterAll);
+afterEach(Helpers.afterEach);
+
+describe('sessionResume tests when resume location is currentLocation', () => {
+  test('should re-use commands multiple times', async () => {
+    koaServer.get('/sessionResume', ctx => (ctx.body = `<body><h1>Hover me</h1></body>`));
+    let sessionId: string;
+    for (let i = 0; i < 5; i += 1) {
+      const options: ISessionCreateOptions = { sessionKeepAlive: true };
+      if (sessionId) {
+        options.sessionResume = {
+          sessionId,
+          startLocation: 'currentLocation',
+        };
+      }
+      const { session, tab } = await createSession(options);
+
+      if (sessionId) expect(sessionId).toBe(session.id);
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResume`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      sessionId = session.id;
+      expect(session.sessionState.commands).toHaveLength(2 * (i + 1));
+      // should reuse the commands from the first 2
+      expect(session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0)).toHaveLength(
+        session.sessionState.commands.length - 2,
+      );
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test('should run new commands when there are none matching', async () => {
+    playInteractionSpy.mockClear();
+    koaServer.get(
+      '/sessionAddon',
+      ctx => (ctx.body = `<body><h1>Hover me</h1><h5>Another</h5></body>`),
+    );
+    let sessionId: string;
+
+    {
+      const { session, tab } = await createSession({ sessionKeepAlive: true });
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionAddon`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+      sessionId = session.id;
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+    }
+    {
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'currentLocation',
+        },
+      });
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionAddon`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h5']] },
+      ]);
+      expect(playInteractionSpy).toHaveBeenCalledTimes(2);
+
+      expect(session.sessionState.commands).toHaveLength(4);
+
+      // should reuse the commands from only the first one
+      expect(session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0)).toHaveLength(
+        1,
+      );
+    }
+  });
+
+  test('should run all commands once the commands have diverged from previous run', async () => {
+    playInteractionSpy.mockClear();
+    koaServer.get(
+      '/sessionResumeDivergence',
+      ctx =>
+        (ctx.body = `<body>
+<div id="div1">div 1</div>
+<div id="div2">div 2</div>
+<div id="div3">div 3</div>
+</body>`),
+    );
+    let sessionId: string;
+
+    {
+      const { session, tab } = await createSession({ sessionKeepAlive: true });
+      sessionId = session.id;
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeDivergence`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 3);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div2']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 4);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div3']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 5);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div1']] },
+      ]);
+      expect(playInteractionSpy).toHaveBeenCalledTimes(4);
+    }
+    {
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'currentLocation',
+        },
+      });
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeDivergence`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 3);
+      // DIFFERENT DIV! should diverge
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div3']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 4);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div3']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 5);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', '#div1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(4 + 3);
+
+      expect(session.sessionState.commands).toHaveLength(10);
+
+      // should reuse the commands from only the first one
+      expect(session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0)).toHaveLength(
+        2,
+      );
+    }
+  });
+});
+
+describe('sessionResume tests when resume location is pageStart', () => {
+  test('should be able to start at the beginning of pages', async () => {
+    playInteractionSpy.mockClear();
+    koaServer.get(
+      '/sessionResumePageStart1',
+      ctx =>
+        (ctx.body = `<body><h1>Hover me</h1><a id="link" href="/sessionResumePageStart2">Go to page 2</a></body>`),
+    );
+    koaServer.get(
+      '/sessionResumePageStart2',
+      ctx =>
+        (ctx.body = `<body><h1>Hover me</h1><a id="link" href="/sessionResumePageStart3">Go to page 3</a></body>`),
+    );
+    koaServer.get(
+      '/sessionResumePageStart3',
+      ctx => (ctx.body = `<body><h1>You got to page 3</h1></body>`),
+    );
+    let sessionId: string;
+
+    {
+      const { session, tab } = await createSession({ sessionKeepAlive: true });
+      sessionId = session.id;
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumePageStart1`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 3);
+      await tab.interact([
+        { command: 'click', mousePosition: ['document', ['querySelector', 'a']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 4);
+      await tab.waitForLocation('change');
+
+      simulateScriptSendingCommandMeta(session, 5);
+      await tab.waitForLoad('PaintingStable');
+
+      simulateScriptSendingCommandMeta(session, 6);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(tab.url).toBe(`${koaServer.baseUrl}/sessionResumePageStart2`);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(3);
+    }
+    {
+      playInteractionSpy.mockClear();
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'pageStart',
+        },
+      });
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumePageStart1`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 3);
+      await tab.interact([
+        { command: 'click', mousePosition: ['document', ['querySelector', 'a']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 4);
+      await tab.waitForLocation('change');
+
+      simulateScriptSendingCommandMeta(session, 5);
+      await tab.waitForLoad('PaintingStable');
+
+      simulateScriptSendingCommandMeta(session, 6);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(tab.url).toBe(`${koaServer.baseUrl}/sessionResumePageStart2`);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+
+      expect(session.sessionState.commands).toHaveLength(12);
+
+      // should reuse the commands from only the first one
+      expect(session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0)).toHaveLength(
+        4,
+      );
+
+      simulateScriptSendingCommandMeta(session, 7);
+      await tab.interact([
+        { command: 'click', mousePosition: ['document', ['querySelector', 'a']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 8);
+      await tab.waitForLoad('PaintingStable');
+
+      // should reuse the commands from only the first one
+      expect(session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0)).toHaveLength(
+        4,
+      );
+    }
+
+    // run 3
+    {
+      playInteractionSpy.mockClear();
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'pageStart',
+        },
+      });
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumePageStart1`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 3);
+      await tab.interact([
+        { command: 'click', mousePosition: ['document', ['querySelector', 'a']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 4);
+      await tab.waitForLocation('change');
+
+      simulateScriptSendingCommandMeta(session, 5);
+      await tab.waitForLoad('PaintingStable');
+
+      simulateScriptSendingCommandMeta(session, 6);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 7);
+      await tab.interact([
+        { command: 'click', mousePosition: ['document', ['querySelector', 'a']] },
+      ]);
+
+      simulateScriptSendingCommandMeta(session, 8);
+      await tab.waitForLoad('PaintingStable');
+
+      simulateScriptSendingCommandMeta(session, 9);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+
+      // should reuse the commands from only the first one
+      expect(
+        session.sessionState.commands.filter(x => x.reusedCommandFromRun === 0 && x.run === 2),
+      ).toHaveLength(4);
+      expect(
+        session.sessionState.commands.filter(x => x.reusedCommandFromRun === 1 && x.run === 2),
+      ).toHaveLength(3);
+    }
+  });
+});
+
+describe('sessionResume tests when resume location is sessionStart', () => {
+  test('should restart a session within a currently open browserContext', async () => {
+    playInteractionSpy.mockClear();
+    let counter = 1;
+    koaServer.get('/sessionResumeSessionStart', ctx => {
+      ctx.cookies.set(`Cookie${counter}`, 'This is a test', {
+        httpOnly: true,
+      });
+      counter += 1;
+      ctx.body = `<body><h1>title</h1></body>`;
+    });
+    let sessionId: string;
+    let firstTabPageId: string;
+    let profile: IUserProfile;
+
+    {
+      const { session, tab } = await createSession({ sessionKeepAlive: true });
+      sessionId = session.id;
+      firstTabPageId = tab.puppetPage.id;
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeSessionStart`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+      profile = await session.exportUserProfile();
+    }
+    {
+      playInteractionSpy.mockClear();
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'sessionStart',
+        },
+      });
+
+      expect(session.id).toBe(sessionId);
+      expect(tab.puppetPage.id).not.toBe(firstTabPageId);
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeSessionStart`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+      expect(
+        session.sessionState.commands.filter(
+          x => x.reusedCommandFromRun === undefined && x.run === 1,
+        ),
+      ).toHaveLength(2);
+      const newProfile = await session.exportUserProfile();
+      expect(newProfile.userAgentString).toBe(profile.userAgentString);
+      expect(newProfile.deviceProfile).toEqual(profile.deviceProfile);
+      expect(newProfile.cookies).not.toEqual(profile.cookies);
+      expect(newProfile.cookies.filter(x => x.name === 'Cookie1')).toHaveLength(0);
+      expect(newProfile.cookies.filter(x => x.name === 'Cookie2')).toHaveLength(1);
+    }
+  });
+
+  test('should restart a session with a closed session', async () => {
+    playInteractionSpy.mockClear();
+    let counter = 1;
+    koaServer.get('/sessionResumeSessionStartClosed', ctx => {
+      ctx.cookies.set(`Cookie${counter}`, 'This is a test', {
+        httpOnly: true,
+      });
+      counter += 1;
+      ctx.body = `<body><h1>title</h1></body>`;
+    });
+    let sessionId: string;
+    let firstTabPageId: string;
+    let profile: IUserProfile;
+
+    {
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        locale: 'de',
+        userProfile: {
+          cookies: [
+            {
+              sameSite: 'None',
+              name: 'CookieRestore',
+              value: 'true',
+              domain: 'localhost',
+              path: '/',
+              expires: '-1',
+              httpOnly: true,
+              secure: false,
+            },
+          ],
+        },
+      });
+      sessionId = session.id;
+      firstTabPageId = tab.puppetPage.id;
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeSessionStartClosed`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+      profile = await session.exportUserProfile();
+      expect(profile.cookies).toHaveLength(2);
+      await session.close();
+    }
+    {
+      playInteractionSpy.mockClear();
+      const { session, tab } = await createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId,
+          startLocation: 'sessionStart',
+        },
+      });
+
+      // should be a new session this time
+      expect(session.id).not.toBe(sessionId);
+      expect(tab.puppetPage.id).not.toBe(firstTabPageId);
+
+      simulateScriptSendingCommandMeta(session, 1);
+      await tab.goto(`${koaServer.baseUrl}/sessionResumeSessionStartClosed`);
+
+      simulateScriptSendingCommandMeta(session, 2);
+      await tab.interact([
+        { command: 'move', mousePosition: ['document', ['querySelector', 'h1']] },
+      ]);
+
+      expect(playInteractionSpy).toHaveBeenCalledTimes(1);
+      expect(session.sessionState.commands).toHaveLength(2);
+      expect(
+        session.sessionState.commands.filter(x => x.reusedCommandFromRun !== undefined),
+      ).toHaveLength(0);
+
+      const meta = await connectionToClient.getHeroMeta({ sessionId: session.id });
+      expect(meta.locale).toBe('de');
+
+      const newProfile = await session.exportUserProfile();
+      expect(newProfile.userAgentString).toBe(profile.userAgentString);
+      expect(newProfile.deviceProfile).toEqual(profile.deviceProfile);
+      expect(newProfile.cookies).not.toEqual(profile.cookies);
+      expect(newProfile.cookies.filter(x => x.name === 'Cookie1')).toHaveLength(0);
+      expect(newProfile.cookies.filter(x => x.name === 'Cookie2')).toHaveLength(1);
+      expect(newProfile.cookies.filter(x => x.name === 'CookieRestore')).toHaveLength(1);
+    }
+  });
+
+  test('should throw an error if a session is not available to resume', async () => {
+    await expect(
+      createSession({
+        sessionKeepAlive: true,
+        sessionResume: {
+          sessionId: 'notreal',
+          startLocation: 'sessionStart',
+        },
+      }),
+    ).rejects.toThrowError();
+  });
+});
+
+function simulateScriptSendingCommandMeta(session: Session, id: number): void {
+  session.sessionState.nextCommandMeta = {
+    commandId: id,
+    startDate: new Date(),
+    sendDate: new Date(),
+  };
+}
+
+async function createSession(
+  options?: ISessionCreateOptions,
+): Promise<{ session: Session; tab: Tab }> {
+  const meta = await connectionToClient.createSession(options);
+  const tab = Session.getTab(meta);
+  Helpers.needsClosing.push(tab.session);
+  return { session: tab.session, tab };
+}

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -7,3 +7,4 @@
 !news.ycombinator.com.ts
 !detach.ts
 !ulixee.org.ts
+!sessionResume.ts

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -8,3 +8,4 @@
 !detach.ts
 !ulixee.org.ts
 !sessionResume.ts
+!server.ts

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -1,0 +1,75 @@
+import Core, { GlobalPool } from '@ulixee/hero-core';
+import * as WebSocket from 'ws';
+import TypeSerializer from '@ulixee/commons/TypeSerializer';
+import ICoreResponsePayload from '@ulixee/hero-interfaces/ICoreResponsePayload';
+import ICoreEventPayload from '@ulixee/hero-interfaces/ICoreEventPayload';
+
+(async () => {
+  await Core.start();
+  const server = new CoreServer(1337);
+
+  Core.onShutdown = () => {
+    console.log('Exiting Core Process');
+    server.close();
+    process.exit();
+  };
+  GlobalPool.events.on('browser-has-no-open-windows', ({ puppet }) => puppet.close());
+  GlobalPool.events.on('all-browsers-closed', () => Core.shutdown());
+})().catch(error => {
+  console.log('ERROR starting core', error);
+  process.exit(1);
+});
+
+class CoreServer {
+  private readonly wsServer: WebSocket.Server;
+
+  constructor(port: number) {
+    this.wsServer = new WebSocket.Server({
+      port,
+    });
+    this.wsServer.on('connection', this.handleWsConnection.bind(this));
+  }
+
+  public close(): void {
+    try {
+      for (const ws of this.wsServer.clients) {
+        if (isOpen(ws)) ws.terminate();
+      }
+      this.wsServer.close();
+    } catch (error) {
+      console.log('Error closing socket connections', error);
+    }
+  }
+
+  private handleWsConnection(ws: WebSocket): void {
+    const connection = Core.addConnection();
+    ws.on('message', message => {
+      const payload = TypeSerializer.parse(message.toString(), 'CLIENT');
+      return connection.handleRequest(payload);
+    });
+
+    ws.once('close', () => connection.disconnect());
+    ws.once('error', error => connection.disconnect(error));
+
+    connection.on('message', this.sendMessage.bind(this, ws));
+  }
+
+  private sendMessage(ws: WebSocket, payload: ICoreResponsePayload | ICoreEventPayload): void {
+    if (!isOpen(ws)) return;
+
+    const json = TypeSerializer.stringify(payload);
+    ws.send(json, error => {
+      if (!error) return;
+      console.log('Error sending message', error, json);
+
+      if (isOpen(ws)) {
+        const CLOSE_UNEXPECTED_ERROR = 1011;
+        ws.close(CLOSE_UNEXPECTED_ERROR, JSON.stringify({ message: error.message }));
+      }
+    });
+  }
+}
+
+function isOpen(ws: WebSocket) {
+  return ws.readyState === WebSocket.OPEN;
+}

--- a/examples/sessionResume.ts
+++ b/examples/sessionResume.ts
@@ -1,0 +1,45 @@
+import Hero from '@ulixee/hero';
+import * as Fs from 'fs';
+
+const sessionIdPath = `${__dirname}/previousSession.txt`;
+const resumeSessionId = Fs.existsSync(sessionIdPath)
+  ? Fs.readFileSync(sessionIdPath, 'utf8')
+  : undefined;
+
+(async () => {
+  const hero = new Hero({
+    showBrowserInteractions: true, // disable to remove mouse movements and node highlights (can be detected by page!)
+    showBrowser: true,
+    sessionKeepAlive: true,
+    sessionResume: {
+      startLocation: 'currentLocation', // 'currentLocation | pageStart', // default: currentLocation
+      sessionId: resumeSessionId,
+    },
+    allowManualBrowserInteraction: true, // enables mouse/keyboard input in headed browser
+    connectionToCore: {
+      host: `ws://localhost:1337`, // NOTE: you need to start your own Ulixee server
+    },
+  });
+  const sessionId = await hero.sessionId;
+  Fs.writeFileSync(sessionIdPath, sessionId);
+  await hero.goto('https://ulixee.org');
+  await hero.waitForPaintingStable();
+
+  await hero.click(hero.document.querySelector('h1'));
+
+  await hero.click(hero.document.querySelector('.search-form  input'));
+
+  // Uncomment one by one to see changes load
+  // await hero.type('flightss');
+  //
+  // await hero.interact({ click: hero.document.querySelectorAll('.datasets .description')[4] });
+  //
+  // await hero.waitForLocation('change');
+  // await hero.waitForPaintingStable();
+  //
+  // await hero.interact({ click: hero.document.querySelector('.related-datasets a') });
+  //
+  // await hero.click(hero.document.querySelector('a[href="/pricing"]'));
+
+  await hero.close();
+})();

--- a/interfaces/ICommandMeta.ts
+++ b/interfaces/ICommandMeta.ts
@@ -11,4 +11,7 @@ export default interface ICommandMeta {
   endDate?: number;
   result?: any;
   resultType?: string;
+  run: number;
+  reusedCommandFromRun?: number;
+  url?: string; // url at time of command
 }

--- a/interfaces/ISessionCreateOptions.ts
+++ b/interfaces/ISessionCreateOptions.ts
@@ -6,6 +6,12 @@ import IGeolocation from './IGeolocation';
 
 export default interface ISessionCreateOptions extends ISessionOptions {
   sessionName?: string;
+  sessionKeepAlive?: boolean;
+  sessionResume?: {
+    startLocation: 'currentLocation' | 'pageStart' | 'sessionStart';
+    sessionId: string;
+  };
+
   browserEmulatorId?: string;
   userAgent?: string;
   scriptInstanceMeta?: IScriptInstanceMeta;
@@ -18,4 +24,8 @@ export default interface ISessionCreateOptions extends ISessionOptions {
   geolocation?: IGeolocation;
   dependencyMap?: { [clientPluginId: string]: string[] };
   corePluginPaths?: string[];
+
+  showBrowser?: boolean;
+  showBrowserInteractions?: boolean;
+  allowManualBrowserInteraction?: boolean;
 }


### PR DESCRIPTION
This feature enables us to keep alive a Chrome session and resume it.

In headed, we include user interactions and a bar showing your current command (so you can see the changes happening).

SessionResume works by comparing the sequence of commands you provide to a previous run. If we can pick up where you left the browser, we ONLY play the new commands. This helps you to build out a new script without constantly running from the beginning.

Here are the different ways SessionResume works (arguments):
- sessionId: 
  - if kept alive, it will resume the current browser context based on the start location
  - if closed, will load the session attributes from the db and recreate it with the same settings
- startLocation: where to resume commands
  - currentLocation: tries to run with as many commands that match as possible. Once a command "forks" the rest of the commands will run (vs returning the previous result)
  - pageStart: reload all commands beginning at the currently loaded page (until commands don't match)
  - sessionStart: reset cookies/storage state in the current browser window and start the script over. Will also load from the db if the session is not active anymore.