### PR TITLE
User Profile Fixes to address FileChooser interference and performance 

### DIFF
--- a/core/injected-scripts/domStorage.ts
+++ b/core/injected-scripts/domStorage.ts
@@ -1,4 +1,4 @@
-import { IDomStorageForOrigin, IStorageEntry } from '@secret-agent/interfaces/IDomStorage';
+import { IDomStorageForOrigin } from '@secret-agent/interfaces/IDomStorage';
 import { IIndexedDB } from '@secret-agent/interfaces/IIndexedDB';
 
 function dumpStorage(storage: Storage) {
@@ -8,15 +8,6 @@ function dumpStorage(storage: Storage) {
     store.push([key, storage.getItem(key)]);
   }
   return store;
-}
-
-function restoreStorage(storage: Storage, store: IStorageEntry[]) {
-  // only run on empty!
-  if (storage.length) return;
-  if (!store || !store.length) return;
-  for (const [key, value] of store) {
-    storage.setItem(key, value);
-  }
 }
 
 async function exportIndexedDbs(dbNames: string[]) {
@@ -151,11 +142,9 @@ async function restoreData(db: IDBDatabase, restoreDB: IIndexedDB) {
 }
 
 // @ts-ignore
-window.restoreUserStorage = async (data: IDomStorageForOrigin) => {
+window.restoreUserStorage = async (data: IDomStorageForOrigin['indexedDB']) => {
   if (!data) return;
-  restoreStorage(localStorage, data.localStorage);
-  restoreStorage(sessionStorage, data.sessionStorage);
-  await restoreIndexedDb(data.indexedDB);
+  await restoreIndexedDb(data);
 };
 
 // @ts-ignore

--- a/core/injected-scripts/domStorage.ts
+++ b/core/injected-scripts/domStorage.ts
@@ -85,68 +85,6 @@ async function readStoreData(store: IDBObjectStore) {
   return data;
 }
 
-async function restoreIndexedDb(restoreDBs: IIndexedDB[]) {
-  if (!restoreDBs || !restoreDBs.length) return;
-
-  for (const restoreDB of restoreDBs) {
-    await new Promise<void>((resolve, reject) => {
-      const openDBRequest = indexedDB.open(restoreDB.name, restoreDB.version);
-      // only run changes when the db doesn't already exist
-      openDBRequest.onupgradeneeded = event => {
-        const request = event.target as IDBRequest<IDBDatabase>;
-        const db = request.result;
-        for (const objectStoreToRestore of restoreDB.objectStores) {
-          const objectStore = db.createObjectStore(objectStoreToRestore.name, {
-            autoIncrement: objectStoreToRestore.autoIncrement,
-            keyPath: objectStoreToRestore.keyPath,
-          });
-
-          for (const restoreIndex of objectStoreToRestore.indexes) {
-            objectStore.createIndex(restoreIndex.name, restoreIndex.keyPath, {
-              multiEntry: restoreIndex.multiEntry,
-              unique: restoreIndex.unique,
-            });
-          }
-        }
-      };
-      openDBRequest.onsuccess = async event => {
-        const request = event.target as IDBRequest<IDBDatabase>;
-        try {
-          await restoreData(request.result, restoreDB);
-          resolve();
-        } catch (err) {
-          reject(err);
-        }
-      };
-      openDBRequest.onerror = reject;
-    });
-  }
-}
-
-async function restoreData(db: IDBDatabase, restoreDB: IIndexedDB) {
-  for (const objectStoreToRestore of restoreDB.objectStores) {
-    const data = restoreDB.data[objectStoreToRestore.name];
-    if (!data || !data.length) continue;
-    const insertStore = db
-      .transaction(objectStoreToRestore.name, 'readwrite')
-      .objectStore(objectStoreToRestore.name);
-    for (const record of data) {
-      const { key, value } = TypeSerializer.parse(record);
-      insertStore.add(value, key);
-    }
-    await new Promise((resolve, reject) => {
-      insertStore.transaction.oncomplete = resolve;
-      insertStore.transaction.onerror = reject;
-    });
-  }
-}
-
-// @ts-ignore
-window.restoreUserStorage = async (data: IDomStorageForOrigin['indexedDB']) => {
-  if (!data) return;
-  await restoreIndexedDb(data);
-};
-
 // @ts-ignore
 window.exportDomStorage = async (dbNames: string[]) => {
   return {

--- a/core/injected-scripts/indexedDbRestore.ts
+++ b/core/injected-scripts/indexedDbRestore.ts
@@ -1,0 +1,60 @@
+import type { IIndexedDB } from '@secret-agent/interfaces/IIndexedDB';
+
+async function restoreIndexedDb(restoreDBs: IIndexedDB[]) {
+  if (!restoreDBs || !restoreDBs.length) return;
+
+  for (const restoreDB of restoreDBs) {
+    await new Promise<void>((resolve, reject) => {
+      const openDBRequest = indexedDB.open(restoreDB.name, restoreDB.version);
+      // only run changes when the db doesn't already exist
+      openDBRequest.onupgradeneeded = event => {
+        const request = event.target as IDBRequest<IDBDatabase>;
+        const db = request.result;
+        for (const objectStoreToRestore of restoreDB.objectStores) {
+          const objectStore = db.createObjectStore(objectStoreToRestore.name, {
+            autoIncrement: objectStoreToRestore.autoIncrement,
+            keyPath: objectStoreToRestore.keyPath,
+          });
+
+          for (const restoreIndex of objectStoreToRestore.indexes) {
+            objectStore.createIndex(restoreIndex.name, restoreIndex.keyPath, {
+              multiEntry: restoreIndex.multiEntry,
+              unique: restoreIndex.unique,
+            });
+          }
+        }
+      };
+      openDBRequest.onsuccess = async event => {
+        const request = event.target as IDBRequest<IDBDatabase>;
+        try {
+          await restoreData(request.result, restoreDB);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      };
+      openDBRequest.onerror = reject;
+    });
+  }
+}
+
+async function restoreData(db: IDBDatabase, restoreDB: IIndexedDB) {
+  for (const objectStoreToRestore of restoreDB.objectStores) {
+    const data = restoreDB.data[objectStoreToRestore.name];
+    if (!data || !data.length) continue;
+    const insertStore = db
+      .transaction(objectStoreToRestore.name, 'readwrite')
+      .objectStore(objectStoreToRestore.name);
+    for (const record of data) {
+      const { key, value } = TypeSerializer.parse(record);
+      insertStore.add(value, key);
+    }
+    await new Promise((resolve, reject) => {
+      insertStore.transaction.oncomplete = resolve;
+      insertStore.transaction.onerror = reject;
+    });
+  }
+}
+
+// @ts-ignore
+window.restoreUserStorage = restoreIndexedDb;

--- a/core/lib/InjectedScripts.ts
+++ b/core/lib/InjectedScripts.ts
@@ -2,10 +2,12 @@ import * as fs from 'fs';
 import { IPuppetPage } from '@secret-agent/interfaces/IPuppetPage';
 import { stringifiedTypeSerializerClass } from '@secret-agent/commons/TypeSerializer';
 import injectedSourceUrl from '@secret-agent/interfaces/injectedSourceUrl';
+import { IIndexedDB } from '@secret-agent/interfaces/IIndexedDB';
 import { IFrontendDomChangeEvent } from '../models/DomChangesTable';
 
 const pageScripts = {
   domStorage: fs.readFileSync(`${__dirname}/../injected-scripts/domStorage.js`, 'utf8'),
+  indexedDbRestore: fs.readFileSync(`${__dirname}/../injected-scripts/indexedDbRestore.js`, 'utf8'),
   domReplayer: fs.readFileSync(`${__dirname}/../injected-scripts/domReplayer.js`, 'utf8'),
   interactReplayer: fs.readFileSync(`${__dirname}/../injected-scripts/interactReplayer.js`, 'utf8'),
   NodeTracker: fs.readFileSync(`${__dirname}/../injected-scripts/NodeTracker.js`, 'utf8'),
@@ -144,15 +146,13 @@ export default class InjectedScripts {
     );
   }
 
-  public static async installDomStorageRestore(puppetPage: IPuppetPage): Promise<void> {
-    await puppetPage.addNewDocumentScript(
-      `(function restoreDomStorage() {
+  public static getIndexedDbStorageRestoreScript(restoreDBs: IIndexedDB[]): string {
+    return `(function restoreIndexedDB(dbs) {
 const exports = {}; // workaround for ts adding an exports variable
 ${stringifiedTypeSerializerClass};
 
-${pageScripts.domStorage};
-})();`,
-      true,
-    );
+${pageScripts.indexedDbRestore};
+restoreUserStorage(dbs);
+})(${JSON.stringify(restoreDBs)});`;
   }
 }

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -259,7 +259,7 @@ export default class Session extends TypedEventEmitter<{
     this.eventSubscriber.on(context, 'devtools-message', this.onDevtoolsMessage.bind(this));
 
     if (this.userProfile) {
-      await UserProfile.install(this);
+      await UserProfile.installCookies(this);
     }
 
     context.defaultPageInitializationFn = InjectedScripts.install;
@@ -291,7 +291,7 @@ export default class Session extends TypedEventEmitter<{
 
     // if first tab, install session storage
     if (!this.hasLoadedUserProfile && this.userProfile?.storage) {
-      await UserProfile.installDomStorage(this, page);
+      await UserProfile.installStorage(this, page);
       this.hasLoadedUserProfile = true;
     }
 

--- a/core/lib/Session.ts
+++ b/core/lib/Session.ts
@@ -291,7 +291,7 @@ export default class Session extends TypedEventEmitter<{
 
     // if first tab, install session storage
     if (!this.hasLoadedUserProfile && this.userProfile?.storage) {
-      await UserProfile.installSessionStorage(this, page);
+      await UserProfile.installDomStorage(this, page);
       this.hasLoadedUserProfile = true;
     }
 

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -4,6 +4,7 @@ import IUserProfile from '@secret-agent/interfaces/IUserProfile';
 import HttpRequestHandler from '@secret-agent/mitm/handlers/HttpRequestHandler';
 import { ITestKoaServer } from '@secret-agent/testing/helpers';
 import { createPromise } from '@secret-agent/commons/utils';
+import MitmRequestAgent from '@secret-agent/mitm/lib/MitmRequestAgent';
 import Core from '../index';
 import ConnectionToClient from '../server/ConnectionToClient';
 import Session from '../lib/Session';
@@ -274,7 +275,7 @@ localStorage.setItem('Test1', 'value1');
   });
 
   it('should not make requests to end sites during profile "install"', async () => {
-    const mitmSpy = jest.spyOn(HttpRequestHandler, 'onRequest');
+    const mitmSpy = jest.spyOn(MitmRequestAgent.prototype, 'request');
     await connection.createSession({
       userProfile: {
         cookies: [],

--- a/core/test/user-profile.test.ts
+++ b/core/test/user-profile.test.ts
@@ -5,6 +5,7 @@ import HttpRequestHandler from '@secret-agent/mitm/handlers/HttpRequestHandler';
 import { ITestKoaServer } from '@secret-agent/testing/helpers';
 import { createPromise } from '@secret-agent/commons/utils';
 import MitmRequestAgent from '@secret-agent/mitm/lib/MitmRequestAgent';
+import IDomStorage from '@secret-agent/interfaces/IDomStorage';
 import Core from '../index';
 import ConnectionToClient from '../server/ConnectionToClient';
 import Session from '../lib/Session';
@@ -217,6 +218,41 @@ document.querySelector('#session').innerHTML = [session1,session2,session3].join
 
     await tab.close();
     await tab2.close();
+  });
+
+  it('should be able to restore storage for a large number of sites', async () => {
+    const storage: IDomStorage = {
+      [`http://${koaServer.baseHost}`]: {
+        indexedDB: [],
+        localStorage: [['test', '1']],
+        sessionStorage: [['test', '2']],
+      },
+    };
+    for (let i = 0; i < 100; i += 1) {
+      storage[`https://domain${i}.com`] = {
+        indexedDB: [],
+        localStorage: [
+          ['1', '2'],
+          ['test2', '1'],
+        ],
+        sessionStorage: [
+          ['1', '2'],
+          ['test2', '1'],
+        ],
+      };
+    }
+    const meta = await connection.createSession({
+      userProfile: {
+        storage,
+      },
+    });
+    const tab = Session.getTab(meta);
+    Helpers.needsClosing.push(tab.session);
+
+    await tab.goto(`${koaServer.baseUrl}`);
+    await tab.waitForLoad('PaintingStable');
+    await expect(tab.getJsValue('localStorage.getItem("test")')).resolves.toBe('1');
+    await expect(tab.getJsValue('sessionStorage.getItem("test")')).resolves.toBe('2');
   });
 
   it("should keep profile information for sites that aren't loaded in a session", async () => {

--- a/mitm/handlers/BlockHandler.ts
+++ b/mitm/handlers/BlockHandler.ts
@@ -21,7 +21,7 @@ export default class BlockHandler {
     }
 
     if (ctx.proxyToClientResponse) {
-      if (requestSession.blockHandler(ctx.clientToProxyRequest, ctx.proxyToClientResponse)) {
+      if (requestSession.blockHandler(ctx)) {
         return true;
       }
 

--- a/mitm/handlers/HeadersHandler.ts
+++ b/mitm/handlers/HeadersHandler.ts
@@ -50,9 +50,14 @@ export default class HeadersHandler {
 
     const requestedResource = session.browserRequestMatcher.onMitmRequestedResource(ctx);
 
+    // if we're going to block this, don't wait for a
+    if (!ctx.resourceType && session.shouldBlockRequest(ctx.url.href)) {
+      requestedResource.browserRequestedPromise.resolve();
+    }
+
     if (ctx.resourceType === 'Websocket') {
       ctx.browserRequestId = await session.getWebsocketUpgradeRequestId(requestHeaders);
-      requestedResource.browserRequestedPromise.resolve(null);
+      requestedResource.browserRequestedPromise.resolve();
     } else if (!ctx.resourceType || ctx.resourceType === 'Fetch') {
       // if fetch, we need to wait for the browser request so we can see if we should use xhr order or fetch order
       await ctx.browserHasRequested;

--- a/mitm/handlers/RequestSession.ts
+++ b/mitm/handlers/RequestSession.ts
@@ -33,6 +33,7 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
     handlerFn?: (
       request: http.IncomingMessage | http2.Http2ServerRequest,
       response: http.ServerResponse | http2.Http2ServerResponse,
+      context: IMitmRequestContext,
     ) => boolean;
   } = {
     types: [],
@@ -154,11 +155,13 @@ export default class RequestSession extends TypedEventEmitter<IRequestSessionEve
   }
 
   // function to override for
-  public blockHandler(
-    request: http.IncomingMessage | http2.Http2ServerRequest,
-    response: http.ServerResponse | http2.Http2ServerResponse,
-  ): boolean {
-    if (this.blockedResources?.handlerFn) return this.blockedResources.handlerFn(request, response);
+  public blockHandler(ctx: IMitmRequestContext): boolean {
+    if (this.blockedResources?.handlerFn)
+      return this.blockedResources.handlerFn(
+        ctx.clientToProxyRequest,
+        ctx.proxyToClientResponse,
+        ctx,
+      );
     return false;
   }
 

--- a/package.build.json
+++ b/package.build.json
@@ -32,7 +32,7 @@
     ]
   },
   "resolutions": {
-    "remark-slug": "git://github.com/ulixee/remark-slug.git",
+    "remark-slug": "https://github.com/ulixee/remark-slug.git",
     "tough-cookie": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ]
   },
   "resolutions": {
-    "remark-slug": "git://github.com/ulixee/remark-slug.git",
+    "remark-slug": "https://github.com/ulixee/remark-slug.git",
     "tough-cookie": "^4.0.0"
   },
   "version": "0.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -24,7 +24,7 @@
     "gridsome": "^0.7.23",
     "lodash.kebabcase": "^4.1.1",
     "moment": "^2.24.1",
-    "remark-slug": "git://github.com/ulixee/remark-slug.git",
+    "remark-slug": "https://github.com/ulixee/remark-slug.git",
     "typography": "^0.16.19",
     "vue": "^2.6.12",
     "vue-prismjs": "^1.2.0",
@@ -35,10 +35,10 @@
     "@types/typography": "^0.16.3",
     "gh-pages": "^3.1.0",
     "gridsome-plugin-pug": "^0.0.3",
-    "gridsome-plugin-typescript": "git://github.com/calebjclark/gridsome-plugin-typescript.git",
+    "gridsome-plugin-typescript": "https://github.com/calebjclark/gridsome-plugin-typescript.git",
     "json2md": "^1.7.0",
     "node-sass": "^6.0.1",
-    "noderdom-detached": "git://github.com/ulixee/noderdom-detached.git#dist",
+    "noderdom-detached": "https://github.com/ulixee/noderdom-detached.git#dist",
     "pug": "^3.0.2",
     "sass-loader": "^10.2.0",
     "sharp": "^0.25.4",
@@ -48,7 +48,7 @@
     "vue-template-compiler": "^2.6.10"
   },
   "resolutions": {
-    "remark-slug": "git://github.com/ulixee/remark-slug.git",
-    "w3c-xmlserializer": "git://github.com/ulixee/w3c-xmlserializer.git"
+    "remark-slug": "https://github.com/ulixee/remark-slug.git",
+    "w3c-xmlserializer": "https://github.com/ulixee/w3c-xmlserializer.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9734,9 +9734,9 @@ gridsome-plugin-pug@^0.0.3:
     pug-loader "^2.4.0"
     pug-plain-loader "^1.0.0"
 
-"gridsome-plugin-typescript@git://github.com/calebjclark/gridsome-plugin-typescript.git":
+"gridsome-plugin-typescript@https://github.com/calebjclark/gridsome-plugin-typescript.git":
   version "0.4.0"
-  resolved "git://github.com/calebjclark/gridsome-plugin-typescript.git#949023371f6a27c41d224c3561e8c3c53c3cab07"
+  resolved "https://github.com/calebjclark/gridsome-plugin-typescript.git#949023371f6a27c41d224c3561e8c3c53c3cab07"
 
 gridsome@^0.7.23:
   version "0.7.23"
@@ -13662,9 +13662,9 @@ node-sass@^6.0.1:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-"noderdom-detached@git://github.com/ulixee/noderdom-detached.git#dist":
+"noderdom-detached@https://github.com/ulixee/noderdom-detached.git#dist":
   version "0.3.2"
-  resolved "git://github.com/ulixee/noderdom-detached.git#25b6180898bec798a18b2821a4ce57896b688da9"
+  resolved "https://github.com/ulixee/noderdom-detached.git#25b6180898bec798a18b2821a4ce57896b688da9"
   dependencies:
     "@types/parse5" "^5.0.2"
     "@types/underscore" "^1.9.4"
@@ -16187,9 +16187,9 @@ remark-parse@^6.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
-remark-slug@^4.2.3, "remark-slug@git://github.com/ulixee/remark-slug.git":
+remark-slug@^4.2.3, "remark-slug@https://github.com/ulixee/remark-slug.git":
   version "6.0.0"
-  resolved "git://github.com/ulixee/remark-slug.git#29da3adcab6a3adc75e25b0f9439b3e1d5b228ce"
+  resolved "https://github.com/ulixee/remark-slug.git#29da3adcab6a3adc75e25b0f9439b3e1d5b228ce"
   dependencies:
     github-slugger "^1.0.0"
     mdast-util-to-string "^1.0.0"


### PR DESCRIPTION
This PR modifies User Profiles so they can be restored in a far shorter period, and don't interfere with file chooser popups. Something about loading more than one site prior to load is causing the file picker to stop working. It's unclear what the root issue is. It appears to be in Chrome - something is causing the execution contexts to get out of sync and have the wrong domains (ie, it will still say domain1 while the page is loaded to about:blank)

Closes #452 and #428