### PR TITLE
fix(core): in page nav not resolving resource

### DIFF
--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -383,9 +383,8 @@ export default class Session extends TypedEventEmitter<{
     const isDocument = request?.resourceType === 'Document';
     if (isDocument && !tabId) {
       for (const tab of this.tabsById.values()) {
-        const isMatch = tab.findFrameWithUnresolvedNavigation(
+        const isMatch = tab.frameWithPendingNavigation(
           request.browserRequestId,
-          request.request?.method,
           url,
           request.response?.url,
         );


### PR DESCRIPTION
Bug reported by user: after a form submission that redirects in-page "before the resource is loaded" will never resolve the resource, so the location change hangs.