### PR TITLE
feat(plugins): mask public ip in webrtc

### DIFF
--- a/core/lib/CorePlugins.ts
+++ b/core/lib/CorePlugins.ts
@@ -10,14 +10,14 @@ import { IInteractionGroups, IInteractionStep } from '@secret-agent/interfaces/I
 import IInteractionsHelper from '@secret-agent/interfaces/IInteractionsHelper';
 import IPoint from '@secret-agent/interfaces/IPoint';
 import ICorePlugin, {
-  IHumanEmulator,
   IBrowserEmulator,
-  IBrowserEmulatorConfig,
-  ISelectBrowserMeta,
-  ICorePluginClass,
-  IOnClientCommandMeta,
   IBrowserEmulatorClass,
+  IBrowserEmulatorConfig,
+  ICorePluginClass,
+  IHumanEmulator,
   IHumanEmulatorClass,
+  IOnClientCommandMeta,
+  ISelectBrowserMeta,
 } from '@secret-agent/interfaces/ICorePlugin';
 import ICorePlugins from '@secret-agent/interfaces/ICorePlugins';
 import ICorePluginCreateOptions from '@secret-agent/interfaces/ICorePluginCreateOptions';
@@ -26,6 +26,7 @@ import { PluginTypes } from '@secret-agent/interfaces/IPluginTypes';
 import requirePlugins from '@secret-agent/plugin-utils/lib/utils/requirePlugins';
 import IHttp2ConnectSettings from '@secret-agent/interfaces/IHttp2ConnectSettings';
 import IDeviceProfile from '@secret-agent/interfaces/IDeviceProfile';
+import IHttpSocketAgent from '@secret-agent/interfaces/IHttpSocketAgent';
 import Core from '../index';
 
 const DefaultBrowserEmulatorId = 'default-browser-emulator';
@@ -134,6 +135,14 @@ export default class CorePlugins implements ICorePlugins {
 
   public onTlsConfiguration(settings: ITlsSettings): void {
     this.instances.filter(p => p.onTlsConfiguration).forEach(p => p.onTlsConfiguration(settings));
+  }
+
+  public async onHttpAgentInitialized(agent: IHttpSocketAgent): Promise<void> {
+    await Promise.all(
+      this.instances
+        .filter(p => p.onHttpAgentInitialized)
+        .map(p => p.onHttpAgentInitialized(agent)),
+    );
   }
 
   public async onNewPuppetPage(page: IPuppetPage): Promise<void> {

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -267,6 +267,7 @@ export default class Session extends TypedEventEmitter<{
     requestSession.on('resource-state', this.onResourceStates.bind(this));
     requestSession.on('socket-close', this.onSocketClose.bind(this));
     requestSession.on('socket-connect', this.onSocketConnect.bind(this));
+    await this.plugins.onHttpAgentInitialized(requestSession.requestAgent);
   }
 
   public nextTabId(): number {

--- a/full-client/test/basic.test.ts
+++ b/full-client/test/basic.test.ts
@@ -60,6 +60,10 @@ describe('basic Full Client tests', () => {
   it('should get unreachable proxy errors in the client', async () => {
     const agent = await handler.createAgent({
       upstreamProxyUrl: koaServer.baseUrl,
+      upstreamProxyIpMask: {
+        proxyIp: '127.0.0.1',
+        publicIp: '127.0.0.1',
+      },
     });
     Helpers.needsClosing.push(agent);
     await expect(agent.goto(`${koaServer.baseUrl}/`)).rejects.toThrow();

--- a/interfaces/ICorePlugin.ts
+++ b/interfaces/ICorePlugin.ts
@@ -12,10 +12,10 @@ import ITlsSettings from './ITlsSettings';
 import IHttpResourceLoadDetails from './IHttpResourceLoadDetails';
 import { IPuppetPage } from './IPuppetPage';
 import { IPuppetWorker } from './IPuppetWorker';
-import IViewport from './IViewport';
-import IGeolocation from './IGeolocation';
 import IDeviceProfile from './IDeviceProfile';
 import IHttp2ConnectSettings from './IHttp2ConnectSettings';
+import IHttpSocketAgent from './IHttpSocketAgent';
+import ISessionCreateOptions from './ISessionCreateOptions';
 
 export default interface ICorePlugin
   extends ICorePluginMethods,
@@ -108,6 +108,7 @@ export interface IBrowserEmulatorMethods {
   onDnsConfiguration?(settings: IDnsSettings): Promise<any> | void;
   onTcpConfiguration?(settings: ITcpSettings): Promise<any> | void;
   onTlsConfiguration?(settings: ITlsSettings): Promise<any> | void;
+  onHttpAgentInitialized?(agent: IHttpSocketAgent): Promise<any> | void;
 
   onHttp2SessionConnect?(
     request: IHttpResourceLoadDetails,
@@ -122,12 +123,10 @@ export interface IBrowserEmulatorMethods {
   websiteHasFirstPartyInteraction?(url: URL): Promise<any> | void; // needed for implementing first-party cookies
 }
 
-export interface IBrowserEmulatorConfig {
-  viewport?: IViewport;
-  geolocation?: IGeolocation;
-  timezoneId?: string;
-  locale?: string;
-}
+export type IBrowserEmulatorConfig = Pick<
+  ISessionCreateOptions,
+  'viewport' | 'geolocation' | 'timezoneId' | 'locale' | 'upstreamProxyIpMask' | 'upstreamProxyUrl'
+>;
 
 // decorator for browser emulator classes. hacky way to check the class implements statics we need
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/interfaces/IHttpSocketAgent.ts
+++ b/interfaces/IHttpSocketAgent.ts
@@ -1,0 +1,6 @@
+import IHttpSocketConnectOptions from './IHttpSocketConnectOptions';
+import IHttpSocketWrapper from './IHttpSocketWrapper';
+
+export default interface IHttpSocketAgent {
+  createSocketConnection(options: IHttpSocketConnectOptions): Promise<IHttpSocketWrapper>;
+}

--- a/interfaces/IHttpSocketConnectOptions.ts
+++ b/interfaces/IHttpSocketConnectOptions.ts
@@ -1,0 +1,11 @@
+export default interface IHttpSocketConnectOptions {
+  host: string;
+  port: string;
+  isSsl: boolean;
+  keepAlive?: boolean;
+  debug?: boolean;
+  servername?: string;
+  isWebsocket?: boolean;
+  keylogPath?: string;
+  proxyUrl?: string;
+}

--- a/interfaces/IHttpSocketWrapper.ts
+++ b/interfaces/IHttpSocketWrapper.ts
@@ -1,0 +1,23 @@
+import * as net from 'net';
+
+export default interface IHttpSocketWrapper {
+  id: number;
+  alpn: string;
+  socket: net.Socket;
+  dnsResolvedIp: string;
+  remoteAddress: string;
+  localAddress: string;
+  serverName: string;
+
+  createTime: Date;
+  dnsLookupTime: Date;
+  connectTime: Date;
+  errorTime: Date;
+  closeTime: Date;
+
+  isConnected: boolean;
+  isClosing: boolean;
+
+  isHttp2(): boolean;
+  close(): void;
+}

--- a/interfaces/ISessionCreateOptions.ts
+++ b/interfaces/ISessionCreateOptions.ts
@@ -14,6 +14,7 @@ export default interface ISessionCreateOptions extends ISessionOptions {
   timezoneId?: string;
   locale?: string;
   upstreamProxyUrl?: string;
+  upstreamProxyIpMask?: { publicIp?: string; proxyIp?: string; ipLookupService?: string };
   input?: { command?: string } & any;
   geolocation?: IGeolocation;
   dependencyMap?: { [clientPluginId: string]: string[] };

--- a/mitm-socket/index.ts
+++ b/mitm-socket/index.ts
@@ -5,18 +5,22 @@ import Log from '@secret-agent/commons/Logger';
 import { TypedEventEmitter } from '@secret-agent/commons/eventUtils';
 import Resolvable from '@secret-agent/commons/Resolvable';
 import { createIpcSocketPath } from '@secret-agent/commons/IpcUtils';
+import IHttpSocketConnectOptions from '@secret-agent/interfaces/IHttpSocketConnectOptions';
+import IHttpSocketWrapper from '@secret-agent/interfaces/IHttpSocketWrapper';
 import MitmSocketSession from './lib/MitmSocketSession';
 
 const { log } = Log(module);
 
 let idCounter = 0;
 
-export default class MitmSocket extends TypedEventEmitter<{
-  connect: void;
-  dial: void;
-  eof: void;
-  close: void;
-}> {
+export default class MitmSocket
+  extends TypedEventEmitter<{
+    connect: void;
+    dial: void;
+    eof: void;
+    close: void;
+  }>
+  implements IHttpSocketWrapper {
   public get isWebsocket(): boolean {
     return this.connectOpts.isWebsocket === true;
   }
@@ -50,7 +54,7 @@ export default class MitmSocket extends TypedEventEmitter<{
   private socketReadyPromise = new Resolvable<void>();
   private readonly callStack: string;
 
-  constructor(readonly sessionId: string, readonly connectOpts: IGoTlsSocketConnectOpts) {
+  constructor(readonly sessionId: string, readonly connectOpts: IHttpSocketConnectOptions) {
     super();
     this.callStack = new Error().stack.replace('Error:', '').trim();
     this.serverName = connectOpts.servername;
@@ -224,18 +228,6 @@ export default class MitmSocket extends TypedEventEmitter<{
   private onSocketClose(): void {
     this.close();
   }
-}
-
-export interface IGoTlsSocketConnectOpts {
-  host: string;
-  port: string;
-  isSsl: boolean;
-  keepAlive?: boolean;
-  debug?: boolean;
-  servername?: string;
-  isWebsocket?: boolean;
-  keylogPath?: string;
-  proxyUrl?: string;
 }
 
 class Socks5ProxyConnectError extends Error {}

--- a/plugins/default-browser-emulator/injected-scripts/webrtc.ts
+++ b/plugins/default-browser-emulator/injected-scripts/webrtc.ts
@@ -1,0 +1,32 @@
+const maskLocalIp = args.localIp;
+const replacementIp = args.proxyIp;
+
+if ('RTCIceCandidate' in self && RTCIceCandidate.prototype) {
+  proxyGetter(RTCIceCandidate.prototype, 'candidate', function () {
+    const result = ReflectCached.apply(...arguments);
+    return result.replace(maskLocalIp, replacementIp);
+  });
+  if ('address' in RTCIceCandidate.prototype) {
+    // @ts-ignore
+    proxyGetter(RTCIceCandidate.prototype, 'address', function () {
+      const result: string = ReflectCached.apply(...arguments);
+      return result.replace(maskLocalIp, replacementIp);
+    });
+  }
+  proxyFunction(RTCIceCandidate.prototype, 'toJSON', function () {
+    const json = ReflectCached.apply(...arguments);
+    if ('address' in json) json.address = json.address.replace(maskLocalIp, replacementIp);
+    if ('candidate' in json) json.candidate = json.candidate.replace(maskLocalIp, replacementIp);
+    return json;
+  });
+}
+
+if ('RTCSessionDescription' in self && RTCSessionDescription.prototype) {
+  proxyGetter(RTCSessionDescription.prototype, 'sdp', function () {
+    let result = ReflectCached.apply(...arguments);
+    while (result.indexOf(maskLocalIp) !== -1) {
+      result = result.replace(maskLocalIp, replacementIp);
+    }
+    return result;
+  });
+}

--- a/plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts
+++ b/plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts
@@ -1,0 +1,84 @@
+import * as http from 'http';
+import { RequestOptions } from 'http';
+import IHttpSocketAgent from '@secret-agent/interfaces/IHttpSocketAgent';
+import * as https from 'https';
+import * as url from 'url';
+import IHttpSocketWrapper from '@secret-agent/interfaces/IHttpSocketWrapper';
+
+export default async function lookupPublicIp(
+  ipLookupServiceUrl: string = IpLookupServices.ipify,
+  agent?: IHttpSocketAgent,
+  proxyUrl?: string,
+): Promise<string> {
+  const lookupService = parse(ipLookupServiceUrl);
+
+  const requestOptions: http.RequestOptions = {
+    method: 'GET',
+  };
+  let socketWrapper: IHttpSocketWrapper;
+  if (agent) {
+    socketWrapper = await agent.createSocketConnection({
+      host: lookupService.host,
+      port: String(lookupService.port),
+      servername: lookupService.host,
+      keepAlive: false,
+      isSsl: ipLookupServiceUrl.startsWith('https'),
+      proxyUrl,
+    });
+
+    requestOptions.createConnection = () => socketWrapper.socket;
+    requestOptions.agent = null;
+  }
+
+  try {
+    return await httpGet(ipLookupServiceUrl, requestOptions);
+  } finally {
+    if (socketWrapper) socketWrapper.close();
+  }
+}
+
+export function httpGet(requestUrl: string, requestOptions: RequestOptions): Promise<string> {
+  const httpModule = requestUrl.startsWith('https') ? https : http;
+
+  return new Promise<string>((resolve, reject) => {
+    const request = httpModule.request(requestUrl, requestOptions, async res => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        resolve(httpGet(res.headers.location, requestOptions));
+        return;
+      }
+
+      res.on('error', reject);
+      res.setEncoding('utf8');
+      let result = '';
+      for await (const chunk of res) {
+        result += chunk;
+      }
+      resolve(result);
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+const parsedLookupServicesByUrl = new Map<string, RequestOptions>();
+function parse(requestUrl: string): RequestOptions {
+  if (!parsedLookupServicesByUrl.has(requestUrl)) {
+    const options = url.parse(requestUrl);
+    options.port ||= requestUrl.startsWith('https') ? '443' : '80';
+
+    parsedLookupServicesByUrl.set(requestUrl, options);
+  }
+  return parsedLookupServicesByUrl.get(requestUrl);
+}
+
+export const IpLookupServices = {
+  ipify: 'http://api.ipify.org',
+  icanhazip: 'http://icanhazip.com', // warn: using cloudflare as of 11/19/21
+  aws: 'http://checkip.amazonaws.com',
+  dyndns: 'http://checkip.dyndns.org',
+  identMe: 'http://ident.me',
+  ifconfigMe: 'http://ifconfig.me/ip',
+  ipecho: 'http://ipecho.net/plain',
+  ipinfo: 'http://ipinfo.io/ip',
+  opendns: 'https://diagnostic.opendns.com/myip',
+};

--- a/plugins/default-browser-emulator/package.json
+++ b/plugins/default-browser-emulator/package.json
@@ -16,6 +16,7 @@
     "@secret-agent/core": "1.5.14",
     "@secret-agent/puppet": "1.5.14",
     "@secret-agent/testing": "1.5.14",
+    "@secret-agent/mitm": "1.5.14",
     "@types/tough-cookie": "^4.0.0",
     "secret-agent": "1.5.14",
     "source-map-loader": "^0.2.4"

--- a/plugins/default-browser-emulator/test/publicIp.test.ts
+++ b/plugins/default-browser-emulator/test/publicIp.test.ts
@@ -1,0 +1,31 @@
+import { Helpers } from '@secret-agent/testing';
+import CorePlugins from '@secret-agent/core/lib/CorePlugins';
+import { IBoundLog } from '@secret-agent/interfaces/ILog';
+import Log from '@secret-agent/commons/Logger';
+import RequestSession from '@secret-agent/mitm/handlers/RequestSession';
+import MitmServer from '@secret-agent/mitm/lib/MitmProxy';
+import lookupPublicIp, { IpLookupServices } from '../lib/helpers/lookupPublicIp';
+import BrowserEmulator from '../index';
+
+const { log } = Log(module);
+const browserEmulatorId = BrowserEmulator.id;
+const selectBrowserMeta = BrowserEmulator.selectBrowserMeta();
+
+afterAll(Helpers.afterAll);
+afterEach(Helpers.afterEach);
+
+test('can resolve a v4 address', async () => {
+  await expect(lookupPublicIp()).resolves.toBeTruthy();
+});
+
+test('can resolve an ip address with a mitm socket', async () => {
+  const mitmServer = await MitmServer.start();
+  Helpers.needsClosing.push(mitmServer);
+
+  const plugins = new CorePlugins({ browserEmulatorId, selectBrowserMeta }, log as IBoundLog);
+  const session = new RequestSession(`1`, plugins);
+  mitmServer.registerSession(session, false);
+  Helpers.needsClosing.push(session);
+
+  await expect(lookupPublicIp(IpLookupServices.aws, session.requestAgent)).resolves.toBeTruthy();
+});

--- a/website/docs/BasicInterfaces/Agent.md
+++ b/website/docs/BasicInterfaces/Agent.md
@@ -94,7 +94,12 @@ const { Agent } = require('secret-agent');
   - userProfile `IUserProfile`. Previous user's cookies, session, etc.
   - input `object`. An object containing properties to attach to the agent. NOTE: if using the default agent, this object will be populated with command line variables starting with `--input.{json path}`. The `{json path}` will be translated into an object set to `agent.input`.
   - showReplay `boolean`. Whether or not to show the Replay UI. Can also be set with an env variable: `SA_SHOW_REPLAY=true`.
-  - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. Dns over Tls requests will also use this proxy, if provided. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
+  - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
+  - upstreamProxyIpMask `object`. Optional settings to mask the Public IP Address of a host machine when using a proxy. This is used by the default BrowserEmulator to mask WebRTC IPs.
+    - ipLookupService `string`. The URL of an http based IpLookupService. A list of common options can be found in `plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts`. Defaults to `ipify.org`. 
+    - proxyIp `string`. The optional IP address of your proxy, if known ahead of time.
+    - publicIp `string`. The optional IP address of your host machine, if known ahead of time.
+
 
 ## Properties
 
@@ -164,7 +169,11 @@ Retrieves metadata about the agent configuration:
 - geolocation `IGeolocation`. The configured geolocation of the user (if set).
 - viewport `IViewport`. The emulated viewport size and location.
 - blockedResourceTypes `BlockedResourceType[]`. The blocked resource types.
-- upstreamProxyUrl `string`. The proxy url in use for this agent.
+- upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
+- upstreamProxyIpMask `object`. Optional settings to mask the Public IP Address of a host machine when using a proxy. This is used by the default BrowserEmulator to mask WebRTC IPs.
+  - ipLookupService `string`. The URL of an http based IpLookupService. A list of common options can be found in `plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts`. Defaults to `ipify.org`.
+  - proxyIp `string`. The optional IP address of your proxy, if known ahead of time.
+  - publicIp `string`. The optional IP address of your host machine, if known ahead of time.
 - userAgentString `string`. The user agent string used in Http requests and within the DOM.
 
 #### **Type**: `Promise<IAgentMeta>`
@@ -277,6 +286,10 @@ Update existing configuration settings.
   - viewport `IViewport`. Sets the emulated screen size, window position in the screen, inner/outer width. (See constructor for parameters).
   - blockedResourceTypes `BlockedResourceType[]`. Controls browser resource loading. Valid options are listed [here](/docs/overview/configuration#blocked-resources).
   - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
+  - upstreamProxyIpMask `object`. Optional settings to mask the Public IP Address of a host machine when using a proxy. This is used by the default BrowserEmulator to mask WebRTC IPs.
+    - ipLookupService `string`. The URL of an http based IpLookupService. A list of common options can be found in `plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts`. Defaults to `ipify.org`.
+    - proxyIp `string`. The optional IP address of your proxy, if known ahead of time.
+    - publicIp `string`. The optional IP address of your host machine, if known ahead of time.
   - connectionToCore `options | ConnectionToCore`. An object containing `IConnectionToCoreOptions` used to connect, or an already created `ConnectionToCore` instance. Defaults to booting up and connecting to a local `Core`.
 
 #### **Returns**: `Promise`

--- a/website/docs/BasicInterfaces/Handler.md
+++ b/website/docs/BasicInterfaces/Handler.md
@@ -155,6 +155,10 @@ NOTE: when using this method, you must call [`agent.close()`](/docs/basic-interf
   - showReplay `boolean`. Whether or not to show the Replay UI. Can also be set with an env variable: `SA_SHOW_REPLAY=true`.
   - input `object`. An object containing properties to attach to the agent (more frequently used with [`dispatchAgent`](#dispatch-agent))
   - upstreamProxyUrl `string`. A socks5 or http proxy url (and optional auth) to use for all HTTP requests in this session. The optional "auth" should be included in the UserInfo section of the url, eg: `http://username:password@proxy.com:80`.
+  - upstreamProxyIpMask `object`. Optional settings to mask the Public IP Address of a host machine when using a proxy. This is used by the default BrowserEmulator to mask WebRTC IPs.
+    - ipLookupService `string`. The URL of an http based IpLookupService. A list of common options can be found in `plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts`. Defaults to `ipify.org`.
+    - proxyIp `string`. The optional IP address of your proxy, if known ahead of time.
+    - publicIp `string`. The optional IP address of your host machine, if known ahead of time.
 
 See the [Configuration](/docs/overview/configuration) page for more details on `options` and its defaults. You may also want to explore [BrowserEmulators](/docs/plugins/browser-emulators) and [HumanEmulators](/docs/plugins/human-emulators).
 


### PR DESCRIPTION
This PR adds a capability to mask public ips when using a proxy. The current Chrome settings do not seem to take in our versions of Chrome. 

The feature works by modifying the dom properties to hide the proxy IP. Part of the Chrome team's challenge is that UDP over proxies is very difficult to support. WebRTC might be slightly easier, but still tough.

A user can pre-provide their proxy ip, public ip and/or an IP Lookup Http Service. If none are provided the default browser emulator will use the ipify to mask the user's public ip if using a proxy url.