### PR TITLE
fix(puppet): don't use contexts we didn't initiate

### DIFF
--- a/plugins/default-browser-emulator/lib/DomOverridesBuilder.ts
+++ b/plugins/default-browser-emulator/lib/DomOverridesBuilder.ts
@@ -25,7 +25,11 @@ export default class DomOverridesBuilder {
       {
         // NOTE: don't make this async. It can cause issues if you read a frame right after creation, for instance
         script: `(function newDocumentScript() {
+  // Worklet has no scope to override, but we can't detect until it loads
+  if (typeof self === 'undefined' && typeof window === 'undefined') return;
+  
   const sourceUrl = '${injectedSourceUrl}';
+  
   ${utilsScript}
 
    ${scripts.join('\n\n')}

--- a/puppet-chrome/lib/FramesManager.ts
+++ b/puppet-chrome/lib/FramesManager.ts
@@ -198,6 +198,12 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameManager
     await this.isReady;
     const { context } = event;
     const frameId = context.auxData.frameId as string;
+    const type = context.auxData.type as string;
+
+    const defaultScope =
+      type === 'default' && context.auxData.isDefault === true && context.name === '';
+    const isolatedScope = type === 'isolated' && context.name === ISOLATED_WORLD;
+    if (!isolatedScope && !defaultScope) return;
 
     this.activeContextIds.add(context.id);
     const frame = this.framesById.get(frameId);
@@ -207,7 +213,7 @@ export default class FramesManager extends TypedEventEmitter<IPuppetFrameManager
         executionContextId: context.id,
       });
     }
-    frame?.addContextId(context.id, context.name === '' || context.auxData?.isDefault === true);
+    frame?.addContextId(context.id, defaultScope);
   }
 
   /////// FRAMES ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
We were letting worker contexts override our default isolated context.

Closes #386 
