### PR TITLE
fix(plugins): improve user agent selector

### DIFF
--- a/commons/Logger.ts
+++ b/commons/Logger.ts
@@ -141,6 +141,7 @@ function translateToPrintable(
         value: true,
       });
       result.error = value;
+      continue;
     }
     const printable = translateValueToPrintable(value);
     if (!printable) continue;

--- a/plugins/default-browser-emulator/lib/BrowserData.ts
+++ b/plugins/default-browser-emulator/lib/BrowserData.ts
@@ -31,6 +31,10 @@ export default class BrowserData implements IBrowserData {
     this.osDataDir = `${this.baseDataDir}/as-${os.name}-${os.version}`;
     if (!this.dataLoader.isSupportedEmulator(this.osDataDir)) {
       const otherVersions = this.dataLoader.getBrowserOperatingSystemVersions(browserId, os.name);
+      if (!otherVersions.length) {
+        throw new Error(`${browserId} has no emulation data for ${os.name}`);
+      }
+
       const closestVersionMatch = findClosestVersionMatch(os.version, otherVersions);
       this.osDataDir = `${this.baseDataDir}/as-${os.name}-${closestVersionMatch}`;
     }

--- a/plugins/default-browser-emulator/lib/DataLoader.ts
+++ b/plugins/default-browser-emulator/lib/DataLoader.ts
@@ -62,6 +62,7 @@ export default class DataLoader implements IDataCore {
   }
 
   public getBrowserOperatingSystemVersions(browserId: string, osName: string): string[] {
+    if (!this.browserOsEmulatorsByVersion[`as-${browserId}`]) return [];
     return this.browserOsEmulatorsByVersion[`as-${browserId}`][osName];
   }
 }

--- a/plugins/default-browser-emulator/lib/VersionUtils.ts
+++ b/plugins/default-browser-emulator/lib/VersionUtils.ts
@@ -11,6 +11,7 @@ export function convertMacOsVersionString(versionString: string) {
 
 export function findClosestVersionMatch(versionToMatch: string, versions: string[]) {
   if (versions.length === 1 && versions[0] === 'ALL') return 'ALL';
+  if (!versions.length) return null;
 
   // there is no guarantee we have an exact match, so let's get the closest
   const versionTree = convertVersionsToTree(versions);

--- a/plugins/default-browser-emulator/test/selectUserAgentOptions.test.ts
+++ b/plugins/default-browser-emulator/test/selectUserAgentOptions.test.ts
@@ -1,0 +1,29 @@
+import selectUserAgentOption from '../lib/helpers/selectUserAgentOption';
+import DataLoader from '../lib/DataLoader';
+
+const dataLoader = new DataLoader(`${__dirname}/..`);
+
+test('should support choosing a specific useragent', async () => {
+  const options = selectUserAgentOption(
+    '~ chrome >= 88 && chrome < 89',
+    dataLoader.userAgentOptions,
+  );
+  expect(options.browserVersion.major).toBe('88');
+});
+
+test('should support choosing a specific OS', async () => {
+  const options = selectUserAgentOption('~ mac & chrome >= 88', dataLoader.userAgentOptions);
+  expect(parseInt(options.browserVersion.major, 10)).toBeGreaterThanOrEqual(88);
+  expect(options.operatingSystemName).toBe('mac-os');
+});
+
+test('should throw an error for a non-installed pattern', async () => {
+  try {
+    expect(
+      selectUserAgentOption('~ mac & chrome >= 500000', dataLoader.userAgentOptions),
+    ).not.toBeTruthy();
+  } catch (err) {
+    // eslint-disable-next-line jest/no-try-expect
+    expect(err.message).toMatch('No installed UserAgent');
+  }
+});


### PR DESCRIPTION
The user agent selector has a few holes that are plugged by this PR.

1. The default example in the docs `~mac and chrome >90` did not work
2. If you had multiple selectors (ie, OS and browser, it would take matches of "either/or", which was not what we wanted)
3. There are issues if you use an OS we don't know about.
4. We needed default selectors if you don't provide an operator (=) or version (*)

Closes #369 and causes #371 to emit a better error, but we probably need to follow up with some kind of actual option to use a mobile user agent on a default browser.