### PR TITLE
feat(core): dialogs should run out of command line

### DIFF
--- a/client/lib/Agent.ts
+++ b/client/lib/Agent.ts
@@ -421,7 +421,7 @@ export default class Agent extends AwaitedEventTarget<{ close: void }> {
     return this.activeTab.waitForFileChooser(options);
   }
 
-  public waitForLocation(trigger: ILocationTrigger, options?: IWaitForOptions): Promise<void> {
+  public waitForLocation(trigger: ILocationTrigger, options?: IWaitForOptions): Promise<Resource> {
     return this.activeTab.waitForLocation(trigger, options);
   }
 

--- a/client/lib/CoreFrameEnvironment.ts
+++ b/client/lib/CoreFrameEnvironment.ts
@@ -10,6 +10,7 @@ import INodePointer from 'awaited-dom/base/INodePointer';
 import ISetCookieOptions from '@secret-agent/interfaces/ISetCookieOptions';
 import IWaitForOptions from '@secret-agent/interfaces/IWaitForOptions';
 import IFrameMeta from '@secret-agent/interfaces/IFrameMeta';
+import IResourceMeta from '@secret-agent/interfaces/IResourceMeta';
 import CoreCommandQueue from './CoreCommandQueue';
 
 export default class CoreFrameEnvironment {
@@ -109,7 +110,10 @@ export default class CoreFrameEnvironment {
     await this.commandQueue.run('FrameEnvironment.waitForLoad', status, opts);
   }
 
-  public async waitForLocation(trigger: ILocationTrigger, opts: IWaitForOptions): Promise<void> {
-    await this.commandQueue.run('FrameEnvironment.waitForLocation', trigger, opts);
+  public async waitForLocation(
+    trigger: ILocationTrigger,
+    opts: IWaitForOptions,
+  ): Promise<IResourceMeta> {
+    return await this.commandQueue.run('FrameEnvironment.waitForLocation', trigger, opts);
   }
 }

--- a/client/lib/CoreTab.ts
+++ b/client/lib/CoreTab.ts
@@ -84,7 +84,7 @@ export default class CoreTab implements IJsPathEventTarget {
   }
 
   public async getResourceProperty<T = any>(id: number, propertyPath: string): Promise<T> {
-    return await this.commandQueue.run('Tab.getResourceProperty', id, propertyPath);
+    return await this.commandQueue.runOutOfBand('Tab.getResourceProperty', id, propertyPath);
   }
 
   public async configure(options: IConfigureSessionOptions): Promise<void> {
@@ -146,7 +146,8 @@ export default class CoreTab implements IJsPathEventTarget {
   }
 
   public async dismissDialog(accept: boolean, promptText?: string): Promise<void> {
-    await this.commandQueue.run('Tab.dismissDialog', accept, promptText);
+    // NOTE: since this can only be called from inside event handlers, it should not go into the queue or it can deadlock
+    await this.commandQueue.runOutOfBand('Tab.dismissDialog', accept, promptText);
   }
 
   public async addEventListener(

--- a/client/lib/FrameEnvironment.ts
+++ b/client/lib/FrameEnvironment.ts
@@ -33,10 +33,12 @@ import CookieStorage, { createCookieStorage } from './CookieStorage';
 import Agent, { IState as IAgentState } from './Agent';
 import { delegate as AwaitedHandler, getAwaitedPathAsMethodArg } from './SetupAwaitedHandler';
 import CoreFrameEnvironment from './CoreFrameEnvironment';
-import Tab from './Tab';
+import Tab, { IState as ITabState } from './Tab';
 import { IMousePosition } from '../interfaces/IInteractions';
+import Resource, { createResource } from './Resource';
 
 const { getState, setState } = StateMachine<FrameEnvironment, IState>();
+const { getState: getTabState } = StateMachine<Tab, ITabState>();
 const agentState = StateMachine<Agent, IAgentState>();
 const awaitedPathState = StateMachine<
   any,
@@ -204,9 +206,12 @@ export default class FrameEnvironment {
   public async waitForLocation(
     trigger: ILocationTrigger,
     options?: IWaitForOptions,
-  ): Promise<void> {
+  ): Promise<Resource> {
     const coreFrame = await getCoreFrameEnvironment(this);
-    await coreFrame.waitForLocation(trigger, options);
+    const resourceMeta = await coreFrame.waitForLocation(trigger, options);
+    const { tab } = getState(this);
+    const { coreTab } = getTabState(tab);
+    return createResource(coreTab, resourceMeta);
   }
 
   public toJSON(): any {

--- a/client/lib/Tab.ts
+++ b/client/lib/Tab.ts
@@ -227,7 +227,7 @@ export default class Tab extends AwaitedEventTarget<IEventType> {
   public async waitForLocation(
     trigger: ILocationTrigger,
     options?: IWaitForOptions,
-  ): Promise<void> {
+  ): Promise<Resource> {
     return await this.mainFrameEnvironment.waitForLocation(trigger, options);
   }
 

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -89,12 +89,12 @@ export default class FrameEnvironment {
   public puppetFrame: IPuppetFrame;
   public isReady: Promise<Error | void>;
   public domNodeId: number;
+  public readonly interactor: Interactor;
   protected readonly logger: IBoundLog;
 
   private puppetNodeIdsBySaNodeId: Record<number, string> = {};
   private prefetchedJsPaths: IJsPathResult[];
   private readonly isDetached: boolean;
-  private readonly interactor: Interactor;
   private isClosing = false;
   private waitTimeouts: { timeout: NodeJS.Timeout; reject: (reason?: any) => void }[] = [];
   private readonly commandRecorder: CommandRecorder;

--- a/core/lib/FrameNavigationsObserver.ts
+++ b/core/lib/FrameNavigationsObserver.ts
@@ -96,7 +96,7 @@ export default class FrameNavigationsObserver {
   }
 
   public waitForReady(): Promise<void> {
-    return this.waitForLoad(LocationStatus.DomContentLoaded);
+    return this.waitForLoad(LocationStatus.HttpResponded);
   }
 
   public async waitForNavigationResourceId(): Promise<number> {

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -15,7 +15,7 @@ import IWaitForOptions from '@secret-agent/interfaces/IWaitForOptions';
 import IScreenshotOptions from '@secret-agent/interfaces/IScreenshotOptions';
 import MitmRequestContext from '@secret-agent/mitm/lib/MitmRequestContext';
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
-import { IInteractionGroups } from '@secret-agent/interfaces/IInteractions';
+import { IInteractionGroups, InteractionCommand } from '@secret-agent/interfaces/IInteractions';
 import IExecJsPathResult from '@secret-agent/interfaces/IExecJsPathResult';
 import IWaitForElementOptions from '@secret-agent/interfaces/IWaitForElementOptions';
 import { ILocationTrigger, IPipelineStatus } from '@secret-agent/interfaces/Location';
@@ -440,7 +440,13 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     return this.puppetPage.screenshot(options.format, options.rectangle, options.jpegQuality);
   }
 
-  public dismissDialog(accept: boolean, promptText?: string): Promise<void> {
+  public async dismissDialog(accept: boolean, promptText?: string): Promise<void> {
+    const resolvable = createPromise();
+    this.mainFrameEnvironment.interactor.play(
+      [[{ command: InteractionCommand.willDismissDialog }]],
+      resolvable,
+    );
+    await resolvable.promise;
     return this.puppetPage.dismissDialog(accept, promptText);
   }
 

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -167,6 +167,8 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     resource: IResourceMeta,
     error?: Error,
   ): boolean {
+    if (resource.type !== 'Document') return;
+
     const frame = this.findFrameWithUnresolvedNavigation(
       browserRequestId,
       resource.request?.method,
@@ -186,8 +188,6 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     requestedUrl: string,
     finalUrl: string,
   ): FrameEnvironment {
-    if (method !== 'GET') return null;
-
     for (const frame of this.frameEnvironmentsById.values()) {
       const top = frame.navigations.top;
       if (!top || top.resourceId.isResolved) continue;
@@ -292,7 +292,6 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     let finalResourceId = resourceId;
     // if no resource id, this is a request for the default resource (page)
     if (!resourceId) {
-      await this.navigationsObserver.waitForReady();
       finalResourceId = await this.navigationsObserver.waitForNavigationResourceId();
     }
 
@@ -341,7 +340,10 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     return this.mainFrameEnvironment.waitForLoad(status, options);
   }
 
-  public waitForLocation(trigger: ILocationTrigger, options?: IWaitForOptions): Promise<void> {
+  public waitForLocation(
+    trigger: ILocationTrigger,
+    options?: IWaitForOptions,
+  ): Promise<IResourceMeta> {
     return this.mainFrameEnvironment.waitForLocation(trigger, options);
   }
 
@@ -421,8 +423,19 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
     const timer = new Timer(timeoutMs, this.waitTimeouts);
     const timeoutMessage = `Timeout waiting for "tab.reload()"`;
 
+    let loaderId = this.puppetPage.mainFrame.activeLoader.id;
     await timer.waitForPromise(this.puppetPage.reload(), timeoutMessage);
-    this.navigations.assignLoaderId(navigation, this.puppetPage.mainFrame.activeLoader?.id);
+    if (this.puppetPage.mainFrame.activeLoader.id === loaderId) {
+      const frameNavigated = await timer.waitForPromise(
+        this.puppetPage.mainFrame.waitOn('frame-navigated', null, timeoutMs),
+        timeoutMessage,
+      );
+      loaderId = frameNavigated.loaderId;
+    }
+    this.navigations.assignLoaderId(
+      navigation,
+      loaderId ?? this.puppetPage.mainFrame.activeLoader?.id,
+    );
 
     const resource = await timer.waitForPromise(
       this.navigationsObserver.waitForNavigationResourceId(),

--- a/core/test/navigation.test.ts
+++ b/core/test/navigation.test.ts
@@ -41,6 +41,14 @@ describe('basic Navigation tests', () => {
     expect(formattedUrl).toBe(`${unformattedUrl}/`);
   });
 
+  it('handles urls with a hash', async () => {
+    koaServer.get('/hash', ctx => {
+      ctx.body = 'done';
+    });
+    const { tab } = await createSession();
+    await expect(tab.goto(`${koaServer.baseUrl}/hash#hash`)).resolves.toBeTruthy();
+  });
+
   it('works without explicit waitForLocation', async () => {
     const { tab } = await createSession();
     await tab.goto(koaServer.baseUrl);

--- a/full-client/test/waitForLocation.test.ts
+++ b/full-client/test/waitForLocation.test.ts
@@ -178,7 +178,7 @@ describe('basic waitForLocation change detections', () => {
     const agent = await handler.createAgent();
     await agent.goto(`${koaServer.baseUrl}/refresh`);
 
-    await expect(agent.waitForLocation('reload')).resolves.toBe(undefined);
+    await expect(agent.waitForLocation('reload')).resolves.toBeTruthy();
   });
 
   it('will trigger reload if the same page is loaded again', async () => {
@@ -207,6 +207,6 @@ describe('basic waitForLocation change detections', () => {
     await agent.goto(`${koaServer.baseUrl}/postback`);
     await agent.click(agent.activeTab.document.querySelector('input'));
 
-    await expect(agent.waitForLocation('reload')).resolves.toBe(undefined);
+    await expect(agent.waitForLocation('reload')).resolves.toBeTruthy();
   });
 });

--- a/interfaces/IInteractions.ts
+++ b/interfaces/IInteractions.ts
@@ -23,6 +23,8 @@ export enum InteractionCommand {
   move = 'move',
   scroll = 'scroll',
 
+  willDismissDialog = 'willDismissDialog',
+
   click = 'click',
   clickDown = 'clickDown',
   clickUp = 'clickUp',

--- a/plugins/default-human-emulator/index.ts
+++ b/plugins/default-human-emulator/index.ts
@@ -89,6 +89,11 @@ export default class DefaultHumanEmulator extends HumanEmulator {
           continue;
         }
 
+        if (step.command === InteractionCommand.willDismissDialog) {
+          const millis = Math.random() * DefaultHumanEmulator.maxDelayBetweenInteractions;
+          await delay(millis);
+          continue;
+        }
         await runFn(step);
       }
     }
@@ -409,7 +414,7 @@ export function isVisible(coordinate: number, length: number, boundaryLength: nu
 
 async function delay(millis: number): Promise<void> {
   if (!millis) return;
-  await new Promise<void>(resolve => setTimeout(resolve, Math.floor(millis)));
+  await new Promise<void>(resolve => setTimeout(resolve, Math.floor(millis)).unref());
 }
 
 function splitIntoMaxLengthSegments(total: number, maxValue: number): number[] {

--- a/website/docs/BasicInterfaces/FrameEnvironment.md
+++ b/website/docs/BasicInterfaces/FrameEnvironment.md
@@ -304,7 +304,7 @@ Waits for a navigational change to document.location either because of a `reload
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - sinceCommandId `number`. A `commandId` from which to look for changes.
 
-#### **Returns**: `Promise`
+#### **Returns**: `Promise<Resource>`
 
 Location changes are triggered in one of two ways:
 

--- a/website/docs/BasicInterfaces/Tab.md
+++ b/website/docs/BasicInterfaces/Tab.md
@@ -364,7 +364,7 @@ Alias for [tab.mainFrameEnvironment.waitForLocation](/docs/basic-interfaces/fram
   - timeoutMs `number`. Timeout in milliseconds. Default `30,000`.
   - sinceCommandId `number`. A `commandId` from which to look for changes.
 
-#### **Returns**: `Promise`
+#### **Returns**: `Promise<Resource>`
 
 Location changes are triggered in one of two ways:
 


### PR DESCRIPTION
This PR introduces two small, but potentially impactful changes:
1) The "waitForReady" state inside core is changed from DomContentLoaded to HttpResponded for the current resource. It seems like a potentially expensive condition to impose on some sites that take a long time to load. 

NOTE: I kept interact and execJsPath as requiring DomContentLoaded before running. Things seemed fragile in our tests without it, which made me question when you'd really not want it for those two. Up for conversation about this.

2) Two core commands are now going to "bypass" the coreCommandQueue "line" and run outside the regular queue: getResourceProperty and dismissDialog. Both are used inside event listeners, and in the case of getResourceProperty, it can't really impact the flow of the script

This PR also integrates "willDismissDialog" into the interaction so that it can provide an optional wait. The default human emulator has a small wait before dismissing.

Closes #397