### PR TITLE
fix(mitm): lookup public ip should use https

### DIFF
--- a/mitm-socket/package.build.json
+++ b/mitm-socket/package.build.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
-    "postinstall": "node install.js"
+    "postinstall": "node install.js",
+    "build": "cross-env SA_REBUILD_MITM_SOCKET=1 node install.js"
   }
 }

--- a/plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts
+++ b/plugins/default-browser-emulator/lib/helpers/lookupPublicIp.ts
@@ -10,16 +10,23 @@ export default async function lookupPublicIp(
   agent?: IHttpSocketAgent,
   proxyUrl?: string,
 ): Promise<string> {
+  if (!ipLookupServiceUrl.startsWith('http')) ipLookupServiceUrl = `https://${ipLookupServiceUrl}`;
+  if (proxyUrl && proxyUrl.startsWith('http')) {
+    // require https for lookup services over http proxies
+    ipLookupServiceUrl.replace('http://', 'https://');
+  }
   const lookupService = parse(ipLookupServiceUrl);
+  const port = lookupService.port ?? lookupService.protocol === 'https:' ? 443 : 80;
 
   const requestOptions: http.RequestOptions = {
     method: 'GET',
   };
+
   let socketWrapper: IHttpSocketWrapper;
   if (agent) {
     socketWrapper = await agent.createSocketConnection({
       host: lookupService.host,
-      port: String(lookupService.port),
+      port: String(port),
       servername: lookupService.host,
       keepAlive: false,
       isSsl: ipLookupServiceUrl.startsWith('https'),
@@ -72,13 +79,12 @@ function parse(requestUrl: string): RequestOptions {
 }
 
 export const IpLookupServices = {
-  ipify: 'http://api.ipify.org',
-  icanhazip: 'http://icanhazip.com', // warn: using cloudflare as of 11/19/21
-  aws: 'http://checkip.amazonaws.com',
-  dyndns: 'http://checkip.dyndns.org',
-  identMe: 'http://ident.me',
-  ifconfigMe: 'http://ifconfig.me/ip',
-  ipecho: 'http://ipecho.net/plain',
-  ipinfo: 'http://ipinfo.io/ip',
-  opendns: 'https://diagnostic.opendns.com/myip',
+  ipify: 'api.ipify.org',
+  icanhazip: 'icanhazip.com', // warn: using cloudflare as of 11/19/21
+  aws: 'checkip.amazonaws.com',
+  identMe: 'ident.me',
+  ifconfigMe: 'ifconfig.me/ip',
+  ipecho: 'ipecho.net/plain',
+  ipinfo: 'ipinfo.io/ip',
+  opendns: 'diagnostic.opendns.com/myip',
 };


### PR DESCRIPTION
When we added a public ip lookup, we had it using http urls for speed. The problem is an http proxy can't do CONNECT to non-secure urls, so it was failing to lookup the public ip. We have a flaw in the system that an http url won't work over our current http proxy system. For now, I've changed the public IP lookups to just use https urls