### PR TITLE
fix(core): cleanup event listener memory

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "@secret-agent/interfaces": "1.6.2",
     "@secret-agent/plugin-utils": "1.6.2",
     "@secret-agent/replay": "1.6.2",
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },

--- a/commons/EventSubscriber.ts
+++ b/commons/EventSubscriber.ts
@@ -1,0 +1,55 @@
+import IRegisteredEventListener, {
+  IEventSubscriber,
+} from '@secret-agent/interfaces/IRegisteredEventListener';
+
+export default class EventSubscriber implements IEventSubscriber {
+  private readonly registeredEventListeners: IRegisteredEventListener[] = [];
+
+  on<K extends string | symbol, Func extends (...args: any[]) => void>(
+    emitter: {
+      on(event: K, listener: Func, includeUnhandledEvents?: boolean);
+      off(event: K, listener: Func);
+    },
+    eventName: K,
+    handler: Func,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener {
+    emitter.on(eventName, handler, includeUnhandledEvents);
+    const registeredEvent: IRegisteredEventListener = { emitter, eventName, handler };
+    this.registeredEventListeners.push(registeredEvent);
+    return registeredEvent;
+  }
+
+  once<Event extends string | symbol, Func extends (...args: any[]) => void>(
+    emitter: {
+      once(event: Event, listener: Func, includeUnhandledEvents?: boolean);
+      off(event: Event, listener: Func);
+    },
+    eventName: Event,
+    handler: Func,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener {
+    emitter.once(eventName, handler, includeUnhandledEvents);
+    const registeredEvent: IRegisteredEventListener = { emitter, eventName, handler };
+    this.registeredEventListeners.push(registeredEvent);
+    return registeredEvent;
+  }
+
+  off(...listeners: IRegisteredEventListener[]): void {
+    for (const listener of listeners) {
+      listener.emitter.off(listener.eventName, listener.handler);
+    }
+    listeners.length = 0;
+  }
+
+  close(...keepMockEvents: (string | symbol)[]): void {
+    for (const listener of this.registeredEventListeners) {
+      if (keepMockEvents.includes(listener.eventName)) {
+        // add a mock event handler (like for capturing events)
+        (listener.emitter as any).on(listener.eventName, () => null);
+      }
+      listener.emitter.off(listener.eventName, listener.handler);
+    }
+    this.registeredEventListeners.length = 0;
+  }
+}

--- a/core/lib/AwaitedEventListener.ts
+++ b/core/lib/AwaitedEventListener.ts
@@ -2,6 +2,7 @@ import { v1 as uuidv1 } from 'uuid';
 import { IJsPath } from 'awaited-dom/base/AwaitedPath';
 import ISessionMeta from '@secret-agent/interfaces/ISessionMeta';
 import { assert } from '@secret-agent/commons/utils';
+import EventSubscriber from '@secret-agent/commons/EventSubscriber';
 import IListenerObject from '../interfaces/IListenerObject';
 import Session from './Session';
 
@@ -14,9 +15,10 @@ export interface ITrigger {
 // TODO: can we merge TypedEventEmitter ideas and eventListenerIdsByType?. Revisit when we get to dom events
 export default class AwaitedEventListener {
   private readonly listenersById = new Map<string, IListenerObject>();
+  private eventSubscriber = new EventSubscriber();
 
-  constructor(readonly session: Session) {
-    session.on('closing', () => this.triggerListenersWithType('close'));
+  constructor(private session: Session) {
+    this.eventSubscriber.once(session, 'closing', () => this.triggerListenersWithType('close'));
   }
 
   public close() {
@@ -25,6 +27,8 @@ export default class AwaitedEventListener {
         this.remove(entry.id);
       }
     }
+    this.eventSubscriber.close();
+    this.session = null;
   }
 
   public listen(

--- a/core/lib/CommandRecorder.ts
+++ b/core/lib/CommandRecorder.ts
@@ -12,8 +12,8 @@ export default class CommandRecorder {
   public readonly fnNames = new Set<string>();
   private logger: IBoundLog;
   constructor(
-    readonly owner: any,
-    readonly session: Session,
+    private owner: any,
+    private session: Session,
     readonly tabId: number,
     readonly frameId: number,
     fns: AsyncFunc[],
@@ -29,8 +29,14 @@ export default class CommandRecorder {
     });
   }
 
+  public clear(): void {
+    this.session = null;
+    this.owner = null;
+  }
+
   private async runCommandFn<T>(commandFn: AsyncFunc, ...args: any[]): Promise<T> {
-    if (!this.fnNames.has(commandFn.name)) throw new Error(`Unsupported function requested ${commandFn.name}`);
+    if (!this.fnNames.has(commandFn.name))
+      throw new Error(`Unsupported function requested ${commandFn.name}`);
 
     const { session } = this;
     const sessionState = session.sessionState;

--- a/core/lib/FrameEnvironment.ts
+++ b/core/lib/FrameEnvironment.ts
@@ -171,6 +171,7 @@ export default class FrameEnvironment {
       for (const path of this.cleanPaths) {
         Fs.promises.unlink(path).catch(() => null);
       }
+      this.commandRecorder.clear();
     } catch (error) {
       if (!error.message.includes('Target closed') && !(error instanceof CanceledPromiseError)) {
         this.logger.error('FrameEnvironment.ClosingError', { error, parentLogId });

--- a/core/lib/SessionState.ts
+++ b/core/lib/SessionState.ts
@@ -56,7 +56,7 @@ export default class SessionState {
 
   private readonly logger: IBoundLog;
 
-  private readonly browserRequestIdToResources: {
+  private browserRequestIdToResources: {
     [browserRequestId: string]: { resourceId: number; url: string }[];
   } = {};
 
@@ -465,6 +465,10 @@ export default class SessionState {
     loggerSessionIdNames.delete(this.sessionId);
     this.db.flush();
     this.db.close();
+    this.resourcesById.clear();
+    this.browserRequestIdToResources = {};
+    this.websocketListeners = {};
+    this.websocketMessages.length = 0;
     SessionState.registry.delete(this.sessionId);
   }
 

--- a/core/lib/Tab.ts
+++ b/core/lib/Tab.ts
@@ -252,6 +252,7 @@ export default class Tab extends TypedEventEmitter<ITabEventParams> {
         errors.push(error);
       }
     }
+    this.commandRecorder.clear();
     this.emit('close');
     this.logger.stats('Tab.Closed', { parentLogId, errors });
   }

--- a/core/package.json
+++ b/core/package.json
@@ -22,7 +22,7 @@
     "@secret-agent/plugin-utils": "1.6.2",
     "@secret-agent/puppet": "1.6.2",
     "@types/ua-parser-js": "^0.7.35",
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "better-sqlite3": "^7.4.1",
     "moment": "^2.24.1",
     "uuid": "^8.3.2",

--- a/core/server/ConnectionToClient.ts
+++ b/core/server/ConnectionToClient.ts
@@ -210,9 +210,10 @@ export default class ConnectionToClient extends TypedEventEmitter<{
     if (this.isClosing) throw new Error('Connection closed');
     clearTimeout(this.autoShutdownTimer);
     const session = await GlobalPool.createSession(options);
-    this.sessionIds.add(session.id);
+    const id = session.id;
+    this.sessionIds.add(id);
     session.on('awaited-event', this.emit.bind(this, 'message'));
-    session.on('closing', () => this.sessionIds.delete(session.id));
+    session.on('closing', () => this.sessionIds.delete(id));
     session.on('closed', this.checkForAutoShutdown.bind(this));
 
     const tab = await session.createTab();

--- a/full-client/package.json
+++ b/full-client/package.json
@@ -18,7 +18,7 @@
     "@secret-agent/mitm": "1.6.2",
     "@secret-agent/plugin-utils": "1.6.2",
     "@secret-agent/testing": "1.6.2",
-    "awaited-dom": "^1.3.0",
+    "awaited-dom": "1.3.1",
     "fpcollect": "^1.0.4",
     "fpscanner": "^0.1.5",
     "ws": "^7.4.6"

--- a/interfaces/IHttpResourceLoadDetails.ts
+++ b/interfaces/IHttpResourceLoadDetails.ts
@@ -2,6 +2,7 @@ import { URL } from 'url';
 import ResourceType from './ResourceType';
 import IResourceHeaders from './IResourceHeaders';
 import OriginType from './OriginType';
+import { IEventSubscriber } from './IRegisteredEventListener';
 
 export default interface IHttpResourceLoadDetails {
   isSSL: boolean;
@@ -42,4 +43,5 @@ export default interface IHttpResourceLoadDetails {
   browserLoadFailure?: string;
   browserBlockedReason?: string;
   browserCanceled?: boolean;
+  eventSubscriber: IEventSubscriber;
 }

--- a/interfaces/IRegisteredEventListener.ts
+++ b/interfaces/IRegisteredEventListener.ts
@@ -1,8 +1,48 @@
-import { EventEmitter } from 'events';
 import ITypedEventEmitter from './ITypedEventEmitter';
 
+export type Callback = (...args: any[]) => void;
+export type EventName = string | symbol;
+
 export default interface IRegisteredEventListener {
-  emitter: EventEmitter | ITypedEventEmitter<any>;
-  eventName: string | symbol;
+  emitter: { off(event: string | symbol, listener: Callback) };
+  eventName: EventName;
   handler: (...args: any[]) => void;
+}
+
+export interface IEventSubscriber {
+  on<T, K extends keyof T & EventName>(
+    emitter: ITypedEventEmitter<T>,
+    eventName: K,
+    handler: (this: ITypedEventEmitter<T>, event?: T[K], initiator?: any) => any,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener;
+  on(
+    emitter: {
+      on(event: EventName, listener: Callback, includeUnhandledEvents?: boolean);
+      off(event: EventName, listener: Callback);
+    },
+    eventName: EventName,
+    handler: Callback,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener;
+
+  once<T, K extends keyof T & EventName>(
+    emitter: ITypedEventEmitter<T>,
+    eventName: K,
+    handler: (this: ITypedEventEmitter<T>, event?: T[K], initiator?: any) => any,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener;
+  once(
+    emitter: {
+      once(event: EventName, listener: Callback, includeUnhandledEvents?: boolean);
+      off(event: EventName, listener: Callback);
+    },
+    eventName: EventName,
+    handler: Callback,
+    includeUnhandledEvents?: boolean,
+  ): IRegisteredEventListener;
+
+  off(...events: IRegisteredEventListener[]): void;
+
+  close(...keepEvents: string[]): void;
 }

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.2",
   "description": "Core interfaces used by SecretAgent",
   "dependencies": {
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "devtools-protocol": "^0.0.799653"
   }
 }

--- a/mitm-socket/lib/MitmSocketSession.ts
+++ b/mitm-socket/lib/MitmSocketSession.ts
@@ -19,7 +19,7 @@ export default class MitmSocketSession extends BaseIpcHandler {
     const id = socket.id;
     this.socketsById.set(id, socket);
 
-    socket.on('close', () => this.socketsById.delete(id));
+    socket.once('close', () => this.socketsById.delete(id));
 
     await this.waitForConnected;
 

--- a/mitm/handlers/BaseHttpHandler.ts
+++ b/mitm/handlers/BaseHttpHandler.ts
@@ -60,7 +60,11 @@ export default abstract class BaseHttpHandler {
 
       const request = await session.requestAgent.request(context);
       this.context.proxyToServerRequest = request;
-      request.on('error', this.onError.bind(this, 'ProxyToServer.RequestError'));
+      this.context.eventSubscriber.on(
+        request,
+        'error',
+        this.onError.bind(this, 'ProxyToServer.RequestError'),
+      );
 
       if (this.context.isServerHttp2) {
         const h2Request = request as ClientHttp2Stream;
@@ -73,22 +77,41 @@ export default abstract class BaseHttpHandler {
     }
   }
 
+  protected cleanup(): void {
+    this.context.eventSubscriber.close('error');
+    this.context.proxyToServerRequest = null;
+    this.context.clientToProxyRequest = null;
+    this.context.requestSession = null;
+    this.context.proxyToClientResponse = null;
+    this.context.proxyToServerMitmSocket = null;
+    this.context.cacheHandler = null;
+    this.context.browserHasRequested = null;
+  }
+
   protected bindHttp2ErrorListeners(
     source: string,
     stream: http2.Http2Stream,
     session: http2.Http2Session,
   ): void {
     if (!stream.listenerCount('error')) {
-      stream.on('error', this.onError.bind(this, `${source}.Http2StreamError`));
+      this.context.eventSubscriber.on(
+        stream,
+        'error',
+        this.onError.bind(this, `${source}.Http2StreamError`),
+      );
     }
 
-    stream.on('streamClosed', code => {
+    this.context.eventSubscriber.on(stream, 'streamClosed', code => {
       if (!code) return;
       this.onError(`${source}.Http2StreamError`, new Error(`Stream Closed ${code}`));
     });
 
     if (session && !session.listenerCount('error')) {
-      session.on('error', this.onError.bind(this, `${source}.Http2SessionError`));
+      this.context.eventSubscriber.on(
+        session,
+        'error',
+        this.onError.bind(this, `${source}.Http2SessionError`),
+      );
     }
   }
 }

--- a/mitm/lib/BrowserRequestMatcher.ts
+++ b/mitm/lib/BrowserRequestMatcher.ts
@@ -157,6 +157,7 @@ export default class BrowserRequestMatcher {
         new CanceledPromiseError('Canceling: Mitm Request Session Closing'),
       );
     }
+    this.requestedResources.length = 0;
   }
 
   private updatePendingResource(

--- a/mitm/lib/Dns.ts
+++ b/mitm/lib/Dns.ts
@@ -12,7 +12,7 @@ export class Dns {
   public socket: DnsOverTlsSocket;
   private readonly dnsSettings: IDnsSettings = {};
 
-  constructor(readonly requestSession?: RequestSession) {
+  constructor(private requestSession?: RequestSession) {
     requestSession?.plugins?.onDnsConfiguration(this.dnsSettings);
   }
 
@@ -54,6 +54,8 @@ export class Dns {
 
   public close(): void {
     this.socket?.close();
+    this.socket = null;
+    this.requestSession = null;
   }
 
   private async systemLookup(host: string): Promise<IDnsEntry> {

--- a/puppet/lib/PipeTransport.ts
+++ b/puppet/lib/PipeTransport.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as EventUtils from '@secret-agent/commons/eventUtils';
-import { addEventListeners } from '@secret-agent/commons/eventUtils';
+import EventSubscriber from '@secret-agent/commons/EventSubscriber';
 import Log from '@secret-agent/commons/Logger';
-import IRegisteredEventListener from '@secret-agent/interfaces/IRegisteredEventListener';
 import { ChildProcess } from 'child_process';
 import IConnectionTransport from '@secret-agent/interfaces/IConnectionTransport';
 
@@ -25,7 +23,7 @@ const { log } = Log(module);
 export class PipeTransport implements IConnectionTransport {
   pipeWrite: NodeJS.WritableStream;
   pendingMessage: string;
-  eventListeners: IRegisteredEventListener[];
+  eventSubscriber = new EventSubscriber();
   isClosed = false;
 
   public onMessageFn: (message: string) => void;
@@ -39,15 +37,13 @@ export class PipeTransport implements IConnectionTransport {
       log.error('PipeTransport.WriteError', { error, sessionId: null });
     });
     this.pendingMessage = '';
-    this.eventListeners = addEventListeners(pipeRead, [
-      ['data', this.onData.bind(this)],
-      ['close', this.onReadClosed.bind(this)],
-      ['error', error => log.error('PipeTransport.ReadError', { error, sessionId: null })],
-    ]);
-    this.eventListeners.push(
-      EventUtils.addEventListener(pipeWrite, 'error', error =>
-        log.error('PipeTransport.WriteError', { error, sessionId: null }),
-      ),
+    this.eventSubscriber.on(pipeRead, 'data', this.onData.bind(this));
+    this.eventSubscriber.on(pipeRead, 'close', this.onReadClosed.bind(this));
+    this.eventSubscriber.on(pipeRead, 'error', error =>
+      log.error('PipeTransport.ReadError', { error, sessionId: null }),
+    );
+    this.eventSubscriber.on(pipeWrite, 'error', error =>
+      log.error('PipeTransport.WriteError', { error, sessionId: null }),
     );
   }
 
@@ -62,7 +58,7 @@ export class PipeTransport implements IConnectionTransport {
   close(): void {
     if (this.isClosed) return;
     this.isClosed = true;
-    EventUtils.removeEventListeners(this.eventListeners);
+    this.eventSubscriber.close();
   }
 
   private emit(message): void {

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@microflash/gridsome-plugin-feed": "^1.2.1",
     "@types/json2md": "^1.5.0",
     "@types/lodash.kebabcase": "^4.1.6",
-    "awaited-dom": "1.3.0",
+    "awaited-dom": "1.3.1",
     "babel-runtime": "^6.26.0",
     "decamelize": "^4.0.0",
     "docsearch.js": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,10 +4672,10 @@ autoprefixer@^9.4.7, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awaited-dom@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.0.tgz#90265018c2f8bb338e3ffd697c8f7d6a60e689c9"
-  integrity sha512-fQ3AgTqb6XdkVUyP/nHrrXUDoEOA/OhWzZIKxp5RvRwq3swm5vnWBAaIaQ4bh1mhIzzM+CTgUjyncePqX54zZQ==
+awaited-dom@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/awaited-dom/-/awaited-dom-1.3.1.tgz#30d9daa86a85b7f55c96914d09f4ea4a257b958f"
+  integrity sha512-v6gwyQucUjfwyTHaYWTW3dt9X1aELcUMT8ov6m5pkWnadCmK4ZyfrfEtu67Tc4g6/8tG1UKBwnno5DVL6GURqg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR cleans up event listeners holding onto memory that cause sessions to be unable to be garbage collected

Closes #310 